### PR TITLE
Release: hologit v0.7.0

### DIFF
--- a/commands/project.js
+++ b/commands/project.js
@@ -48,16 +48,10 @@ exports.handler = async function project ({
     commitBranch = null,
     commitMessage = null
 }) {
-    const logger = require('../lib/logger.js');
-    const handlebars = require('handlebars');
-    const { Repo, Projection } = require('../lib');
-    const mkdirp = require('mz-modules/mkdirp');
     const path = require('path');
-    const shellParse = require('shell-quote-word');
-    const sortKeys = require('sort-keys');
-    const squish = require('object-squish');
-    const TOML = require('@iarna/toml');
     const toposort = require('toposort');
+    const logger = require('../lib/logger.js');
+    const { Repo, Projection } = require('../lib');
 
     // check inputs
     if (!holobranch) {

--- a/commands/project.js
+++ b/commands/project.js
@@ -201,6 +201,12 @@ exports.handler = async function project ({
             }
 
 
+            // verify output
+            if (!git.isHash(outputTreeHash)) {
+                throw new Error(`no output tree hash was returned by lens ${lens.name}`);
+            }
+
+
             // apply lense output to main output tree
             logger.info(`merging lens output tree(${outputTreeHash}) into /${outputRoot != '.' ? outputRoot+'/' : ''}`);
 

--- a/commands/project.js
+++ b/commands/project.js
@@ -208,9 +208,11 @@ exports.handler = async function project ({
     } else {
         const holoTree = await projection.output.getSubtree('.holo');
 
-        for (const childName in await holoTree.getChildren()) {
-            if (childName != 'lenses') {
-                holoTree.deleteChild(childName);
+        if (holoTree) {
+            for (const childName in await holoTree.getChildren()) {
+                if (childName != 'lenses') {
+                    holoTree.deleteChild(childName);
+                }
             }
         }
     }

--- a/commands/project.js
+++ b/commands/project.js
@@ -23,6 +23,11 @@ exports.builder = {
         describe: 'Whether to apply lensing to the composite tree',
         type: 'boolean',
         default: true
+    },
+    'fetch': {
+        describe: 'Whether to fetch the latest commit for all sources while projecting',
+        type: 'boolean',
+        default: false
     }
 };
 
@@ -45,6 +50,7 @@ exports.handler = async function project ({
     lens = true,
     working = false,
     debug = false,
+    fetch = false,
     commitBranch = null,
     commitMessage = null
 }) {
@@ -62,6 +68,18 @@ exports.handler = async function project ({
     // load holorepo
     const repo = await Repo.getFromEnvironment({ ref, working });
     const repoHash = await repo.resolveRef();
+
+
+    // fetch all sources
+    if (fetch) {
+        const sources = await repo.getSources();
+
+        for (const source of sources.values()) {
+            const hash = await source.fetch();
+            const { url, ref } = await source.getCachedConfig();
+            logger.info(`fetched ${source.name} ${url}#${ref}@${hash.substr(0, 8)}`);
+        }
+    }
 
 
     // instantiate projection

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -183,7 +183,7 @@ class Source extends Configurable {
 
         await git.fetch({ depth: 1 }, url, `+${hash}:${specRef}`);
 
-        return hash;
+        return this.getHead();
     }
 
     async getSubmodule ({ required=false } = {}) {

--- a/lib/Studio.js
+++ b/lib/Studio.js
@@ -74,7 +74,7 @@ class Studio {
                 HostConfig: {
                     Binds: [
                         `${gitDir}:/git`,
-                        // `/Users/chris/Repositories/hologit:/src`
+                        // `${__dirname.substr(0, __dirname.length-4)}:/src`
                     ],
                     // ExposedPorts: {
                     //     "9229/tcp": { }
@@ -155,13 +155,17 @@ class Studio {
     }
 
     async holoExec (...command) {
-        // return this.habExec(
-        //     'core/node',
+        // const holoPath = await this.exec('hab', 'pkg', 'path', 'jarvus/hologit');
+        // const PATH = await this.exec('cat', `${holoPath}/RUNTIME_PATH`);
+        // return this.exec(
         //     'node',
-        //         // '--inspect-brk=0.0.0.0:9229',
+        //         '--inspect-brk=0.0.0.0:9229',
         //         '--nolazy',
         //         '/src/bin/cli.js',
-        //             ...command
+        //             ...command,
+        //     {
+        //         $env: { PATH }
+        //     }
         // );
         return this.habExec('jarvus/hologit', 'git-holo', ...command);
     }

--- a/lib/Studio.js
+++ b/lib/Studio.js
@@ -117,12 +117,24 @@ class Studio {
      * Run a command in the studio
      */
     async exec (...command) {
+        const options = typeof command[command.length-1] == 'object'
+            ? command.pop()
+            : {};
+
         logger.debug('studio-exec:', ...command);
+
+        const env = [];
+        if (options.$env) {
+            for (const key of Object.keys(options.$env)) {
+                env.push(`${key}=${options.$env[key]}`);
+            }
+        }
 
         const exec = await this.container.exec({
             Cmd: command,
             AttachStdout: true,
-            AttachStderr: true
+            AttachStderr: true,
+            Env: env
         });
 
         const execStream = await exec.start();

--- a/lib/Studio.js
+++ b/lib/Studio.js
@@ -62,7 +62,8 @@ class Studio {
                 AttachStderr: true,
                 Env: [
                     'GIT_DIR=/git',
-                    'GIT_WORK_TREE=/hab/cache'
+                    'GIT_WORK_TREE=/hab/cache',
+                    `DEBUG=${process.env.DEBUG}`
                 ],
                 WorkingDir: '/git',
                 Volumes: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -316,9 +316,9 @@
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "git-client": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/git-client/-/git-client-1.1.1.tgz",
-      "integrity": "sha512-/fyMucvZdGkBA1bJNoYD58xzy4w495XXzpO6gtx1Y9GxXoGjJ/ceeAfrVO0O6aO0PO/JcWwYvCl5tlbAyam3+g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/git-client/-/git-client-1.2.0.tgz",
+      "integrity": "sha512-lQ+/tsRlC78NU7AklBts2A6f/E9oJNFLtfglZFVgJN4xKByrubzMdKuCXYllGAZYzH9RvYX9XzlzTskh3H58jQ==",
       "requires": {
         "mz": "^2.7.0",
         "semver": "^5.5.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "axios": "^0.18.0",
     "dockerode": "^2.5.7",
     "fb-watchman": "^2.0.0",
-    "git-client": "^1.1.1",
+    "git-client": "^1.2.0",
     "hab-client": "^1.0.0",
     "handlebars": "^4.0.12",
     "minimatch": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hologit",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Hologit automates the projection of layered composite file trees based on flat, declarative plans",
   "repository": "https://github.com/EmergencePlatform/hologit",
   "main": "bin/cli.js",


### PR DESCRIPTION
- feat: record source as merge parent when committing projection
- feat: add --fetch option to project command
- feat: improved lens output
- feat: pass DEBUG env flag through to studio
- feat: add support for passing $env to studio.exec()
- feat: improve container debugging code
- fix: skip scrubbing .holo if not found
- fix: update head cache on source fetch
- fix: test that lens output is a hash