### PR TITLE
Release: hologit v0.10.0

### DIFF
--- a/commands/project.js
+++ b/commands/project.js
@@ -75,10 +75,13 @@ exports.handler = async function project ({
         const sources = await workspace.getSources();
 
         for (const source of sources.values()) {
-            await source.fetch(); // TODO: skip fetch if there is a submodule gitlink
-            const hash = await source.getHead();
             const { url, ref } = await source.getCachedConfig();
-            logger.info(`fetched ${source.name} ${url}#${ref}@${hash.substr(0, 8)}`);
+            const { refs: [ fetchedRef ] } = await source.fetch();
+            const fetchedHash = await repo.resolveRef(fetchedRef);
+            if (!fetchedHash) {
+               throw new Error(`failed to fetch ${source.name} ${url||''}#${ref}`);
+            }
+            logger.info(`fetched ${source.name} ${url||''}#${ref}@${fetchedHash.substr(0, 8)}`);
         }
     }
 

--- a/commands/project.js
+++ b/commands/project.js
@@ -103,10 +103,7 @@ exports.handler = async function project ({
             callback: async (newTreeHash, newCommitHash=null) => {
                 logger.info('watch new hash: %s (from:%s)', newTreeHash, newCommitHash||'unknown');
 
-                const newWorkspace = new Workspace({
-                    root: await repo.createTree({ hash: newTreeHash })
-                });
-
+                const newWorkspace = await repo.createWorkspaceFromTreeHash(newTreeHash);
                 outputHash = await Projection.projectBranch(newWorkspace.getBranch(holobranch), {
                     debug,
                     lens,

--- a/commands/project.js
+++ b/commands/project.js
@@ -75,7 +75,8 @@ exports.handler = async function project ({
         const sources = await workspace.getSources();
 
         for (const source of sources.values()) {
-            const hash = await source.fetch(); // TODO: skip fetch if there is a submodule gitlink
+            await source.fetch(); // TODO: skip fetch if there is a submodule gitlink
+            const hash = await source.getHead();
             const { url, ref } = await source.getCachedConfig();
             logger.info(`fetched ${source.name} ${url}#${ref}@${hash.substr(0, 8)}`);
         }

--- a/commands/source/checkout.js
+++ b/commands/source/checkout.js
@@ -1,14 +1,19 @@
-exports.command = 'checkout [name]';
-exports.desc = 'Check out submodule for source named <name> or --all sources';
+exports.command = 'checkout [name|--all]';
+exports.desc = 'Check out repositories for source named <name> or --all sources';
 exports.builder = {
     all: {
-        describe: 'Check out submodules for all defined sources',
+        describe: 'Check out repositories for all defined sources',
+        type: 'boolean',
+        default: false
+    },
+    submodule: {
+        describe: 'Create a submodule for tracking the source\'s version in the outer repository',
         type: 'boolean',
         default: false
     }
 };
 
-exports.handler = async function checkoutSource ({ name, all }) {
+exports.handler = async function checkoutSource ({ name, all, submodule }) {
     const logger = require('../../lib/logger.js');
     const { Repo } = require('../../lib');
 
@@ -33,7 +38,7 @@ exports.handler = async function checkoutSource ({ name, all }) {
 
     // execute fetch
     for (const source of sources) {
-        const result = await source.checkoutSubmodule();
+        const result = await source.checkout({ submodule });
         console.log(`checked out ${result.path} from ${result.url}#${result.branch||result.ref}@${result.head.substr(0, 8)}`);
     }
 

--- a/commands/source/checkout.js
+++ b/commands/source/checkout.js
@@ -39,7 +39,7 @@ exports.handler = async function checkoutSource ({ name, all, submodule }) {
     // execute fetch
     for (const source of sources) {
         const result = await source.checkout({ submodule });
-        console.log(`checked out ${result.path} from ${result.url}#${result.branch||result.ref}@${result.head.substr(0, 8)}`);
+        console.log(`checked out ${result.path} from ${result.url||''}#${result.branch||result.ref}@${result.head.substr(0, 8)}`);
     }
 
 };

--- a/commands/source/checkout.js
+++ b/commands/source/checkout.js
@@ -1,4 +1,4 @@
-exports.command = 'checkout [name|--all]';
+exports.command = 'checkout [name]';
 exports.desc = 'Check out repositories for source named <name> or --all sources';
 exports.builder = {
     all: {

--- a/commands/source/create.js
+++ b/commands/source/create.js
@@ -64,14 +64,18 @@ exports.handler = async function createSource ({
 
     // examine remote repo/branch to discover absolute ref and current commit hash
     logger.info(`listing ${url}#${ref}`);
-    const { hash, ref: remoteRef } = await source.queryRef();
+    const { ref: remoteRef } = await source.queryRef();
     source.phantom.ref = remoteRef;
 
 
     // fetch objects
-    logger.info(`fetching ${url}#${remoteRef}@${hash}`);
-    await source.fetch();
-    console.log(`fetched ${url}#${remoteRef}@${hash}`);
+    logger.info(`fetching ${url||''}#${remoteRef}`);
+    const { refs: [ fetchedRef ] } = await source.fetch();
+    const fetchedHash = await repo.resolveRef(fetchedRef);
+    if (!fetchedHash) {
+       throw new Error(`failed to fetch ${source.name} ${url||''}#${ref}`);
+    }
+    console.log(`fetched ${url||''}#${remoteRef}@${fetchedHash}`);
 
 
     // write config

--- a/commands/source/fetch.js
+++ b/commands/source/fetch.js
@@ -33,7 +33,8 @@ exports.handler = async function fetch ({ name, all }) {
 
     // execute fetch
     for (const source of sources) {
-        const hash = await source.fetch();
+        await source.fetch();
+        const hash = await source.getHead();
         const { url, ref } = await source.getCachedConfig();
         console.log(`fetched${all?` ${source.name}`:''} ${url}#${ref}@${hash.substr(0, 8)}`);
     }

--- a/lib/Projection.js
+++ b/lib/Projection.js
@@ -98,7 +98,7 @@ class Projection {
 
             // load source
             const source = await this.workspace.getSource(holosource);
-            const sourceHead = await source.getCachedHead();
+            const sourceHead = await source.getHead();
 
             // load tree
             const sourceTree = await repo.createTreeFromRef(`${sourceHead}:${root == '.' ? '' : root}`);

--- a/lib/Projection.js
+++ b/lib/Projection.js
@@ -24,14 +24,13 @@ class Projection {
         await projection.composite();
 
 
-        // write and output pre-lensing hash if debug enabled
-        if (debug) {
-            logger.info('writing output tree before lensing...');
-            logger.info('output tree before lensing:', await projection.output.root.write());
-        }
-
-
         if (lens) {
+            // write and output pre-lensing hash if debug enabled
+            if (debug) {
+                logger.info('writing output tree before lensing...');
+                logger.info('output tree before lensing:', await projection.output.root.write());
+            }
+
             await projection.lens();
         } else {
             const holoTree = await projection.output.root.getSubtree('.holo');

--- a/lib/Projection.js
+++ b/lib/Projection.js
@@ -2,8 +2,7 @@ const path = require('path');
 
 
 const logger = require('./logger');
-const Workspace = require('./Workspace.js');
-
+const hololib = require('.');
 
 class Projection {
 
@@ -74,7 +73,7 @@ class Projection {
 
         this.branch = branch;
         this.workspace = branch.workspace;
-        this.output = new Workspace({
+        this.output = new hololib.Workspace({
             root: branch.getRepo().createTree()
         });
 

--- a/lib/Repo.js
+++ b/lib/Repo.js
@@ -153,6 +153,15 @@ class Repo {
         return new CommitObject(this, ...arguments);
     }
 
+    /**
+     * Test whether a given commit is available in the repository
+     * @param {string} commit-  hash or ref for commit to check
+     */
+    async hasCommit (commit) {
+        const git = await this.getGit();
+        return null != await git.revList(commit, { not: true }, { all: true }, { $nullOnError: true });
+    }
+
     async hashWorkTree () {
         if (!this.workTree) {
             throw new Error('cannot call hashWorkTree from non-working repo instance');

--- a/lib/Repo.js
+++ b/lib/Repo.js
@@ -159,7 +159,7 @@ class Repo {
      */
     async hasCommit (commit) {
         const git = await this.getGit();
-        return null != await git.revList(commit, { not: true }, { all: true }, { $nullOnError: true });
+        return 'commit' == await git.catFile({ t: true }, commit, { $nullOnError: true });
     }
 
     async hashWorkTree () {

--- a/lib/Repo.js
+++ b/lib/Repo.js
@@ -95,19 +95,21 @@ class Repo {
         let workspace = workspaces.get(this);
 
         if (!workspace) {
-            let root;
-
-            if (this.workTree) {
-                root = await this.createTreeFromRef(await this.hashWorkTree());
-            } else {
-                root = await this.createTreeFromRef(this.ref);
-            }
-
-            workspace = new Workspace({ root });
+            workspace = this.workTree
+                ? await this.createWorkspaceFromTreeHash(await this.hashWorkTree())
+                : await this.createWorkspaceFromRef(this.ref);
             workspaces.set(this, workspace);
         }
 
         return workspace;
+    }
+
+    async createWorkspaceFromRef (ref) {
+        return new Workspace({ root: await this.createTreeFromRef(ref) });
+    }
+
+    async createWorkspaceFromTreeHash (hash) {
+        return new Workspace({ root: await this.createTree({ hash }) });
     }
 
     async getGit () {

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -296,7 +296,17 @@ class Source extends Configurable {
             depth = null;
         }
 
-        return git.fetch({ depth, unshallow }, url, ...refs.map(ref => `+${ref}:${specRef}/${ref.substr(5)}`));
+        if (url) {
+            await git.fetch({ depth, unshallow }, url, ...refs.map(ref => `+${ref}:${specRef}/${ref.substr(5)}`));
+        } else {
+            for (const ref of refs) {
+                await git.updateRef(`${specRef}/${ref.substr(5)}`, ref);
+            }
+        }
+
+        return {
+            refs: refs.map(ref => `${specRef}/${ref.substr(5)}`)
+        };
     }
 
     async getSubGit ({ required=false } = {}) {

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -104,6 +104,33 @@ class Source extends Configurable {
         };
     }
 
+    async hashWorkTree () {
+        const repo = this.getRepo();
+        if (!repo.workTree) {
+            throw new Error('cannot call hashWorkTree from non-working repo instance');
+        }
+
+
+        const subGit = await this.getSubGit();
+        if (!subGit) {
+            return;
+        }
+
+
+        // get holoindex path, cloning index if needed
+        const indexPath = await subGit.getIndexPath();
+        const holoIndexPath = `${indexPath}.holo`;
+        if (!await fs.exists(holoIndexPath)) {
+            await fs.copyFile(indexPath, holoIndexPath);
+        }
+
+
+        // build a tree via the cloned index
+        const holoIndexEnv = { $indexFile: holoIndexPath };
+        await subGit.add(holoIndexEnv, { all: true });
+        return subGit.writeTree(holoIndexEnv);
+    }
+
     async getHead ({ required=false } = {}) {
         const repo = this.getRepo();
         const { local, ref } = await this.getCachedConfig();
@@ -116,11 +143,7 @@ class Source extends Configurable {
 
         // try to get from submodule
         if (repo.workTree) {
-            const subGit = await this.getSubGit();
-
-            if (subGit) {
-                head = await subGit.revParse({ verify: true }, 'HEAD', { $nullOnError: true });
-            }
+            head = await this.hashWorkTree();
         }
 
 

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -117,10 +117,10 @@ class Source extends Configurable {
 
         // try to get from submodule
         if (repo.workTree) {
-            const submodule = await this.getSubmodule();
+            const subGit = await this.getSubGit();
 
-            if (submodule) {
-                head = await submodule.revParse('HEAD');
+            if (subGit) {
+                head = await subGit.revParse({ verify: true }, 'HEAD', { $nullOnError: true });
             }
         }
 
@@ -182,17 +182,17 @@ class Source extends Configurable {
         return this.getHead();
     }
 
-    async getSubmodule ({ required=false } = {}) {
+    async getSubGit ({ required=false } = {}) {
         const envGit = await Git.get();
         const repo = this.getRepo();
 
-        const submodulePath = `.holo/sources/${this.name}`;
-        const gitDir = path.join(repo.gitDir, 'modules', submodulePath);
-        const workTree = repo.workTree && path.join(repo.workTree, submodulePath);
+        const subRepoPath = `.holo/sources/${this.name}`;
+        const gitDir = path.join(repo.gitDir, 'modules', subRepoPath);
+        const workTree = repo.workTree && path.join(repo.workTree, subRepoPath);
 
         if (!await fs.exists(gitDir)) {
             if (required) {
-                throw new Error(`submodule ${submodulePath} is not initialized; try running: git holo source checkout ${this.name}`);
+                throw new Error(`submodule ${subRepoPath} is not initialized; try running: git holo source checkout ${this.name}`);
             } else {
                 return null;
             }
@@ -204,7 +204,7 @@ class Source extends Configurable {
         });
     }
 
-    async checkoutSubmodule () {
+    async checkout ({ submodule=false }) {
         const mkdirp = require('mz-modules/mkdirp');
 
         const repo = this.getRepo();
@@ -216,117 +216,113 @@ class Source extends Configurable {
 
         // get work tree
         if (!workTree) {
-            throw new Error('no work tree found, cannot checkout submodule');
+            throw new Error('no work tree found, cannot checkout sub-repository');
         }
+
+
+        // determine commit and path for subrepo
+        const head = await this.getCachedHead();
+        const subRepoPath = `.holo/sources/${this.name}`;
 
 
         // generate submodule config
-        const submodulePath = `.holo/sources/${this.name}`;
-        const submoduleConfig = {
-            path: submodulePath,
-            url,
-            shallow: 'true'
-        };
+        if (submodule) {
+            const submoduleConfig = {
+                path: subRepoPath,
+                url,
+                shallow: 'true'
+            };
 
-        if (branch) {
-            submoduleConfig.branch = branch;
+            if (branch) {
+                submoduleConfig.branch = branch;
+            }
+
+
+            // write submodule config
+            for (const key in submoduleConfig) {
+                await git.config({ file: '.gitmodules' }, `submodule.${subRepoPath}.${key}`, submoduleConfig[key]);
+            }
+            await git.add('.gitmodules');
+
+
+            // stage head as gitlink
+            await git.updateIndex({ add: true, cacheinfo: true }, `160000,${head},${subRepoPath}`);
         }
 
 
-        // write submodule config
-        for (const key in submoduleConfig) {
-            await git.config({ file: '.gitmodules' }, `submodule.${submodulePath}.${key}`, submoduleConfig[key]);
-        }
-        await git.add('.gitmodules');
-
-
-        // stage head as gitlink
-        const head = await this.getCachedHead();
-        await git.updateIndex({ add: true, cacheinfo: true }, `160000,${head},${submodulePath}`);
-
-
-        // initialize submodule repository
-        const submoduleGitDir = path.join(gitDir, 'modules', submodulePath);
+        // initialize sub-repository
+        const subRepoGitDir = path.join(gitDir, 'modules', subRepoPath);
         const envGit = await Git.get();
-        await envGit.init({ bare: true }, submoduleGitDir);
+        await envGit.init({ bare: true }, subRepoGitDir);
 
 
-        // have submodule use objects from main repository
-        const submoduleAlternatesPath = `${submoduleGitDir}/objects/info/alternates`;
-        const submoduleAlternatesList = await fs.exists(submoduleAlternatesPath)
-            ? new Set((await fs.readFile(submoduleAlternatesPath, 'ascii')).trim().split('\n'))
-            : new Set();
-        submoduleAlternatesList.add(path.relative(`${submoduleGitDir}/objects`, `${gitDir}/objects`));
-        await mkdirp(path.dirname(submoduleAlternatesPath));
-        await fs.writeFile(submoduleAlternatesPath, Array.from(submoduleAlternatesList.values()).join('\n')+'\n');
-
-
-        // have main repository use objects from submodule
-        const alternatesPath = `${gitDir}/objects/info/alternates`;
-        const alternatesList = await fs.exists(alternatesPath)
-            ? new Set((await fs.readFile(alternatesPath, 'ascii')).trim().split('\n'))
-            : new Set();
-        alternatesList.add(path.relative(`${gitDir}/objects`, `${submoduleGitDir}/objects`));
-        await mkdirp(path.dirname(alternatesPath));
-        await fs.writeFile(alternatesPath, Array.from(alternatesList.values()).join('\n')+'\n');
-
-
-        // initialize submodule work tree
-        const submoduleWorkTree = path.join(workTree, submodulePath);
-        await mkdirp(submoduleWorkTree);
-        await fs.writeFile(`${submoduleWorkTree}/.git`, `gitdir: ${path.relative(submoduleWorkTree, submoduleGitDir)}\n`);
+        // initialize sub-repository work tree
+        const subWorkTree = path.join(workTree, subRepoPath);
+        await mkdirp(subWorkTree);
+        await fs.writeFile(`${subWorkTree}/.git`, `gitdir: ${path.relative(subWorkTree, subRepoGitDir)}\n`);
 
 
         // instantiate git client
-        const submodule = await this.getSubmodule();
+        const subGit = await this.getSubGit();
 
 
-        // configure submodule
-        await submodule.config('core.bare', 'false');
-        await submodule.config('core.worktree', path.relative(submoduleGitDir, submoduleWorkTree));
-        await submodule.config(`submodule.${submodulePath}.active`, 'true');
-        await submodule.config(`submodule.${submodulePath}.url`, url);
+        // configure two-way object sharing
+        await subGit.addToConfigSet('objects/info/alternates', path.relative(`${subRepoGitDir}/objects`, `${gitDir}/objects`));
+        await git.addToConfigSet('objects/info/alternates', path.relative(`${gitDir}/objects`, `${subRepoGitDir}/objects`));
+
+
+        // configure sub-repository
+        await subGit.config('core.bare', 'false');
+        await subGit.config('core.worktree', path.relative(subRepoGitDir, subWorkTree));
+
+        if (submodule) {
+            await git.config(`submodule.${subRepoPath}.active`, 'true');
+            await git.config(`submodule.${subRepoPath}.url`, url);
+            await git.removeFromConfigSet('info/exclude', `${subRepoPath}/`);
+        } else {
+            await git.addToConfigSet('info/exclude', `${subRepoPath}/`);
+        }
 
 
         // check out ref
-        const shallowPath = `${submoduleGitDir}/shallow`;
+        const shallowPath = `${subRepoGitDir}/shallow`;
         const shallowList = await fs.exists(shallowPath)
             ? new Set((await fs.readFile(shallowPath, 'ascii')).trim().split('\n'))
             : new Set();
         shallowList.add(head); // TODO: don't add if any ancestors already within
         await fs.writeFile(shallowPath, Array.from(shallowList.values()).join('\n')+'\n');
 
-        await submodule.updateRef(ref, head);
-        await submodule.symbolicRef('HEAD', ref);
+        await subGit.updateRef(ref, head);
+        await subGit.symbolicRef('HEAD', ref);
 
-        await submodule.checkout();
+        await subGit.checkout();
 
 
         // add remote
-        await submodule.config(`remote.origin.url`, url);
+        await subGit.config(`remote.origin.url`, url);
 
 
         // configure upstream
         if (branch) {
             const remoteRef = `refs/remotes/origin/${branch}`;
-            await submodule.updateRef(remoteRef, head);
-            await submodule.updateRef('FETCH_HEAD', ref);
+            await subGit.updateRef(remoteRef, head);
+            await subGit.updateRef('FETCH_HEAD', ref);
 
-            await submodule.config(`branch.${branch}.remote`, 'origin');
-            await submodule.config(`branch.${branch}.merge`, ref);
-            await submodule.config(`branch.${branch}.rebase`, 'true');
-            await submodule.config(`remote.origin.fetch`, `+${ref}:${remoteRef}`);
+            await subGit.config(`branch.${branch}.remote`, 'origin');
+            await subGit.config(`branch.${branch}.merge`, ref);
+            await subGit.config(`branch.${branch}.rebase`, 'true');
+            await subGit.config(`remote.origin.fetch`, `+${ref}:${remoteRef}`);
         } else {
-            await submodule.config(`remote.origin.fetch`, `+${ref}:${ref}`);
+            await subGit.config(`remote.origin.fetch`, `+${ref}:${ref}`);
         }
 
 
         // initialize FETCH_HEAD
-        await submodule.fetch({ depth: 1 });
+        await subGit.fetch({ depth: 1 });
 
 
         return {
-            path: submodulePath,
+            path: subRepoPath,
             head,
             branch,
             url,

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -388,7 +388,7 @@ class Source extends Configurable {
             // check out ref
             await subGit.updateRef(ref, head);
             await subGit.symbolicRef('HEAD', ref);
-            await subGit.checkout('--', subWorkTree);
+            await subGit.checkout({ $cwd: subWorkTree }, '--', '.');
         }
 
 

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -35,7 +35,7 @@ class Source extends Configurable {
 
         if (this.name == workspaceName) {
             return {
-                local: true
+                $workspace: true
             };
         }
 
@@ -45,28 +45,24 @@ class Source extends Configurable {
     async getConfig () {
         const config = await super.getConfig();
 
-        if (!config.local) {
-            if (!config.url) {
+        if (!config.$workspace && !config.ref) {
                 throw new Error(`holosource has no url defined: ${this.name}`);
             }
-
-            if (!config.ref) {
-                throw new Error(`holosource has no url defined: ${this.name}`);
-            }
-        }
 
         return config;
     }
 
     async getSpec () {
         const { url } = await this.getCachedConfig();
+        const data = {};
 
+        if (url) {
         const { resource: host, pathname: path } = parseUrl(url);
-
-        const data = {
-            host: host.toLowerCase(),
-            path: path.toLowerCase().replace(/\/?\.git$/, '')
-        };
+            data.host = host.toLowerCase();
+            data.path = path.toLowerCase().replace(/\/?\.git$/, '');
+        } else {
+            data.path = '.';
+        }
 
         const spec = {
             ...await SpecObject.write(this.workspace.root.repo, 'source', data),

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -282,14 +282,22 @@ class Source extends Configurable {
     }
 
     async getSubGit ({ required=false } = {}) {
-        const envGit = await Git.get();
         const repo = this.getRepo();
-
         const subRepoPath = `.holo/sources/${this.name}`;
-        const { hash: specHash } = await this.getCachedSpec();
-        const gitDir = path.join(repo.gitDir, 'modules', specHash);
-        const workTree = repo.workTree && path.join(repo.workTree, subRepoPath);
 
+
+        // determine workTree
+        let workTree = repo.workTree && path.join(repo.workTree, subRepoPath);
+
+        if (!workTree || !await fs.exists(workTree)) {
+            workTree = null;
+        }
+
+
+        // determine gitDir
+        const { hash: specHash } = await this.getCachedSpec();
+
+        const gitDir = path.join(repo.gitDir, 'modules', specHash);
         if (!await fs.exists(gitDir)) {
             if (required) {
                 throw new Error(`submodule ${subRepoPath} is not initialized; try running: git holo source checkout ${this.name}`);
@@ -298,10 +306,10 @@ class Source extends Configurable {
             }
         }
 
-        return new envGit.Git({
-            gitDir,
-            workTree: workTree && await fs.exists(workTree) ? workTree : null
-        });
+
+        // build git instance
+        const envGit = await Git.get();
+        return new envGit.Git({ gitDir, workTree });
     }
 
     async checkout ({ submodule=false }) {

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -116,7 +116,7 @@ class Source extends Configurable {
         // get holoindex path, cloning index if needed
         const indexPath = await subGit.getIndexPath();
         const holoIndexPath = `${indexPath}.holo`;
-        if (!await fs.exists(holoIndexPath)) {
+        if (!await fs.exists(holoIndexPath) && await fs.exists(indexPath)) {
             await fs.copyFile(indexPath, holoIndexPath);
         }
 

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -6,6 +6,7 @@ const parseUrl = require('parse-url');
 const Git = require('./Git.js');
 const Configurable = require('./Configurable.js');
 const SpecObject = require('./SpecObject.js');
+const Projection = require('./Projection.js');
 
 
 const specCache = new WeakMap();
@@ -130,7 +131,7 @@ class Source extends Configurable {
     async getHead ({ required=false, working=null } = {}) {
         const repo = this.getRepo();
         const git = await repo.getGit();
-        const { $workspace, url, ref } = await this.getCachedConfig();
+        const { $workspace, url, ref, project } = await this.getCachedConfig();
 
 
         // special value indicates that the containing in-flight workspace is the source
@@ -232,6 +233,20 @@ class Source extends Configurable {
         // unresolved head is an exception
         if (required && !head) {
             throw new Error(`could not resolve head commit for holosource ${this.name}`);
+        }
+
+        // apply projection
+        if (head && project) {
+            if (!project.holobranch) {
+                throw new Error('holosource.project config must include holobranch');
+            }
+
+            const workspace = await repo.createWorkspaceFromRef(head);
+            head = await Projection.projectBranch(workspace.getBranch(project.holobranch), {
+                debug: true,
+                lens: 'lens' in project ? project.lens : true,
+                parentCommit: head
+            });
         }
 
         if (!head) {

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -129,27 +129,69 @@ class Source extends Configurable {
 
     async getHead ({ required=false } = {}) {
         const repo = this.getRepo();
-        const { local, ref } = await this.getCachedConfig();
+        const git = await repo.getGit();
+        const { $workspace, url, ref } = await this.getCachedConfig();
 
-        if (local) {
+
+        // special value indicates that the containing in-flight workspace is the source
+        if ($workspace) {
             return await this.workspace.root.write();
         }
 
+
+        // get value of gitlink if it exists
+        const [,,gitLinkHash] = (await git.lsTree(`${repo.ref}:.holo/sources`, this.name)).split(/\s/, 4);
+
+        // fall few a few different ways to determine the current commit hash to use
         let head;
 
-        // try to get from submodule
+
+        // hash source sub-worktree if available
         if (repo.workTree) {
-            head = await this.hashWorkTree();
+            const workTreeHash = await this.hashWorkTree();
+            if (workTreeHash) {
+                let workTreeCommit;
+
+                // check if staged gitlink matches working tree
+                const [,stagedHash] = (await git.lsFiles({ stage: true }, `.holo/sources/${this.name}`)).split(/\s/, 4);
+                if (
+                    stagedHash
+                    && await git.getTreeHash(stagedHash) == workTreeHash
+                ) {
+                    workTreeCommit = stagedHash;
+        }
+
+                // else, check if committed gitlink matches working tree
+                if (
+                    !workTreeCommit
+                    && gitLinkHash
+                    && await git.getTreeHash(gitLinkHash) == workTreeHash
+                ) {
+                    workTreeCommit = gitLinkHash;
+                }
+
+                // else, create a commit
+                if (workTreeCommit) {
+                    head = workTreeCommit;
+                } else {
+                    head = await git.commitTree(
+                        {
+                            p: stagedHash || gitLinkHash || null,
+                            m: `working snapshot of ${repo.workTree}`
+                        },
+                        workTreeHash
+                    );
+                }
+            }
         }
 
 
-        // try to get head from submodule gitlink
-        if (!head) {
-            const git = await repo.getGit();
-            [,,head] = (await git.lsTree(`${repo.ref}:.holo/sources`, this.name)).split(/\s/, 4);
+        // try to get head from gitlink commit entry in sources tree
+        if (!head && gitLinkHash) {
+            head = gitLinkHash;
 
             // if the indicated head is not available, try a broad fetch on the source
-            if (head && !await repo.hasCommit(head)) {
+            if (!await repo.hasCommit(gitLinkHash)) {
                 const { ref: specRef } = await this.getCachedSpec();
                 const headRef = `${specRef}/${ref.substr(5)}`;
                 const resolvedRef = await repo.resolveRef(headRef);
@@ -158,18 +200,23 @@ class Source extends Configurable {
                     await this.fetch();
                 }
 
-                if (!await repo.hasCommit(head)) {
+                if (!await repo.hasCommit(gitLinkHash)) {
                     await this.fetch({ unshallow: true }, 'refs/heads/*');
 
-                    if (!await repo.hasCommit(head)) {
+                    if (!await repo.hasCommit(gitLinkHash)) {
                         throw new Error(`.holo/sources/${this.name} is set to commit ${head}, but that commit is not exposed by any branch on the source`);
                     }
                 }
             }
         }
 
-        // try to get head from specRef
-        if (!head) {
+        // try to get from local ref
+        if (!head && !url) {
+            head = await repo.resolveRef(ref);
+        }
+
+        // try to get head from remote specRef
+        if (!head && url) {
             const { ref: specRef } = await this.getCachedSpec();
             const headRef = `${specRef}/${ref.substr(5)}`;
 

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -46,8 +46,8 @@ class Source extends Configurable {
         const config = await super.getConfig();
 
         if (!config.$workspace && !config.ref) {
-                throw new Error(`holosource has no url defined: ${this.name}`);
-            }
+            throw new Error(`holosource has no url defined: ${this.name}`);
+        }
 
         return config;
     }
@@ -57,7 +57,7 @@ class Source extends Configurable {
         const data = {};
 
         if (url) {
-        const { resource: host, pathname: path } = parseUrl(url);
+            const { resource: host, pathname: path } = parseUrl(url);
             data.host = host.toLowerCase();
             data.path = path.toLowerCase().replace(/\/?\.git$/, '');
         } else {
@@ -127,7 +127,7 @@ class Source extends Configurable {
         return subGit.writeTree(holoIndexEnv);
     }
 
-    async getHead ({ required=false } = {}) {
+    async getHead ({ required=false, working=null } = {}) {
         const repo = this.getRepo();
         const git = await repo.getGit();
         const { $workspace, url, ref } = await this.getCachedConfig();
@@ -147,7 +147,7 @@ class Source extends Configurable {
 
 
         // hash source sub-worktree if available
-        if (repo.workTree) {
+        if (repo.workTree && working !== false) {
             const workTreeHash = await this.hashWorkTree();
             if (workTreeHash) {
                 let workTreeCommit;
@@ -159,7 +159,7 @@ class Source extends Configurable {
                     && await git.getTreeHash(stagedHash) == workTreeHash
                 ) {
                     workTreeCommit = stagedHash;
-        }
+                }
 
                 // else, check if committed gitlink matches working tree
                 if (
@@ -328,13 +328,76 @@ class Source extends Configurable {
         }
 
 
-        // determine commit and path for subrepo
-        const head = await this.getHead();
+        // initialize sub-repository work tree
         const subRepoPath = `.holo/sources/${this.name}`;
+        const subWorkTree = path.join(workTree, subRepoPath);
+        await mkdirp(subWorkTree);
 
 
-        // generate submodule config
+        // initialize sub-repository
+        let head;
+        if (await fs.exists(`${subWorkTree}/.git`)) {
+            const subGit = await this.getSubGit();
+            head = await subGit.revParse({ verify: true }, 'HEAD');
+        } else {
+            const { hash: specHash } = await this.getCachedSpec();
+            const subRepoGitDir = path.join(gitDir, 'modules', specHash);
+
+            // initialize bare repository in submodule-like location
+            if (!await fs.exists(subRepoGitDir)) {
+                const envGit = await Git.get();
+                await envGit.init({ bare: true }, subRepoGitDir);
+            }
+
+            // point sub working tree at submodule-like repo outside working tree
+            await fs.writeFile(`${subWorkTree}/.git`, `gitdir: ${path.relative(subWorkTree, subRepoGitDir)}\n`);
+
+            // configure sub-repository
+            const subGit = await this.getSubGit();
+            await subGit.config('core.bare', 'false');
+            await subGit.config('core.worktree', path.relative(subRepoGitDir, subWorkTree));
+
+            // share objects in both directions with superproject repo
+            await subGit.addToConfigSet('objects/info/alternates', path.relative(`${subRepoGitDir}/objects`, `${gitDir}/objects`));
+            await git.addToConfigSet('objects/info/alternates', path.relative(`${gitDir}/objects`, `${subRepoGitDir}/objects`));
+
+            // stage head as gitlink
+            head = await this.getHead({ working: false });
+            await git.updateIndex({ add: true, cacheinfo: true }, `160000,${head},${subRepoPath}`);
+
+            // add remote
+            await subGit.config(`remote.origin.url`, url ? url : gitDir);
+
+            // configure upstream
+            debugger;
+            if (branch) {
+                const remoteRef = `refs/remotes/origin/${branch}`;
+                await subGit.updateRef(remoteRef, head);
+                await subGit.updateRef('FETCH_HEAD', head);
+
+                await subGit.config(`branch.${branch}.remote`, 'origin');
+                await subGit.config(`branch.${branch}.merge`, ref);
+                await subGit.config(`branch.${branch}.rebase`, 'true');
+                await subGit.config(`remote.origin.fetch`, `+${ref}:${remoteRef}`);
+            } else {
+                await subGit.config(`remote.origin.fetch`, `+${ref}:${ref}`);
+            }
+
+            // initialize FETCH_HEAD
+            await subGit.fetch({ depth: 1 }); // TODO: shallow: true? does this make that happen?
+
+            // check out ref
+            await subGit.updateRef(ref, head);
+            await subGit.symbolicRef('HEAD', ref);
+            await subGit.checkout('--', subWorkTree);
+        }
+
+
+        // configure submodule
         if (submodule) {
+            await git.config(`submodule.${subRepoPath}.active`, 'true');
+            await git.config(`submodule.${subRepoPath}.url`, url); // TODO: relative filesystem path?
+
             const submoduleConfig = {
                 path: subRepoPath,
                 url,
@@ -351,77 +414,7 @@ class Source extends Configurable {
                 await git.config({ file: '.gitmodules' }, `submodule.${subRepoPath}.${key}`, submoduleConfig[key]);
             }
             await git.add('.gitmodules');
-
-
-            // stage head as gitlink
-            await git.updateIndex({ add: true, cacheinfo: true }, `160000,${head},${subRepoPath}`);
         }
-
-
-        // initialize sub-repository as bare
-        const { hash: specHash } = await this.getCachedSpec();
-        const subRepoGitDir = path.join(gitDir, 'modules', specHash);
-        const envGit = await Git.get();
-        await envGit.init({ bare: true }, subRepoGitDir);
-
-
-        // initialize sub-repository work tree
-        const subWorkTree = path.join(workTree, subRepoPath);
-        await mkdirp(subWorkTree);
-        await fs.writeFile(`${subWorkTree}/.git`, `gitdir: ${path.relative(subWorkTree, subRepoGitDir)}\n`);
-
-
-        // instantiate git client
-        const subGit = await this.getSubGit();
-
-
-        // configure two-way object sharing
-        await subGit.addToConfigSet('objects/info/alternates', path.relative(`${subRepoGitDir}/objects`, `${gitDir}/objects`));
-        await git.addToConfigSet('objects/info/alternates', path.relative(`${gitDir}/objects`, `${subRepoGitDir}/objects`));
-
-
-        // configure sub-repository
-        await subGit.config('core.bare', 'false');
-        await subGit.config('core.worktree', path.relative(subRepoGitDir, subWorkTree));
-
-        if (submodule) {
-            await git.config(`submodule.${subRepoPath}.active`, 'true');
-            await git.config(`submodule.${subRepoPath}.url`, url);
-            await git.removeFromConfigSet('info/exclude', `${subRepoPath}/`);
-        } else {
-            await git.addToConfigSet('info/exclude', `${subRepoPath}/`);
-        }
-
-
-        // check out ref
-        await subGit.addToConfigSet('shallow', head);
-        await subGit.updateRef(ref, head);
-        await subGit.symbolicRef('HEAD', ref);
-
-        await subGit.checkout();
-
-
-        // add remote
-        await subGit.config(`remote.origin.url`, url);
-
-
-        // configure upstream
-        if (branch) {
-            const remoteRef = `refs/remotes/origin/${branch}`;
-            await subGit.updateRef(remoteRef, head);
-            await subGit.updateRef('FETCH_HEAD', ref);
-
-            await subGit.config(`branch.${branch}.remote`, 'origin');
-            await subGit.config(`branch.${branch}.merge`, ref);
-            await subGit.config(`branch.${branch}.rebase`, 'true');
-            await subGit.config(`remote.origin.fetch`, `+${ref}:${remoteRef}`);
-        } else {
-            await subGit.config(`remote.origin.fetch`, `+${ref}:${ref}`);
-        }
-
-
-        // initialize FETCH_HEAD
-        await subGit.fetch({ depth: 1 });
 
 
         return {

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -59,14 +59,13 @@ class Source extends Configurable {
     }
 
     async getSpec () {
-        const { url, ref } = await this.getCachedConfig();
+        const { url } = await this.getCachedConfig();
 
         const { resource: host, pathname: path } = parseUrl(url);
 
         const data = {
-            host,
-            path: path.replace(/\/?\.git$/, ''),
-            ref
+            host: host.toLowerCase(),
+            path: path.toLowerCase().replace(/\/?\.git$/, '')
         };
 
         const spec = {
@@ -107,7 +106,7 @@ class Source extends Configurable {
 
     async getHead ({ required=false } = {}) {
         const repo = this.getRepo();
-        const { local } = await this.getCachedConfig();
+        const { local, ref } = await this.getCachedConfig();
 
         if (local) {
             return await this.workspace.root.write();
@@ -127,18 +126,31 @@ class Source extends Configurable {
 
         // try to get head from submodule gitlink
         if (!head) {
-            head = await repo.resolveRef(`${repo.ref}:.holo/sources/${this.name}`);
+            const git = await repo.getGit();
+            [,,head] = (await git.lsTree(`${repo.ref}:.holo/sources`, this.name)).split(/\s/, 4);
+
+            // if the indicated head is not available, try a broad fetch on the source
+            if (head && !await repo.hasCommit(head)) {
+                await this.fetch({ unshallow: true }, 'refs/heads/*');
+
+                if (!await repo.hasCommit(head)) {
+                    throw new Error(`.holo/sources/${this.name} is set to commit ${head}, but that commit is not exposed by any branch on the source`);
+        }
+            }
         }
 
         // try to get head from specRef
         if (!head) {
             const { ref: specRef } = await this.getCachedSpec();
-            head = await repo.resolveRef(specRef);
-        }
+            const headRef = `${specRef}/${ref.substr(5)}`;
+
+            head = await repo.resolveRef(headRef);
 
         // try to fetch head
         if (!head) {
-            head = await this.fetch();
+                await this.fetch();
+                head = await repo.resolveRef(headRef);
+            }
         }
 
         // unresolved head is an exception
@@ -171,15 +183,26 @@ class Source extends Configurable {
         return refMatch ? refMatch[1] : null;
     }
 
-    async fetch () {
-        const { url } = await this.getCachedConfig();
+    async fetch ({ depth=1, unshallow=false } = {}, ...refs) {
+        const { url, ref: configRef } = await this.getCachedConfig();
         const { ref: specRef } = await this.getCachedSpec();
-        const { hash } = await this.queryRef();
         const git = await this.getRepo().getGit();
 
-        await git.fetch({ depth: 1 }, url, `+${hash}:${specRef}`);
+        if (!refs.length) {
+            refs.push(configRef);
+        }
 
-        return this.getHead();
+        for (const ref of refs) {
+            if (!ref.startsWith('refs/')) {
+                throw new Error(`ref ${ref} must start with refs/`);
+            }
+        }
+
+        if (unshallow) {
+            depth = null;
+    }
+
+        return git.fetch({ depth, unshallow }, url, ...refs.map(ref => `+${ref}:${specRef}/${ref.substr(5)}`));
     }
 
     async getSubGit ({ required=false } = {}) {
@@ -221,7 +244,7 @@ class Source extends Configurable {
 
 
         // determine commit and path for subrepo
-        const head = await this.getCachedHead();
+        const head = await this.getHead();
         const subRepoPath = `.holo/sources/${this.name}`;
 
 

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -108,8 +108,8 @@ class Source extends Configurable {
 
 
         const subGit = await this.getSubGit();
-        if (!subGit) {
-            return;
+        if (!subGit || !subGit.workTree) {
+            return null;
         }
 
 

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -220,7 +220,8 @@ class Source extends Configurable {
         const repo = this.getRepo();
 
         const subRepoPath = `.holo/sources/${this.name}`;
-        const gitDir = path.join(repo.gitDir, 'modules', subRepoPath);
+        const { hash: specHash } = await this.getCachedSpec();
+        const gitDir = path.join(repo.gitDir, 'modules', specHash);
         const workTree = repo.workTree && path.join(repo.workTree, subRepoPath);
 
         if (!await fs.exists(gitDir)) {
@@ -284,7 +285,8 @@ class Source extends Configurable {
 
 
         // initialize sub-repository as bare
-        const subRepoGitDir = path.join(gitDir, 'modules', subRepoPath);
+        const { hash: specHash } = await this.getCachedSpec();
+        const subRepoGitDir = path.join(gitDir, 'modules', specHash);
         const envGit = await Git.get();
         await envGit.init({ bare: true }, subRepoGitDir);
 

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -142,6 +142,7 @@ class Source extends Configurable {
 
 
         // get value of gitlink if it exists
+        const sourcePath = `.holo/sources/${this.name}`;
         const [,,gitLinkHash] = (await git.lsTree(`${repo.ref}:.holo/sources`, this.name)).split(/\s/, 4);
 
         // fall few a few different ways to determine the current commit hash to use
@@ -155,7 +156,7 @@ class Source extends Configurable {
                 let workTreeCommit;
 
                 // check if staged gitlink matches working tree
-                const [,stagedHash] = (await git.lsFiles({ stage: true }, `.holo/sources/${this.name}`)).split(/\s/, 4);
+                const [,stagedHash] = (await git.lsFiles({ stage: true }, sourcePath)).split(/\s/, 4);
                 if (
                     stagedHash
                     && await git.getTreeHash(stagedHash) == workTreeHash
@@ -179,7 +180,7 @@ class Source extends Configurable {
                     head = await git.commitTree(
                         {
                             p: stagedHash || gitLinkHash || null,
-                            m: `working snapshot of ${repo.workTree}/.holo/sources/${this.name}`
+                            m: `working snapshot of ${repo.workTree}/${sourcePath}`
                         },
                         workTreeHash
                     );
@@ -206,7 +207,7 @@ class Source extends Configurable {
                     await this.fetch({ unshallow: true }, 'refs/heads/*');
 
                     if (!await repo.hasCommit(gitLinkHash)) {
-                        throw new Error(`.holo/sources/${this.name} is set to commit ${head}, but that commit is not exposed by any branch on the source`);
+                        throw new Error(`${sourcePath} is set to commit ${head}, but that commit is not exposed by any branch on the source`);
                     }
                 }
             }

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -416,7 +416,7 @@ class Source extends Configurable {
             // check out ref
             await subGit.updateRef(ref, head);
             await subGit.symbolicRef('HEAD', ref);
-            await subGit.checkout({ $cwd: subWorkTree }, '--', '.');
+            await subGit.checkout({ $cwd: subWorkTree }, '--');
         }
 
 

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -273,7 +273,7 @@ class Source extends Configurable {
         }
 
 
-        // initialize sub-repository
+        // initialize sub-repository as bare
         const subRepoGitDir = path.join(gitDir, 'modules', subRepoPath);
         const envGit = await Git.get();
         await envGit.init({ bare: true }, subRepoGitDir);
@@ -308,13 +308,7 @@ class Source extends Configurable {
 
 
         // check out ref
-        const shallowPath = `${subRepoGitDir}/shallow`;
-        const shallowList = await fs.exists(shallowPath)
-            ? new Set((await fs.readFile(shallowPath, 'ascii')).trim().split('\n'))
-            : new Set();
-        shallowList.add(head); // TODO: don't add if any ancestors already within
-        await fs.writeFile(shallowPath, Array.from(shallowList.values()).join('\n')+'\n');
-
+        await subGit.addToConfigSet('shallow', head);
         await subGit.updateRef(ref, head);
         await subGit.symbolicRef('HEAD', ref);
 

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -48,7 +48,7 @@ class Source extends Configurable {
         const config = await super.getConfig();
 
         if (!config.$workspace && !config.ref) {
-            throw new Error(`holosource has no url defined: ${this.name}`);
+            throw new Error(`holosource has no ref defined: ${this.name}`);
         }
 
         return config;

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -131,11 +131,21 @@ class Source extends Configurable {
 
             // if the indicated head is not available, try a broad fetch on the source
             if (head && !await repo.hasCommit(head)) {
-                await this.fetch({ unshallow: true }, 'refs/heads/*');
+                const { ref: specRef } = await this.getCachedSpec();
+                const headRef = `${specRef}/${ref.substr(5)}`;
+                const resolvedRef = await repo.resolveRef(headRef);
+
+                if (!resolvedRef) {
+                    await this.fetch();
+                }
 
                 if (!await repo.hasCommit(head)) {
-                    throw new Error(`.holo/sources/${this.name} is set to commit ${head}, but that commit is not exposed by any branch on the source`);
-        }
+                    await this.fetch({ unshallow: true }, 'refs/heads/*');
+
+                    if (!await repo.hasCommit(head)) {
+                        throw new Error(`.holo/sources/${this.name} is set to commit ${head}, but that commit is not exposed by any branch on the source`);
+                    }
+                }
             }
         }
 
@@ -146,8 +156,8 @@ class Source extends Configurable {
 
             head = await repo.resolveRef(headRef);
 
-        // try to fetch head
-        if (!head) {
+            // try to fetch head
+            if (!head) {
                 await this.fetch();
                 head = await repo.resolveRef(headRef);
             }
@@ -200,7 +210,7 @@ class Source extends Configurable {
 
         if (unshallow) {
             depth = null;
-    }
+        }
 
         return git.fetch({ depth, unshallow }, url, ...refs.map(ref => `+${ref}:${specRef}/${ref.substr(5)}`));
     }

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -3,6 +3,7 @@ const fs = require('mz/fs');
 const parseUrl = require('parse-url');
 
 
+const logger = require('./logger');
 const Git = require('./Git.js');
 const Configurable = require('./Configurable.js');
 const SpecObject = require('./SpecObject.js');
@@ -241,12 +242,14 @@ class Source extends Configurable {
                 throw new Error('holosource.project config must include holobranch');
             }
 
+            logger.info(`projecting holobranch ${project.holobranch} within source ${this.name}`);
             const workspace = await repo.createWorkspaceFromRef(head);
             head = await Projection.projectBranch(workspace.getBranch(project.holobranch), {
                 debug: true,
                 lens: 'lens' in project ? project.lens : true,
                 parentCommit: head
             });
+            logger.info(`using projection result for holobranch ${project.holobranch} as source ${this.name}: ${head}`);
         }
 
         if (!head) {

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -366,7 +366,7 @@ class Source extends Configurable {
             await git.updateIndex({ add: true, cacheinfo: true }, `160000,${head},${subRepoPath}`);
 
             // add remote
-            await subGit.config(`remote.origin.url`, url ? url : gitDir);
+            await subGit.config(`remote.origin.url`, url || gitDir);
 
             // configure upstream
             if (branch) {
@@ -395,11 +395,11 @@ class Source extends Configurable {
         // configure submodule
         if (submodule) {
             await git.config(`submodule.${subRepoPath}.active`, 'true');
-            await git.config(`submodule.${subRepoPath}.url`, url); // TODO: relative filesystem path?
+            await git.config(`submodule.${subRepoPath}.url`, url || gitDir);
 
             const submoduleConfig = {
                 path: subRepoPath,
-                url,
+                url: url || gitDir,
                 shallow: 'true'
             };
 

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -143,7 +143,9 @@ class Source extends Configurable {
 
         // get value of gitlink if it exists
         const sourcePath = `.holo/sources/${this.name}`;
-        const [,,gitLinkHash] = (await git.lsTree(`${repo.ref}:.holo/sources`, this.name)).split(/\s/, 4);
+        const gitLink = await this.workspace.root.getChild(sourcePath);
+        const gitLinkHash = gitLink && gitLink.isCommit && gitLink.hash;
+
 
         // fall few a few different ways to determine the current commit hash to use
         let head;

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -177,7 +177,7 @@ class Source extends Configurable {
                     head = await git.commitTree(
                         {
                             p: stagedHash || gitLinkHash || null,
-                            m: `working snapshot of ${repo.workTree}`
+                            m: `working snapshot of ${repo.workTree}/.holo/sources/${this.name}`
                         },
                         workTreeHash
                     );

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -365,7 +365,7 @@ class Source extends Configurable {
         // initialize sub-repository
         let head;
         if (await fs.exists(`${subWorkTree}/.git`)) {
-            const subGit = await this.getSubGit();
+            const subGit = await this.getSubGit({ required: true });
             head = await subGit.revParse({ verify: true }, 'HEAD');
         } else {
             const { hash: specHash } = await this.getCachedSpec();
@@ -381,7 +381,7 @@ class Source extends Configurable {
             await fs.writeFile(`${subWorkTree}/.git`, `gitdir: ${path.relative(subWorkTree, subRepoGitDir)}\n`);
 
             // configure sub-repository
-            const subGit = await this.getSubGit();
+            const subGit = await this.getSubGit({ required: true });
             await subGit.config('core.bare', 'false');
             await subGit.config('core.worktree', path.relative(subRepoGitDir, subWorkTree));
 

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -369,7 +369,6 @@ class Source extends Configurable {
             await subGit.config(`remote.origin.url`, url ? url : gitDir);
 
             // configure upstream
-            debugger;
             if (branch) {
                 const remoteRef = `refs/remotes/origin/${branch}`;
                 await subGit.updateRef(remoteRef, head);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1189,9 +1189,9 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "git-client": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/git-client/-/git-client-1.3.0.tgz",
-      "integrity": "sha512-5/qoGIF7kGZwrUZ83qmXwrN3c1WShHBlG8DLGF1Vl7Kr+hJQxxguDWHl3TOnRoZI614BK4i8vfUHJyjyqqr1PA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/git-client/-/git-client-1.5.0.tgz",
+      "integrity": "sha512-pyvCMXoxGbU8GphWe95w2EYkufYWyyk/2HBH+8dLsCP63Ylb13lBqOl6pMcwnVTdq+JAiyM3/Xfwy2f6JZIwSg==",
       "requires": {
         "mz": "^2.7.0",
         "node-cleanup": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1180,7 +1180,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
@@ -1189,9 +1189,9 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "git-client": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/git-client/-/git-client-1.2.5.tgz",
-      "integrity": "sha512-U64v58FUfqFDmEtEt9v3OTWStuTyUPaZMlL+sig8urdSKlUNHjpgMgNc5L0sXd9ZDuVPtSkd3UbE9ix4c6aYtw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/git-client/-/git-client-1.3.0.tgz",
+      "integrity": "sha512-5/qoGIF7kGZwrUZ83qmXwrN3c1WShHBlG8DLGF1Vl7Kr+hJQxxguDWHl3TOnRoZI614BK4i8vfUHJyjyqqr1PA==",
       "requires": {
         "mz": "^2.7.0",
         "node-cleanup": "^2.1.2",
@@ -2485,7 +2485,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -2517,7 +2517,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -2547,7 +2547,7 @@
     },
     "yargs": {
       "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
       "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "requires": {
         "cliui": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "debounce": "^1.2.0",
     "dockerode": "^2.5.7",
     "fb-watchman": "^2.0.0",
-    "git-client": "^1.3.0",
+    "git-client": "^1.5.0",
     "hab-client": "^1.0.0",
     "handlebars": "^4.0.12",
     "minimatch": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hologit",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "Hologit automates the projection of layered composite file trees based on flat, declarative plans",
   "repository": "https://github.com/EmergencePlatform/hologit",
   "main": "bin/cli.js",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "debounce": "^1.2.0",
     "dockerode": "^2.5.7",
     "fb-watchman": "^2.0.0",
-    "git-client": "^1.2.5",
+    "git-client": "^1.3.0",
     "hab-client": "^1.0.0",
     "handlebars": "^4.0.12",
     "minimatch": "^3.0.4",


### PR DESCRIPTION
- feat: make submodule setup optional when checking out a source
- fix: remove invalid addition to yargs command template
- refactor: track source refs discretely and handle submodule fetching
- refactor: use new set routine to update shallow
- fix: ensure shallow fetch is tried before deep fetch
- refactor: use source spec to name .git/modules path
- feat: use working tree for sources
- fix: render source without url correctly in log
- feat: all source specs without url
- fix: skip hashing work tree if it doesn't exist
- fix: skip cloning source repo index if it doesn't exist
- feat: always return commit for source.getHead()
- refactor: reorganize getSubRepo method
- fix: use cat-file to test for commit
- feat: support checking out local sources and improve overall checkout…  …
- fix: remove errant debugger statement
- fix: use cwd+. for more consistent checkout behavior
- fix: use gitDir as url for local submodule config
- refactor: add repo methods for creating workspaces
- fix: correct path in working snapshot commit message
- refactor: access sibling class via index object
- feat: add initial support for sub-projection
- style: improve log output for sub-projection
- fix: avoid calling getHead when fetching and handle local sources
- fix: catch if subGit is unexpectedly unavailable
- fix: skip providing any path for checkout
- refactor: consolidate sourcePath
- fix: read gitlink from active workspace