### PR TITLE
Release: hologit v0.13.1

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,8 +5,10 @@
 **/.studiorc
 **/plan.sh
 **/test/
+**/*.test.js
 /studio/
 /docs/
+/lenses/
 .bldr.toml
 .eslintrc.json
 jsconfig.json

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -40,7 +40,7 @@ require('yargs')
 
         return true;
     })
-    .commandDir('../commands')
+    .commandDir('../commands', { exclude: /\.test\.js$/ })
     .demandCommand()
     .showHelpOnFail(false, 'Specify --help for available options')
     .fail((msg, err) => {

--- a/lib/Studio.js
+++ b/lib/Studio.js
@@ -231,10 +231,10 @@ class Studio {
         return this.habPkgExec('jarvus/hologit', 'git-holo', ...command);
     }
 
-    async getPackage (query) {
-        let packagePath = await this.habExec('pkg', 'path', query);
+    async getPackage (query, { install } = { install: false }) {
+        let packagePath = await this.habExec('pkg', 'path', query, { $nullOnError: true, $relayStderr: false });
 
-        if (!packagePath) {
+        if (!packagePath && install) {
             await this.habExec('pkg', 'install', query);
             packagePath = await this.habExec('pkg', 'path', query);
         }

--- a/lib/Studio.js
+++ b/lib/Studio.js
@@ -188,20 +188,27 @@ class Studio {
      * Run a command in the studio
      */
     async habExec (...command) {
+        const options = typeof command[command.length-1] == 'object'
+            ? command.pop()
+            : {};
+
         if (this.container.type == 'studio') {
             const hab = await Studio.getHab();
 
             const habProcess = await hab.exec(...command, {
                 $spawn: true,
-                $env: this.container.env
+                $env: this.container.env,
+                ...options
             });
 
-            habProcess.stderr.pipe(process.stderr);
+            if (options.$relayStderr !== false) {
+                habProcess.stderr.pipe(process.stderr);
+            }
 
             return habProcess.captureOutputTrimmed();
         }
 
-        return containerExec(this.container, 'hab', ...command);
+        return containerExec(this.container, 'hab', ...command, options);
     }
 
     async habPkgExec (pkg, bin, ...args) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hologit",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hologit",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Hologit automates the projection of layered composite file trees based on flat, declarative plans",
   "repository": "https://github.com/EmergencePlatform/hologit",
   "main": "bin/cli.js",


### PR DESCRIPTION
- chore: update .npmignore
- feat: add support for nullOnError and relayStderr options to studio.h…  …
- feat: make install optional for studio.getPackage
- fix: ignore .test.js files in commands directory