### PR TITLE
Release: hologit v0.18.1

### DIFF
--- a/lib/BlobObject.js
+++ b/lib/BlobObject.js
@@ -10,7 +10,7 @@ class BlobObject {
         });
     }
 
-    constructor (repo, { hash, mode }) {
+    constructor (repo, { hash, mode=null }) {
         this.repo = repo;
         this.hash = hash;
 

--- a/lib/TreeObject.js
+++ b/lib/TreeObject.js
@@ -213,6 +213,8 @@ class TreeObject {
 
         tree._children[childName] = content;
         tree.markDirty();
+
+        return content;
     }
 
     async getChildren () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -468,9 +468,9 @@
       }
     },
     "@types/jest": {
-      "version": "24.0.15",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.15.tgz",
-      "integrity": "sha512-MU1HIvWUme74stAoc3mgAi+aMlgKOudgEvQDIm1v4RkrDudBh1T+NFp5sftpBAdXdx1J0PbdpJ+M2EsSOi1djA==",
+      "version": "24.0.16",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.16.tgz",
+      "integrity": "sha512-JrAiyV+PPGKZzw6uxbI761cHZ0G7QMOHXPhtSpcl08rZH6CswXaaejckn3goFKmF7M3nzEoJ0lwYCbqLMmjziQ==",
       "dev": true,
       "requires": {
         "@types/jest-diff": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hologit",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2252,7 +2252,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
@@ -2270,13 +2270,20 @@
       }
     },
     "git-client": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/git-client/-/git-client-1.6.1.tgz",
-      "integrity": "sha512-qvWfx7d8A8BviQcA3xsTG3Jglan6CbyPm/r83YtDTXufST3M3En6fP0Gy2Jj98JniBMhB77PJfbW0kFmhmSi7g==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/git-client/-/git-client-1.6.2.tgz",
+      "integrity": "sha512-MuXOyotMC7nHa/7jHVqvTp8S48MR1QRSi6TnmboMi9zhbPLq659FpAYYhEQZy5MwoQtEdivPRrzq9gCRm+8Keg==",
       "requires": {
         "mz": "^2.7.0",
         "node-cleanup": "^2.1.2",
-        "semver": "^5.5.0"
+        "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "glob": {
@@ -6234,7 +6241,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -6266,7 +6273,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -6322,7 +6329,7 @@
     },
     "yargs": {
       "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
       "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "requires": {
         "cliui": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hologit",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Hologit automates the projection of layered composite file trees based on flat, declarative plans",
   "repository": "https://github.com/EmergencePlatform/hologit",
   "main": "bin/cli.js",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "projection"
   ],
   "devDependencies": {
-    "@types/jest": "^24.0.15",
+    "@types/jest": "^24.0.16",
     "jest": "^24.8.0"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "debounce": "^1.2.0",
     "dockerode": "^2.5.8",
     "fb-watchman": "^2.0.0",
-    "git-client": "^1.6.1",
+    "git-client": "^1.6.2",
     "hab-client": "^1.0.3",
     "handlebars": "^4.1.2",
     "minimatch": "^3.0.4",


### PR DESCRIPTION
- feat: return BlobObject from TreeObject.writeChild
- fix: indicate mode param as optional
- fix: bump git-client to v1.6.2 to resolve failing capture of parallel output
- chore: npm update