### PR TITLE
feat: support listing sources to fetch via param and/or env

### DIFF
--- a/commands/project.js
+++ b/commands/project.js
@@ -25,9 +25,8 @@ exports.builder = {
         default: null
     },
     'fetch': {
-        describe: 'Whether to fetch the latest commit for all sources while projecting',
-        type: 'boolean',
-        default: false
+        describe: 'List of sources to fetch while projecting or * to fetch all',
+        type: 'string'
     },
     'watch': {
         describe: 'Set to continously output updated output',
@@ -42,7 +41,7 @@ exports.handler = async function project ({
     lens = null,
     working = false,
     debug = false,
-    fetch = false,
+    fetch = null,
     watch = false,
     commitTo = null,
     commitMessage = null
@@ -54,6 +53,27 @@ exports.handler = async function project ({
     // check inputs
     if (!holobranch) {
         throw new Error('holobranch required');
+    }
+
+
+    // parse fetch list from options and env
+    const fetchSplitRe = /[\s,:]+/;
+
+    if (fetch || fetch === '') {
+        if (fetch == '*' || !fetch) {
+            fetch = true;
+        } else if (!Array.isArray(fetch)) {
+            fetch = fetch.split(fetchSplitRe);
+        }
+    }
+
+    const fetchEnv = process.env.HOLO_FETCH;
+    if (fetchEnv) {
+        if (fetchEnv == '*' || fetch === true) {
+            fetch = true;
+        } else {
+            (fetch || (fetch = [])).push(...fetchEnv.split(fetchSplitRe));
+        }
     }
 
 

--- a/lib/Branch.js
+++ b/lib/Branch.js
@@ -147,7 +147,7 @@ class Branch extends Configurable {
                         for (const otherLayer in mappingsByLayer) {
                             if (otherLayer != layer && after.indexOf(otherLayer) == -1) {
                                 after.push(otherLayer);
-                    }
+                            }
                         }
                         continue;
                     }
@@ -215,7 +215,10 @@ class Branch extends Configurable {
             // load source
             const source = await this.workspace.getSource(holosource);
 
-            if (fetch) {
+            if (
+                fetch === true
+                || (Array.isArray(fetch) && fetch.indexOf(source.name) >= 0)
+            ) {
                 const originalHash = await source.getHead();
                 await source.fetch();
                 const hash = await source.getHead();
@@ -234,6 +237,7 @@ class Branch extends Configurable {
 
             // merge source into target
             const targetTree = await outputTree.getSubtree(output, true);
+            // TODO: investigate why this crashes when a submodule commit is present at the target tree path
             await targetTree.merge(sourceTree, {
                 files: files
             });


### PR DESCRIPTION
Currently, you can pass `--fetch` to the `git holo project` command to request that every source (including sub-projection sources) be fetched before merge

This feature changes that param to a string:

- adds the ability to set a `:` delimited list of named sources to fetch (whitespace and comma delimiters work too)
- adds the ability to set the environment variable `HOLO_FETCH` to `*` or a `:`-delimited list of named sources
- if either `--fetch` or `HOLO_FETCH` is set to `*`,  then all sources are fetched
- if `--fetch` and `HOLO_FETCH` both contain lists of sources, the lists are combined
- the legacy `--fetch` but making it equivalent to `--fetch=*`