### PR TITLE
Release: hologit v0.23.0

### DIFF
--- a/commands/lens/exec.js
+++ b/commands/lens/exec.js
@@ -84,6 +84,7 @@ exports.handler = async function exportTree ({
     logger.info(`executing lens command: ${command}`);
     const lensProcess = await hab.pkg('exec', spec.package, ...shellParse(command), {
         $env: env,
+        $cwd: scratchPath,
         $spawn: true
     });
 

--- a/lib/Lens.js
+++ b/lib/Lens.js
@@ -174,7 +174,7 @@ class Lens extends Configurable {
     async execute (specHash) {
         const studio = await Studio.get(this.workspace.getRepo().gitDir);
 
-        return studio.holoExec('lens', 'exec', specHash);
+        return studio.holoLensExec(specHash);
     }
 
 }

--- a/lib/Studio.js
+++ b/lib/Studio.js
@@ -197,6 +197,10 @@ class Studio {
         Object.freeze(this);
     }
 
+    isLocal () {
+        return this.container.type == 'studio';
+    }
+
     /**
      * Run a command in the studio
      */
@@ -205,7 +209,7 @@ class Studio {
             ? command.pop()
             : {};
 
-        if (this.container.type == 'studio') {
+        if (this.isLocal()) {
             const hab = await Studio.getHab();
 
             const habProcess = await hab.exec(...command, {

--- a/lib/Studio.js
+++ b/lib/Studio.js
@@ -252,6 +252,14 @@ class Studio {
         return this.habPkgExec('jarvus/hologit', 'git-holo', ...command);
     }
 
+    async holoLensExec(spec) {
+        if (this.isLocal()) {
+            return require('../commands/lens/exec.js').handler({ spec });
+        }
+
+        return this.holoExec('lens', 'exec', spec);
+    }
+
     async getPackage (query, { install } = { install: false }) {
         let packagePath = await this.habExec('pkg', 'path', query, { $nullOnError: true, $relayStderr: false });
 

--- a/lib/TreeObject.js
+++ b/lib/TreeObject.js
@@ -39,6 +39,10 @@ class MergeOptions {
 
 class TreeObject {
 
+    static getEmptyTreeHash () {
+        return EMPTY_TREE_HASH;
+    }
+
     static async createFromRef (repo, ref) {
         const git = await repo.getGit();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2336,11 +2336,11 @@
       "dev": true
     },
     "hab-client": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hab-client/-/hab-client-1.0.3.tgz",
-      "integrity": "sha512-+CK0XNZEoVvghC6S8WygfbgmzqHpWBxcipx1B92ssfNw7DCoyXGzc/E+ISNELHXrhSaXF4Rs0fOap3dUIta5Jw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hab-client/-/hab-client-1.1.0.tgz",
+      "integrity": "sha512-Owokx2lvK0tlejcRkjt9TY5a3IYBJ0E68IftIwlCVBEIWOoiD2C9bXx1R000G6ahxu3GEmV++65ZbyGkSIm+Ag==",
       "requires": {
-        "axios": "^0.18.0",
+        "axios": "^0.18.1",
         "semver": "^5.6.0",
         "underscore": "^1.9.1"
       },
@@ -2355,9 +2355,9 @@
           }
         },
         "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hologit",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dockerode": "^2.5.8",
     "fb-watchman": "^2.0.0",
     "git-client": "^1.6.2",
-    "hab-client": "^1.0.3",
+    "hab-client": "^1.1.0",
     "handlebars": "^4.3.1",
     "minimatch": "^3.0.4",
     "mz": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hologit",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "description": "Hologit automates the projection of layered composite file trees based on flat, declarative plans",
   "repository": "https://github.com/EmergencePlatform/hologit",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.22.1",
   "description": "Hologit automates the projection of layered composite file trees based on flat, declarative plans",
   "repository": "https://github.com/EmergencePlatform/hologit",
-  "main": "bin/cli.js",
+  "main": "lib/index.js",
   "preferGlobal": true,
   "author": "Chris Alfano <chris@jarv.us>",
   "license": "MIT",


### PR DESCRIPTION
- feat: add TreeObject.getEmptyTreeHash()
- feat: add studio.isLocal() method
- feat: execute lens in-process if in local studio
- execute lenses against their own cache directory
- fix: change npm "main" to library index.js
- fix: bump hab-client to 1.1.0