### PR TITLE
Release: hologit v0.28.0

### DIFF
--- a/commands/lens/exec.js
+++ b/commands/lens/exec.js
@@ -1,26 +1,10 @@
 exports.command = 'exec <spec-hash>';
 exports.desc = 'Execute lens spec and output result hash';
-exports.builder = {
-    refresh: {
-        describe: 'True to execute lens even if existing result is available',
-        type: 'boolean',
-        default: false
-    },
-    save: {
-        describe: 'False to disable updating spec ref with result',
-        type: 'boolean',
-        default: true
-    }
-};
 
-exports.handler = async function exportTree ({
-    specHash,
-    refresh=false,
-    save=true
-}) {
+exports.handler = async function exportTree ({ specHash }) {
     const Lens = require('../../lib/Lens.js');
 
-    const lensedTreeHash = await Lens.executeSpec(specHash, { refresh, save });
+    const lensedTreeHash = await Lens.executeSpec(specHash, { refresh: true });
 
     if (lensedTreeHash) {
         console.log(lensedTreeHash);

--- a/lib/Branch.js
+++ b/lib/Branch.js
@@ -200,7 +200,9 @@ class Branch extends Configurable {
 
     async composite ({
         outputTree = this.getRepo().createTree(),
-        fetch = false
+        fetch = false,
+        cacheFrom = null,
+        cacheTo = null
     }) {
         const repo = this.getRepo();
         const mappings = await this.getMappings();
@@ -232,7 +234,7 @@ class Branch extends Configurable {
             }
 
             // load tree
-            const sourceTreeHash = await source.getOutputTree({ fetch });
+            const sourceTreeHash = await source.getOutputTree({ fetch, cacheFrom, cacheTo });
             const sourceTree = await repo.createTreeFromRef(`${sourceTreeHash}:${root == '.' ? '' : root}`);
 
             // merge source into target

--- a/lib/Lens.js
+++ b/lib/Lens.js
@@ -205,21 +205,22 @@ class Lens extends Configurable {
         const git = await repo.getGit();
 
 
+        // check for existing build
+        const specRef = SpecObject.buildRef('lens', specHash);
+        if (!refresh) {
+            const existingBuildHash = await git.getTreeHash(specRef, { verify: false });
+
+            if (existingBuildHash) {
+                logger.info(`found existing output tree matching holospec(${specHash})`);
+                return existingBuildHash;
+            }
+        }
+
+
         // ensure the rest runs inside a studio environment
         if (!await Studio.isEnvironmentStudio()) {
             const studio = await Studio.get(repo.gitDir);
             return studio.holoLensExec(specHash);
-        }
-
-
-        // check for existing build
-        const specRef = SpecObject.buildRef('lens', specHash);
-        if (!refresh) {
-            const existingBuildHash = await repo.resolveRef(specRef);
-
-            if (existingBuildHash) {
-                return existingBuildHash;
-            }
         }
 
 

--- a/lib/Lens.js
+++ b/lib/Lens.js
@@ -215,15 +215,10 @@ class Lens extends Configurable {
             }
 
             if (cacheFrom) {
-                try {
-                    await git.fetch(cacheFrom, `${specRef}:${specRef}`);
-                    existingBuildHash = await git.getTreeHash(specRef, { verify: false });
-                    if (existingBuildHash) {
-                        logger.info(`fetched cached result from ${cacheTo}: ${specRef}`);
-                        return existingBuildHash;
-                    }
-                } catch (err) {
-                    // continue with execution
+                existingBuildHash = await _cacheResultFrom(repo, specRef, cacheFrom);
+
+                if (existingBuildHash) {
+                    return existingBuildHash;
                 }
             }
         }
@@ -322,9 +317,32 @@ module.exports = Lens;
 
 
 // private methods
+function _getTrackingRef(specRef, remote) {
+    return `refs/holo/lens-remotes/${remote}/${specRef.substr(15)}`;
+}
+
+async function _cacheResultFrom(repo, specRef, cacheFrom) {
+    const git = await repo.getGit();
+
+    try {
+        await git.fetch(cacheFrom, `${specRef}:${specRef}`);
+
+        const existingBuildHash = await git.getTreeHash(specRef, { verify: false });
+
+        if (existingBuildHash) {
+            logger.info(`fetched cached result from ${cacheFrom}: ${specRef}`);
+            await git.updateRef(_getTrackingRef(specRef, cacheFrom), existingBuildHash);
+            return existingBuildHash;
+        }
+    } catch (err) {
+        return null;
+    }
+}
+
+
 async function _cacheResultTo(repo, specRef, cacheTo) {
     const git = await repo.getGit();
-    const trackingSpecRef = `refs/holo/lens-remotes/${cacheTo}/${specRef.substr(15)}`;
+    const trackingSpecRef = _getTrackingRef(specRef, cacheTo);
 
     if (!await repo.resolveRef(trackingSpecRef)) {
         logger.info(`pushing cached result to ${cacheTo}: ${specRef}`);

--- a/lib/Lens.js
+++ b/lib/Lens.js
@@ -189,13 +189,7 @@ class Lens extends Configurable {
         return Lens.executeSpec(specHash, {...options, repo: this.workspace.getRepo()});
     }
 
-    static async executeSpec (specHash, { refresh=false, save=true, repo=null }) {
-
-        // return studio.holoLensExec(specHash);
-
-        // TODO: run in studio if not in one?
-        // TODO: delegate some of this to Studio
-
+    static async executeSpec (specHash, { refresh=false, save=true, repo=null, cacheFrom=null, cacheTo=null }) {
 
         // load holorepo
         if (!repo) {
@@ -208,90 +202,115 @@ class Lens extends Configurable {
         // check for existing build
         const specRef = SpecObject.buildRef('lens', specHash);
         if (!refresh) {
-            const existingBuildHash = await git.getTreeHash(specRef, { verify: false });
+            let existingBuildHash = await git.getTreeHash(specRef, { verify: false });
 
             if (existingBuildHash) {
                 logger.info(`found existing output tree matching holospec(${specHash})`);
+
+                if (cacheTo) {
+                    logger.info(`pushing cached result to ${cacheTo}: ${specRef}`);
+                    await git.push(cacheTo, specRef);
+                }
+
                 return existingBuildHash;
+            }
+
+            if (cacheFrom) {
+                try {
+                    await git.fetch(cacheFrom, `${specRef}:${specRef}`);
+                    existingBuildHash = await git.getTreeHash(specRef, { verify: false });
+                    if (existingBuildHash) {
+                        logger.info(`fetched cached result from ${cacheTo}: ${specRef}`);
+                        return existingBuildHash;
+                    }
+                } catch (err) {
+                    // continue with execution
+                }
             }
         }
 
 
         // ensure the rest runs inside a studio environment
+        let lensedTreeHash;
+
         if (!await Studio.isEnvironmentStudio()) {
             const studio = await Studio.get(repo.gitDir);
-            return studio.holoLensExec(specHash);
-        }
-
-
-        // load spec
-        const specToml = await git.catFile({ p: true }, specHash);
-        const {
-            holospec: {
-                lens: spec
-            }
-        } = TOML.parse(specToml);
-
-
-        // assign scratch directory
-        const scratchPath = `${process.env.HOLO_SCRATCH||'/hab/cache/hololens'}/${spec.package.split('/').slice(0, 2).join('/')}`;
-        await mkdirp(scratchPath);
-
-
-        // install lens package
-        const hab = await Studio.getHab();
-        logger.info(`installing lens package: ${spec.package}`);
-        await hab.pkg('install', spec.package);
-
-
-        // prepare command and environment
-        const command = handlebars.compile(spec.command)(spec);
-        const env = Object.assign(
-            squish(
-                {
-                    hololens: { ...spec, spec: specHash }
-                },
-                {
-                    seperator: '_',
-                    modifyKey: key => key.toUpperCase().replace(/-/g, '_')
+            lensedTreeHash = await studio.holoLensExec(specHash);
+        } else {
+            // load spec
+            const specToml = await git.catFile({ p: true }, specHash);
+            const {
+                holospec: {
+                    lens: spec
                 }
-            ),
-            {
-                GIT_DIR: repo.gitDir,
-                GIT_WORK_TREE: scratchPath,
-                GIT_INDEX_FILE: `${scratchPath}.index`,
-                DEBUG: process.env.DEBUG || ''
+            } = TOML.parse(specToml);
+
+
+            // assign scratch directory
+            const scratchPath = `${process.env.HOLO_SCRATCH||'/hab/cache/hololens'}/${spec.package.split('/').slice(0, 2).join('/')}`;
+            await mkdirp(scratchPath);
+
+
+            // install lens package
+            const hab = await Studio.getHab();
+            logger.info(`installing lens package: ${spec.package}`);
+            await hab.pkg('install', spec.package);
+
+
+            // prepare command and environment
+            const command = handlebars.compile(spec.command)(spec);
+            const env = Object.assign(
+                squish(
+                    {
+                        hololens: { ...spec, spec: specHash }
+                    },
+                    {
+                        seperator: '_',
+                        modifyKey: key => key.toUpperCase().replace(/-/g, '_')
+                    }
+                ),
+                {
+                    GIT_DIR: repo.gitDir,
+                    GIT_WORK_TREE: scratchPath,
+                    GIT_INDEX_FILE: `${scratchPath}.index`,
+                    DEBUG: process.env.DEBUG || ''
+                }
+            );
+            logger.debug('lens environment:', env);
+
+
+            // spawn process and log STDERR
+            logger.info(`executing lens command: ${command}`);
+            const lensProcess = await hab.pkg('exec', spec.package, ...shellParse(command), {
+                $env: env,
+                $cwd: scratchPath,
+                $spawn: true
+            });
+
+            lensProcess.stderr.on('data', data => {
+                data.toString().trim().split(/\n/).forEach(
+                    line => logger.info(`lens: ${line}`)
+                )
+            });
+
+
+            // process output
+            lensedTreeHash = await lensProcess.captureOutputTrimmed();
+
+            if (!git.isHash(lensedTreeHash)) {
+                throw new Error(`lens "${command}" did not return hash: ${lensedTreeHash}`);
             }
-        );
-        logger.debug('lens environment:', env);
-
-
-        // spawn process and log STDERR
-        logger.info(`executing lens command: ${command}`);
-        const lensProcess = await hab.pkg('exec', spec.package, ...shellParse(command), {
-            $env: env,
-            $cwd: scratchPath,
-            $spawn: true
-        });
-
-        lensProcess.stderr.on('data', data => {
-            data.toString().trim().split(/\n/).forEach(
-                line => logger.info(`lens: ${line}`)
-            )
-        });
-
-
-        // process output
-        const lensedTreeHash = await lensProcess.captureOutputTrimmed();
-
-        if (!git.isHash(lensedTreeHash)) {
-            throw new Error(`lens "${command}" did not return hash: ${lensedTreeHash}`);
         }
 
 
         // save ref to accelerate next projection
         if (save) {
             await git.updateRef(specRef, lensedTreeHash);
+
+            if (cacheTo) {
+                logger.info(`pushing cached result to ${cacheTo}: ${specRef}`);
+                await git.push(cacheTo, specRef);
+            }
         }
 
 

--- a/lib/Lens.js
+++ b/lib/Lens.js
@@ -208,8 +208,7 @@ class Lens extends Configurable {
                 logger.info(`found existing output tree matching holospec(${specHash})`);
 
                 if (cacheTo) {
-                    logger.info(`pushing cached result to ${cacheTo}: ${specRef}`);
-                    await git.push(cacheTo, specRef);
+                    await _cacheResultTo(repo, specRef, cacheTo);
                 }
 
                 return existingBuildHash;
@@ -308,8 +307,7 @@ class Lens extends Configurable {
             await git.updateRef(specRef, lensedTreeHash);
 
             if (cacheTo) {
-                logger.info(`pushing cached result to ${cacheTo}: ${specRef}`);
-                await git.push(cacheTo, specRef);
+                await _cacheResultTo(repo, specRef, cacheTo);
             }
         }
 
@@ -321,3 +319,16 @@ class Lens extends Configurable {
 }
 
 module.exports = Lens;
+
+
+// private methods
+async function _cacheResultTo(repo, specRef, cacheTo) {
+    const git = await repo.getGit();
+    const trackingSpecRef = `refs/holo/lens-remotes/${cacheTo}/${specRef.substr(15)}`;
+
+    if (!await repo.resolveRef(trackingSpecRef)) {
+        logger.info(`pushing cached result to ${cacheTo}: ${specRef}`);
+        await git.push(cacheTo, specRef);
+        await git.updateRef(trackingSpecRef, specRef);
+    }
+}

--- a/lib/Projection.js
+++ b/lib/Projection.js
@@ -160,7 +160,7 @@ class Projection {
 
             // build tree of matching files to input to lens
             logger.info(`building input tree for lens ${lens.name} from ${inputRoot == '.' ? '' : (path.join(inputRoot, '.')+'/')}{${inputFiles}}`);
-            const { hash: specHash, ref: specRef } = await lens.buildSpec(await lens.buildInputTree(this.output.root));
+            const { hash: specHash } = await lens.buildSpec(await lens.buildInputTree(this.output.root));
 
 
             // check for existing output tree

--- a/lib/Projection.js
+++ b/lib/Projection.js
@@ -164,15 +164,7 @@ class Projection {
 
 
             // check for existing output tree
-            let outputTreeHash = await git.getTreeHash(specRef, { verify: false });
-
-
-            // apply lens if existing tree not found
-            if (outputTreeHash) {
-                logger.info(`found existing output tree matching holospec(${specHash})`);
-            } else {
-                outputTreeHash = await lens.executeSpec(specHash);
-            }
+            const outputTreeHash = await lens.executeSpec(specHash);
 
 
             // verify output

--- a/lib/Projection.js
+++ b/lib/Projection.js
@@ -14,7 +14,9 @@ class Projection {
             commitTo = null,
             commitMessage = null,
             parentCommit = null,
-            fetch = false
+            fetch = false,
+            cacheFrom = null,
+            cacheTo = null
         } = {}
     ) {
         // instantiate projection
@@ -22,7 +24,7 @@ class Projection {
 
 
         // apply composition
-        await projection.composite({ fetch });
+        await projection.composite({ fetch, cacheFrom, cacheTo });
 
 
         // apply lensing
@@ -41,7 +43,7 @@ class Projection {
                 logger.info('output tree before lensing:', await projection.output.root.write());
             }
 
-            await projection.lens();
+            await projection.lens({ cacheFrom, cacheTo });
         }
 
 
@@ -99,7 +101,7 @@ class Projection {
         Object.freeze(this);
     }
 
-    async composite ({ fetch = false }) {
+    async composite ({ fetch = false, cacheFrom = null, cacheTo = null }) {
         const branchStack = [];
 
         // merge extended holobranch onto output first
@@ -122,7 +124,7 @@ class Projection {
 
 
         // merge projected holobranch onto output
-        await this.branch.composite({ outputTree: this.output.root, fetch });
+        await this.branch.composite({ outputTree: this.output.root, fetch, cacheFrom, cacheTo });
 
 
         // strip .holo/{branches,sources} from output
@@ -134,7 +136,7 @@ class Projection {
         }
     }
 
-    async lens () {
+    async lens ({ cacheFrom = null, cacheTo = null }) {
         const repo = this.branch.getRepo();
         const git = await repo.getGit();
 
@@ -164,7 +166,7 @@ class Projection {
 
 
             // check for existing output tree
-            const outputTreeHash = await lens.executeSpec(specHash);
+            const outputTreeHash = await lens.executeSpec(specHash, { cacheFrom, cacheTo });
 
 
             // verify output

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -168,7 +168,7 @@ class Source extends Configurable {
         return treeHash;
     }
 
-    async getOutputTree ({ working = null, fetch = false } = {}) {
+    async getOutputTree ({ working = null, fetch = false, cacheFrom = null, cacheTo = null } = {}) {
         const repo = this.getRepo();
         const git = await repo.getGit();
         const { project } = await this.getCachedConfig();
@@ -197,7 +197,9 @@ class Source extends Configurable {
             head = await Projection.projectBranch(branch, {
                 debug: true,
                 lens,
-                fetch
+                fetch,
+                cacheFrom,
+                cacheTo
             });
 
             logger.info(`using projection result for holobranch ${project.holobranch} as source ${this.name}: ${head}`);


### PR DESCRIPTION
- feat: add cache-from and cache-to options for remote lens output caching
- feat: track remote caches to reduce pushes
- feat: track fetched remote caches immediately to further reduce pushes
- refactor: handle cache matching within lens
- refactor: purify lens-exec command to take no options, always exec
- chore: delete unused variable