### PR TITLE
Studio.js: replace docker client with CLI communication

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,12 +4,6 @@ declare module 'git-client' {
     }
 }
 
-declare module 'dockerode' {
-    export class Docker {
-        constructor(options: { socketPath: string });
-    }
-}
-
 declare module 'hologit' {
     import { Git as GitClient } from 'git-client';
     import { Docker } from 'dockerode';

--- a/lib/Studio.js
+++ b/lib/Studio.js
@@ -1,16 +1,44 @@
+const { spawn } = require('child_process');
 const stream = require('stream');
-const Docker = require('dockerode');
 const os = require('os');
 const exitHook = require('async-exit-hook');
 const fs = require('mz/fs');
 
-
 const logger = require('./logger');
 
-
 const studioCache = new Map();
-let hab, docker;
+let hab;
 
+/**
+ * Helper function to execute a Docker CLI command.
+ * @param {Array<string>} args - The arguments to pass to the docker command.
+ * @param {Object} options - Options for child_process.spawn.
+ * @returns {Promise<string>} - Resolves with stdout data.
+ */
+function execDocker(args, options = {}) {
+    return new Promise((resolve, reject) => {
+        const dockerProcess = spawn('docker', args, { stdio: 'pipe', ...options });
+
+        let stdout = '';
+        let stderr = '';
+
+        dockerProcess.stdout.on('data', (data) => {
+            stdout += data.toString();
+        });
+
+        dockerProcess.stderr.on('data', (data) => {
+            stderr += data.toString();
+        });
+
+        dockerProcess.on('close', (code) => {
+            if (code === 0) {
+                resolve(stdout.trim());
+            } else {
+                reject(new Error(stderr.trim()));
+            }
+        });
+    });
+}
 
 /**
  * A studio session that can be used to run multiple commands, using chroot if available or docker container
@@ -23,11 +51,15 @@ class Studio {
         for (const [gitDir, studio] of studioCache) {
             const { container } = studio;
 
-            if (container && container.type != 'studio') {
+            if (container && container.type !== 'studio') {
                 logger.info(`terminating studio container: ${container.id}`);
-                await container.stop();
-                await container.remove();
-                cleanupCount++;
+                try {
+                    await execDocker(['stop', container.id]);
+                    await execDocker(['rm', container.id]);
+                    cleanupCount++;
+                } catch (err) {
+                    logger.error(`Failed to stop/remove container ${container.id}: ${err.message}`);
+                }
             }
 
             studioCache.delete(gitDir);
@@ -44,19 +76,6 @@ class Studio {
         }
 
         return hab;
-    }
-
-    static async getDocker () {
-        if (!docker) {
-            const { DOCKER_HOST: dockerHost } = process.env;
-            const dockerHostMatch = dockerHost && dockerHost.match(/^unix:\/\/(\/.*)$/);
-            const socketPath = dockerHostMatch ? dockerHostMatch[1] : '/var/run/docker.sock';
-
-            docker = new Docker({ socketPath });
-            logger.info(`connected to docker on: ${socketPath}`);
-        }
-
-        return docker;
     }
 
     static async isEnvironmentStudio () {
@@ -91,39 +110,9 @@ class Studio {
         }
 
 
-        // connect with Docker API
-        const docker = await Studio.getDocker();
-
-
         // pull latest studio container
         try {
-            await new Promise((resolve, reject) => {
-                docker.pull('jarvus/hologit-studio:latest', (streamErr, stream) => {
-                    if (streamErr) {
-                        reject(streamErr);
-                        return;
-                    }
-
-                    let lastStatus;
-
-                    docker.modem.followProgress(
-                        stream,
-                        (err, output) => {
-                            if (err) {
-                                reject(err);
-                            } else {
-                                resolve(output);
-                            }
-                        },
-                        event => {
-                            if (event.status != lastStatus) {
-                                logger.info(`docker pull: ${event.status}`);
-                                lastStatus = event.status;
-                            }
-                        }
-                    );
-                });
-            });
+            await execDocker(['pull', 'jarvus/hologit-studio:latest']);
         } catch (err) {
             logger.error(`failed to pull studio image via docker: ${err.message}`);
         }
@@ -157,65 +146,69 @@ class Studio {
         }
 
 
-        // start studio container
-        let container;
+        // create studio container
+        let containerId;
+        let defaultUser;
         try {
-            container = await docker.createContainer({
-                Image: 'jarvus/hologit-studio',
-                Labels: {
-                    'sh.holo.studio': 'yes'
-                },
-                AttachStdin: false,
-                AttachStdout: true,
-                AttachStderr: true,
-                Env: [
-                    'STUDIO_TYPE=holo',
-                    'GIT_DIR=/git',
-                    'GIT_WORK_TREE=/hab/cache',
-                    `DEBUG=${process.env.DEBUG||''}`,
-                    `HAB_LICENSE=accept-no-persist`
-                ],
-                WorkingDir: '/git',
-                Volumes: volumesConfig,
-                HostConfig: {
-                    Binds: bindsConfig,
-                    // ExposedPorts: {
-                    //     "9229/tcp": { }
-                    // },
-                    // PortBindings: {
-                    //     '9229/tcp': [
-                    //         {
-                    //             HostIp: '0.0.0.0',
-                    //             HostPort: '9229'
-                    //         }
-                    //     ]
-                    // }
-                }
-            });
+            // Prepare environment variables
+            const envArgs = [
+                '--env', 'STUDIO_TYPE=holo',
+                '--env', 'GIT_DIR=/git',
+                '--env', 'GIT_WORK_TREE=/hab/cache',
+                '--env', `DEBUG=${process.env.DEBUG || ''}`,
+                '--env', 'HAB_LICENSE=accept-no-persist'
+            ];
+
+            // Prepare volume bindings
+            const volumeArgs = [];
+            for (const bind of bindsConfig) {
+                volumeArgs.push('-v', bind);
+            }
+
+            // Create container
+            const createArgs = [
+                'create',
+                '--label', 'sh.holo.studio=yes',
+                '--workdir', '/git',
+                ...envArgs,
+                ...volumeArgs,
+                'jarvus/hologit-studio:latest'
+            ];
+
+            containerId = await execDocker(createArgs);
+            containerId = containerId.split('\n').pop().trim(); // Get the container ID from output
 
             logger.info('starting studio container');
-            await container.start();
+            await execDocker(['start', containerId]);
 
             const { uid, gid, username } = os.userInfo();
 
             if (uid && gid && username) {
                 logger.info(`configuring container to use user: ${username}`);
-                await containerExec(container, 'adduser', '-u', `${uid}`, '-G', 'developer', '-D', username);
-                await containerExec(container, 'mkdir', '-p', `/home/${username}/.hab`);
-                await containerExec(container, 'ln', '-sf', '/hab/cache', `/home/${username}/.hab/`);
-                container.defaultUser = `${uid}`;
+                await containerExec({ id: containerId }, 'adduser', '-u', `${uid}`, '-G', 'developer', '-D', username);
+                await containerExec({ id: containerId }, 'mkdir', '-p', `/home/${username}/.hab`);
+                await containerExec({ id: containerId }, 'ln', '-sf', '/hab/cache', `/home/${username}/.hab/`);
+                defaultUser = `${uid}`;
             }
 
-            const studio = new Studio({ gitDir, container });
+            const studio = new Studio({ gitDir, container: { id: containerId, defaultUser } });
             studioCache.set(gitDir, studio);
             return studio;
 
         } catch (err) {
-            logger.error('container failed: %o', err);
+            logger.error(`container failed: ${err.message}`);
 
-            if (container) {
-                await container.stop();
-                await container.remove();
+            if (containerId) {
+                try {
+                    await execDocker(['stop', containerId]);
+                } catch (stopErr) {
+                    logger.error(`Failed to stop container ${containerId}: ${stopErr.message}`);
+                }
+                try {
+                    await execDocker(['rm', containerId]);
+                } catch (rmErr) {
+                    logger.error(`Failed to remove container ${containerId}: ${rmErr.message}`);
+                }
             }
         }
     }
@@ -227,14 +220,14 @@ class Studio {
     }
 
     isLocal () {
-        return this.container.type == 'studio';
+        return this.container.type === 'studio';
     }
 
     /**
      * Run a command in the studio
      */
     async habExec (...command) {
-        const options = typeof command[command.length-1] == 'object'
+        const options = typeof command[command.length-1] === 'object'
             ? command.pop()
             : {};
 
@@ -274,7 +267,7 @@ class Studio {
         //         $env: { PATH }
         //     }
         // );
-        if (logger.level == 'debug') {
+        if (logger.level === 'debug') {
             command.unshift('--debug');
         }
 
@@ -286,55 +279,66 @@ class Studio {
     }
 
     async getPackage (query, { install } = { install: false }) {
-        let packagePath = await this.habExec('pkg', 'path', query, { $nullOnError: true, $relayStderr: false });
+        let packagePath;
+        try {
+            packagePath = await this.habExec('pkg', 'path', query, { $nullOnError: true, $relayStderr: false });
+        } catch (err) {
+            packagePath = null;
+        }
 
         if (!packagePath && install) {
             await this.habExec('pkg', 'install', query);
-            packagePath = await this.habExec('pkg', 'path', query);
+            try {
+                packagePath = await this.habExec('pkg', 'path', query);
+            } catch (err) {
+                packagePath = null;
+            }
         }
 
         return packagePath ? packagePath.substr(10) : null;
     }
 }
 
-
 exitHook(callback => Studio.cleanup().then(callback));
 
-
+/**
+ * Executes a command inside the specified Docker container.
+ * @param {Object} container - The container object containing at least the `id` and optionally `defaultUser`.
+ * @param  {...string} command - The command and its arguments to execute.
+ * @returns {Promise<string>} - Resolves with the command's stdout output.
+ */
 async function containerExec (container, ...command) {
-    const options = typeof command[command.length-1] == 'object'
+    const options = typeof command[command.length-1] === 'object'
         ? command.pop()
         : {};
 
     logger.info(`studio-exec: ${command.join(' ')}`);
 
-    const env = [];
+    const execArgs = ['exec'];
+
+    if (options.$user) {
+        execArgs.push('--user', options.$user);
+    } else if (container.defaultUser) {
+        execArgs.push('--user', container.defaultUser);
+    }
+
     if (options.$env) {
-        for (const key of Object.keys(options.$env)) {
-            env.push(`${key}=${options.$env[key]}`);
+        for (const [key, value] of Object.entries(options.$env)) {
+            execArgs.push('--env', `${key}=${value}`);
         }
     }
 
-    const exec = await container.exec({
-        Cmd: command,
-        AttachStdout: true,
-        AttachStderr: options.$relayStderr !== false,
-        Env: env,
-        User: `${container.defaultUser || options.$user || ''}`
-    });
+    execArgs.push(container.id, ...command);
 
-    const execStream = await exec.start();
-
-    return new Promise((resolve, reject) => {
-        const output = [];
-        const outputStream = new stream.PassThrough();
-
-        outputStream.on('data', chunk => output.push(chunk.toString('utf8')));
-        execStream.on('end', () => resolve(output.join('').trim()));
-
-        container.modem.demuxStream(execStream, outputStream, process.stderr);
-    });
+    try {
+        const output = await execDocker(execArgs);
+        return output;
+    } catch (err) {
+        if (options.$nullOnError) {
+            return null;
+        }
+        throw err;
+    }
 }
-
 
 module.exports = Studio;

--- a/lib/Studio.js
+++ b/lib/Studio.js
@@ -16,6 +16,8 @@ let hab;
  * @returns {Promise<string>} - Resolves with stdout data.
  */
 function execDocker(args, options = {}) {
+    logger.debug(`docker ${args.join(' ')}`);
+
     return new Promise((resolve, reject) => {
         const dockerProcess = spawn('docker', args, { stdio: 'pipe', ...options });
 

--- a/lib/Studio.js
+++ b/lib/Studio.js
@@ -15,11 +15,19 @@ let hab;
  * @param {Object} options - Options for child_process.spawn.
  * @returns {Promise<string>} - Resolves with stdout data.
  */
-function execDocker(args, options = {}) {
+function execDocker(args, options = { $relayStderr: false, $relayStdout: false }) {
     logger.debug(`docker ${args.join(' ')}`);
 
     return new Promise((resolve, reject) => {
         const dockerProcess = spawn('docker', args, { stdio: 'pipe', ...options });
+
+        if (options.$relayStderr !== false) {
+            dockerProcess.stderr.pipe(process.stderr);
+        }
+
+        if (options.$relayStdout !== false) {
+            dockerProcess.stdout.pipe(process.stdout);
+        }
 
         let stdout = '';
         let stderr = '';
@@ -114,7 +122,7 @@ class Studio {
 
         // pull latest studio container
         try {
-            await execDocker(['pull', 'jarvus/hologit-studio:latest']);
+            await execDocker(['pull', 'jarvus/hologit-studio:latest'], { $relayStdout: true, $relayStderr: true });
         } catch (err) {
             logger.error(`failed to pull studio image via docker: ${err.message}`);
         }
@@ -333,7 +341,7 @@ async function containerExec (container, ...command) {
     execArgs.push(container.id, ...command);
 
     try {
-        const output = await execDocker(execArgs);
+        const output = await execDocker(execArgs, { $relayStdout: true, $relayStderr: true });
         return output;
     } catch (err) {
         if (options.$nullOnError) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "async-exit-hook": "^2.0.1",
         "axios": "^1.7.7",
         "chokidar": "^3.5.3",
-        "debounce": "^2.2.0",
-        "dockerode": "^4.0.2",
+        "debounce": "^2.0.0",
         "fb-watchman": "^2.0.1",
         "git-client": "^1.8.3",
         "hab-client": "^1.1.3",
@@ -521,11 +520,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@balena/dockerignore": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
-      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -1118,14 +1112,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -1278,33 +1264,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1314,16 +1273,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -1385,43 +1334,11 @@
         "node-int64": "^0.4.0"
       }
     },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
-    },
-    "node_modules/buildcheck": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
-      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
-      "optional": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -1508,11 +1425,6 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/ci-info": {
       "version": "3.9.0",
@@ -1642,20 +1554,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
-    "node_modules/cpu-features": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
-      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "buildcheck": "~0.0.6",
-        "nan": "^2.19.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -1706,6 +1604,7 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1765,33 +1664,6 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/docker-modem": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.3.tgz",
-      "integrity": "sha512-89zhop5YVhcPEt5FpUFGr3cDyceGhq/F9J+ZndQ4KfqNvfbJpPMfgeixFgUj5OjCYAboElqODxY5Z1EBsSa6sg==",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "readable-stream": "^3.5.0",
-        "split-ca": "^1.0.1",
-        "ssh2": "^1.15.0"
-      },
-      "engines": {
-        "node": ">= 8.0"
-      }
-    },
-    "node_modules/dockerode": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.2.tgz",
-      "integrity": "sha512-9wM1BVpVMFr2Pw3eJNXrYYt6DT9k0xMcsSCjtPvyQ+xa1iPg/Mo3T/gUcwI0B2cczqCeCYRPF8yFYDwtFXT0+w==",
-      "dependencies": {
-        "@balena/dockerignore": "^1.0.2",
-        "docker-modem": "^5.0.3",
-        "tar-fs": "~2.0.1"
-      },
-      "engines": {
-        "node": ">= 8.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -1996,11 +1868,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -2220,25 +2087,6 @@
       "engines": {
         "node": ">=10.17.0"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/import-local": {
       "version": "3.2.0",
@@ -3268,11 +3116,6 @@
         "mkdirp": "bin/cmd.js"
       }
     },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3302,12 +3145,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/nan": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
-      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
-      "optional": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -3757,11 +3594,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "node_modules/semver": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
@@ -3862,33 +3694,11 @@
         "source-map": "^0.6.0"
       }
     },
-    "node_modules/split-ca": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
-      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ=="
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
-    },
-    "node_modules/ssh2": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.16.0.tgz",
-      "integrity": "sha512-r1X4KsBGedJqo7h8F5c4Ybpcr5RjyP+aWIG007uBPRjmdQWfEiVLzSK71Zji1B9sKxwaCvD8y8cwSkYrlLiRRg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "asn1": "^0.2.6",
-        "bcrypt-pbkdf": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      },
-      "optionalDependencies": {
-        "cpu-features": "~0.0.10",
-        "nan": "^2.20.0"
-      }
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -4009,32 +3819,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
-      "integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.0.0"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -4124,11 +3908,6 @@
       "engines": {
         "node": ">= 14.0.0"
       }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "node_modules/type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "axios": "^1.7.7",
     "chokidar": "^3.5.3",
     "debounce": "^2.0.0",
-    "dockerode": "^4.0.2",
     "fb-watchman": "^2.0.1",
     "git-client": "^1.8.3",
     "hab-client": "^1.1.3",


### PR DESCRIPTION
Interacting with the docker CLI enables the transparent use of other docker-compatible runtimes, such as podman or nerdctl.