### PR TITLE
Studio.js: fix hab cache permissions on hosts without habitat install

### DIFF
--- a/lib/Studio.js
+++ b/lib/Studio.js
@@ -198,6 +198,7 @@ class Studio {
                 await containerExec({ id: containerId }, 'adduser', '-u', `${uid}`, '-G', 'developer', '-D', username);
                 await containerExec({ id: containerId }, 'mkdir', '-p', `/home/${username}/.hab`);
                 await containerExec({ id: containerId }, 'ln', '-sf', '/hab/cache', `/home/${username}/.hab/`);
+                if (!artifactCachePath) await containerExec({ id: containerId }, 'chown', '-R', `${uid}:${gid}`, '/hab/cache');
                 defaultUser = `${uid}`;
             }
 


### PR DESCRIPTION
This PR is stacked on: https://github.com/JarvusInnovations/hologit/pull/363

When a host machine does not have habitat already installed, it will not mount the host habitat cache into the studio container. Consequently, the habitat cache inside the studio will be owned by root and will in turn cause unprivileged `hab pkg install` operations to fail.