### PR TITLE
chore(deps): upgrade sort-keys from 4.2.0 to 6.0.0

### DIFF
--- a/lib/SpecObject.js
+++ b/lib/SpecObject.js
@@ -1,4 +1,3 @@
-const sortKeys = require('sort-keys');
 const TOML = require('@iarna/toml');
 
 
@@ -8,7 +7,8 @@ const BlobObject = require('./BlobObject.js');
 class SpecObject extends BlobObject {
 
     static async write (repo, kind, data) {
-        // build ordered spec object
+        // build ordered spec object (sort-keys is ESM-only, requires dynamic import)
+        const { default: sortKeys } = await import('sort-keys');
         const holospec = {};
         holospec[kind] = sortKeys(data, { deep: true });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "object-squish": "^1.1.0",
         "parse-url": "^10.0.3",
         "shell-quote-word": "^1.0.1",
-        "sort-keys": "^4.2.0",
+        "sort-keys": "^6.0.0",
         "toposort": "^2.0.2",
         "winston": "^3.17.0",
         "yargs": "^17.5.1"
@@ -41,7 +41,7 @@
         "jest": "^30.2.0"
       },
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3000,12 +3000,15 @@
       }
     },
     "node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-stream": {
@@ -4645,15 +4648,15 @@
       }
     },
     "node_modules/sort-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.2.0.tgz",
-      "integrity": "sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-6.0.0.tgz",
+      "integrity": "sha512-ueSlHJMwpIw42CJ4B11Uxzh/S0p0AlOyiNktlv2KOu5e1JpUE6DlC4AAUjXqesHdBRv/g0wC9Q4vwq0NP2pA9w==",
       "license": "MIT",
       "dependencies": {
-        "is-plain-obj": "^2.0.0"
+        "is-plain-obj": "^4.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "object-squish": "^1.1.0",
     "parse-url": "^10.0.3",
     "shell-quote-word": "^1.0.1",
-    "sort-keys": "^4.2.0",
+    "sort-keys": "^6.0.0",
     "toposort": "^2.0.2",
     "winston": "^3.17.0",
     "yargs": "^17.5.1"
@@ -33,7 +33,7 @@
     "git-holo": "./bin/cli.js"
   },
   "engines": {
-    "node": ">=8.3.0"
+    "node": ">=20"
   },
   "os": [
     "darwin",


### PR DESCRIPTION
## Summary

- Upgrade `sort-keys` from 4.2.0 to 6.0.0
- Fix ESM compatibility by using dynamic `import()` instead of `require()` (sort-keys v5+ is a pure ESM module)
- Update Node.js engine requirement from `>=8.3.0` to `>=20` (required by sort-keys 6.0.0)

This supersedes #382 which only bumped the version without addressing the ESM compatibility issue.

## Test plan

- [x] Verified `node bin/cli.js project --no-cache-from --cache-to=origin github-action-projector` passes
- [x] Verified `node bin/cli.js project --no-cache-from --cache-to=origin docs-site` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)