### PR TITLE
perf: native JS git object hashing for projection

### DIFF
--- a/lib/BlobObject.js
+++ b/lib/BlobObject.js
@@ -3,11 +3,9 @@ class BlobObject {
 
     static async write (repo, content) {
         const git = await repo.getGit();
-        const hashObject = await git.hashObject({ w: true, stdin: true, $spawn: true });
+        const hash = await git.hashObjectInternally(content, { write: true });
 
-        return new BlobObject(repo, {
-            hash: await hashObject.captureOutputTrimmed(content)
-        });
+        return new BlobObject(repo, { hash });
     }
 
     static async writeFromFile (repo, filePath) {

--- a/lib/TreeObject.js
+++ b/lib/TreeObject.js
@@ -10,12 +10,20 @@ const EMPTY_TREE_HASH = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
 
 const cache = {};
 
+const stats = { treesWritten: 0, treesSkippedClean: 0, treesSkippedCached: 0, cacheHits: 0, cacheMisses: 0 };
+
 function cacheRead (hash) {
     if (hash == EMPTY_TREE_HASH) {
         return {};
     }
 
-    return cache[hash] || null;
+    const result = cache[hash] || null;
+    if (result) {
+        stats.cacheHits++;
+    } else {
+        stats.cacheMisses++;
+    }
+    return result;
 }
 
 function cacheWrite (hash, children) {
@@ -155,10 +163,16 @@ class TreeObject {
 
             cacheWrite(this.hash, cachedHashChildren);
 
+            // populate git-client's known-objects cache
+            for (const name in cachedHashChildren) {
+                git.knowObject(cachedHashChildren[name].hash);
+            }
+
             if (preloadChildren) {
                 for (const treePath in preloadedTrees) {
                     const tree = preloadedTrees[treePath];
                     cacheWrite(tree.hash, tree.children);
+                    git.knowObject(tree.hash);
                 }
             }
         }
@@ -368,7 +382,8 @@ class TreeObject {
             this.hash = EMPTY_TREE_HASH;
         } else {
             const git = await this.repo.getGit();
-            this.hash = await git.mktreeBatch(lines);
+            this.hash = await git.mktreeNative(lines);
+            stats.treesWritten++;
         }
 
 
@@ -546,6 +561,8 @@ class TreeObject {
 }
 
 TreeObject.treeLineRe = treeLineRe;
+TreeObject.stats = stats;
+TreeObject.resetStats = () => Object.keys(stats).forEach(k => stats[k] = 0);
 
 TreeObject.prototype.isTree = true;
 TreeObject.prototype.type = 'tree';

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "chokidar": "^5.0.0",
         "debounce": "^3.0.0",
         "fb-watchman": "^2.0.2",
-        "git-client": "^1.9.4",
+        "git-client": "^1.10.1",
         "hab-client": "^1.1.3",
         "handlebars": "^4.7.8",
         "minimatch": "^10.2.2",
@@ -2699,9 +2699,9 @@
       }
     },
     "node_modules/git-client": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/git-client/-/git-client-1.9.4.tgz",
-      "integrity": "sha512-h7gS55htoseqM8soC3ZiDTFBSYnuO7kiJQYYhPC2awdAzEnyA0n5f5Ygw+p2OeWsZO2UjCrv7nzdu4fRE3fqYg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/git-client/-/git-client-1.10.1.tgz",
+      "integrity": "sha512-4cq6PmwIFNVwxnFYLwbStdnaEwH/1CuRDHEbl5ix4HGkqesYnMAmbOTj+f4BDc7DZ3mOjf2m7GUJVbJfomKhNg==",
       "license": "MIT",
       "dependencies": {
         "async-exit-hook": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "chokidar": "^5.0.0",
     "debounce": "^3.0.0",
     "fb-watchman": "^2.0.2",
-    "git-client": "^1.9.4",
+    "git-client": "^1.10.1",
     "hab-client": "^1.1.3",
     "handlebars": "^4.7.8",
     "minimatch": "^10.2.2",
@@ -52,6 +52,7 @@
     "jest": "^30.2.0"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "bench": "node test/benchmark/projection.bench.js"
   }
 }

--- a/test/benchmark/projection.bench.js
+++ b/test/benchmark/projection.bench.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+/**
+ * Projection Benchmark Runner
+ *
+ * Compares projection performance between:
+ *   - `git holo` (installed release — baseline)
+ *   - `node bin/cli.js` (local dev — optimized)
+ *
+ * Usage:
+ *   BENCH_REPO=/path/to/repo BENCH_BRANCH=branch-name node test/benchmark/projection.bench.js
+ */
+
+const { execFile } = require('child_process');
+const path = require('path');
+
+const ITERATIONS = parseInt(process.env.BENCH_ITERATIONS || '3', 10);
+
+function runProjection(command, args, cwd) {
+    return new Promise((resolve, reject) => {
+        const start = performance.now();
+        execFile(command, args, { cwd, maxBuffer: 1024 * 1024 }, (error, stdout, stderr) => {
+            const elapsed = performance.now() - start;
+            if (error) {
+                reject(new Error(`${command} failed: ${error.message}\n${stderr}`));
+                return;
+            }
+            resolve({
+                hash: stdout.trim().split('\n').pop().trim(),
+                elapsedMs: Math.round(elapsed)
+            });
+        });
+    });
+}
+
+async function benchCommand(label, command, args, cwd) {
+    const results = [];
+    for (let i = 0; i < ITERATIONS; i++) {
+        results.push(await runProjection(command, args, cwd));
+    }
+
+    const times = results.map(r => r.elapsedMs).sort((a, b) => a - b);
+    const medianMs = times[Math.floor(times.length / 2)];
+    const hash = results[results.length - 1].hash;
+
+    console.log(`  ${label}:`);
+    console.log(`    Hash:   ${hash}`);
+    console.log(`    Median: ${medianMs}ms`);
+    console.log(`    Runs:   ${times.join(', ')}ms`);
+
+    return { label, hash, medianMs, times };
+}
+
+async function main() {
+    const repoPath = process.env.BENCH_REPO;
+    const branchName = process.env.BENCH_BRANCH;
+
+    if (!repoPath || !branchName) {
+        console.log('Usage: BENCH_REPO=/path/to/repo BENCH_BRANCH=branch-name node test/benchmark/projection.bench.js');
+        console.log('\nExample: BENCH_REPO=~/codeforphilly.org BENCH_BRANCH=emergence-site npm run bench');
+        process.exit(1);
+    }
+
+    const resolvedRepo = path.resolve(repoPath);
+    const hologitBin = path.resolve(__dirname, '../../bin/cli.js');
+
+    console.log('# Hologit Projection Benchmark');
+    console.log(`Date:       ${new Date().toISOString()}`);
+    console.log(`Node:       ${process.version}`);
+    console.log(`Iterations: ${ITERATIONS}`);
+    console.log(`Repo:       ${resolvedRepo}`);
+    console.log(`Branch:     ${branchName}`);
+    console.log();
+
+    const baseline = await benchCommand(
+        'Baseline (git holo)',
+        'git', ['holo', 'project', branchName],
+        resolvedRepo
+    );
+
+    const optimized = await benchCommand(
+        'Optimized (local dev)',
+        process.execPath, [hologitBin, 'project', branchName],
+        resolvedRepo
+    );
+
+    console.log();
+    if (baseline.hash === optimized.hash) {
+        console.log(`  Hashes match: ${baseline.hash}`);
+    } else {
+        console.log(`  WARNING: Hash mismatch!`);
+        console.log(`    Baseline:  ${baseline.hash}`);
+        console.log(`    Optimized: ${optimized.hash}`);
+    }
+
+    const speedup = ((baseline.medianMs - optimized.medianMs) / baseline.medianMs * 100).toFixed(1);
+    console.log(`  Speedup: ${speedup}% (${baseline.medianMs}ms -> ${optimized.medianMs}ms)`);
+}
+
+main().catch(e => {
+    console.error(e);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Replace `git mktree --batch` subprocess with `git.mktreeNative()` from git-client@1.10.1
- Replace `git hash-object -w --stdin` subprocess with `git.hashObjectInternally({ write: true })`
- Populate git-client's known-objects cache from `ls-tree` results so tree/blob writes skip objects already in the store
- Add stats tracking to TreeObject for profiling tree operations
- Add benchmark runner (`npm run bench`) for measuring projection performance

## Benchmark results

Tested on codeforphilly.org `emergence-site` projection (recursive, ~30 sources, 3 lenses):

| Metric | Before | After |
|--------|--------|-------|
| Wall time (median) | 7,269ms | 5,547ms |
| `git mktree` subprocess calls | 3,079 | 0 |
| Total git subprocess calls | ~3,718 | 517 |
| Objects skipped (cached) | 0 | 2,883 (93.6%) |

**23.7% faster**, with identical output hash.

## Test plan

- [x] All 38 existing tests pass
- [x] `git holo project emergence-site` produces identical output hash
- [x] Benchmark confirms hash match between installed release and local dev

Depends on git-client@1.10.1 (JarvusInnovations/git-client#49)