### PR TITLE
perf: native read methods and $ naming convention

### DIFF
--- a/lib/BlobObject.js
+++ b/lib/BlobObject.js
@@ -36,7 +36,7 @@ class BlobObject {
 
     async read () {
         const git = await this.repo.getGit();
-        return git.catFile({ p: true }, this.hash);
+        return git.$getBlob(this.hash);
     }
 }
 

--- a/lib/BlobObject.js
+++ b/lib/BlobObject.js
@@ -3,7 +3,7 @@ class BlobObject {
 
     static async write (repo, content) {
         const git = await repo.getGit();
-        const hash = await git.hashObjectInternally(content, { write: true });
+        const hash = await git.$putBlob(content);
 
         return new BlobObject(repo, { hash });
     }

--- a/lib/Lens.js
+++ b/lib/Lens.js
@@ -261,7 +261,7 @@ class Lens extends Configurable {
 
 
         // determine spec type from content
-        const specToml = await git.catFile({ p: true }, specHash);
+        const specToml = await git.$getBlob(specHash);
         const { holospec: { lens: spec } } = TOML.parse(specToml);
         const specType = spec.container ? 'container' : spec.package ? 'habitat' : null;
 
@@ -319,7 +319,7 @@ class Lens extends Configurable {
         const git = await repo.getGit();
 
         // read and parse spec file
-        const specToml = await git.catFile({ p: true }, specHash);
+        const specToml = await git.$getBlob(specHash);
         const {
             holospec: {
                 lens: spec
@@ -474,7 +474,7 @@ class Lens extends Configurable {
             }
         } else {
             // load spec
-            const specToml = await git.catFile({ p: true }, specHash);
+            const specToml = await git.$getBlob(specHash);
             const {
                 holospec: {
                     lens: spec

--- a/lib/Repo.js
+++ b/lib/Repo.js
@@ -157,7 +157,7 @@ class Repo {
      */
     async hasCommit (commit) {
         const git = await this.getGit();
-        return 'commit' == await git.catFile({ t: true }, commit, { $nullOnError: true });
+        return 'commit' == await git.$objectExists(commit);
     }
 
     async hashWorkTree () {

--- a/lib/TreeObject.js
+++ b/lib/TreeObject.js
@@ -128,21 +128,20 @@ class TreeObject {
         if (!cachedHashChildren) {
             cachedHashChildren = {};
 
-            const treeLines = (await git.lsTree(preloadChildren ? { r: true, t: true, z: true, 'full-tree': true } : { z: true, 'full-tree': true }, this.hash)).split('\0');
-            const preloadedTrees = {};
+            if (preloadChildren) {
+                // recursive ls-tree: one subprocess call to load the entire tree hierarchy
+                const treeLines = (await git.lsTree({ r: true, t: true, z: true, 'full-tree': true }, this.hash)).split('\0');
+                const preloadedTrees = {};
 
-            for (const treeLine of treeLines) {
-                if (!treeLine) {
-                    continue;
-                }
+                for (const treeLine of treeLines) {
+                    if (!treeLine) {
+                        continue;
+                    }
 
-                const [, mode, type, hash, childPath] = treeLineRe.exec(treeLine);
-
-                if (preloadChildren) {
+                    const [, mode, type, hash, childPath] = treeLineRe.exec(treeLine);
                     const parentTreePathLength = childPath.lastIndexOf('/');
 
                     if (type == 'tree') {
-                        // any tree listed will have children, begin cache entry
                         preloadedTrees[childPath] = {
                             hash,
                             children: {}
@@ -150,31 +149,32 @@ class TreeObject {
                     }
 
                     if (parentTreePathLength == -1) {
-                        // direct child, add to current result
                         cachedHashChildren[childPath] = { type, hash, mode };
                     } else {
                         preloadedTrees[childPath.substr(0, parentTreePathLength)]
                             .children[childPath.substr(parentTreePathLength+1)] = { type, hash, mode };
                     }
-                } else {
-                    cachedHashChildren[childPath] = { type, hash, mode };
                 }
-            }
 
-            cacheWrite(this.hash, cachedHashChildren);
+                // populate git-client's known-objects cache
+                for (const name in cachedHashChildren) {
+                    git.$knowObject(cachedHashChildren[name].hash);
+                }
 
-            // populate git-client's known-objects cache
-            for (const name in cachedHashChildren) {
-                git.$knowObject(cachedHashChildren[name].hash);
-            }
-
-            if (preloadChildren) {
                 for (const treePath in preloadedTrees) {
                     const tree = preloadedTrees[treePath];
                     cacheWrite(tree.hash, tree.children);
                     git.$knowObject(tree.hash);
                 }
+            } else {
+                // non-recursive: read single tree level via cat-file --batch
+                const entries = await git.$getTree(this.hash);
+                for (const { mode, type, hash, name } of entries) {
+                    cachedHashChildren[name] = { type, hash, mode };
+                }
             }
+
+            cacheWrite(this.hash, cachedHashChildren);
         }
 
 

--- a/lib/TreeObject.js
+++ b/lib/TreeObject.js
@@ -165,14 +165,14 @@ class TreeObject {
 
             // populate git-client's known-objects cache
             for (const name in cachedHashChildren) {
-                git.knowObject(cachedHashChildren[name].hash);
+                git.$knowObject(cachedHashChildren[name].hash);
             }
 
             if (preloadChildren) {
                 for (const treePath in preloadedTrees) {
                     const tree = preloadedTrees[treePath];
                     cacheWrite(tree.hash, tree.children);
-                    git.knowObject(tree.hash);
+                    git.$knowObject(tree.hash);
                 }
             }
         }
@@ -382,7 +382,7 @@ class TreeObject {
             this.hash = EMPTY_TREE_HASH;
         } else {
             const git = await this.repo.getGit();
-            this.hash = await git.mktreeNative(lines);
+            this.hash = await git.$putTree(lines);
             stats.treesWritten++;
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "chokidar": "^5.0.0",
         "debounce": "^3.0.0",
         "fb-watchman": "^2.0.2",
-        "git-client": "^1.10.1",
+        "git-client": "^1.11.0",
         "hab-client": "^1.1.3",
         "handlebars": "^4.7.8",
         "minimatch": "^10.2.4",
@@ -2660,9 +2660,9 @@
       }
     },
     "node_modules/git-client": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/git-client/-/git-client-1.10.1.tgz",
-      "integrity": "sha512-4cq6PmwIFNVwxnFYLwbStdnaEwH/1CuRDHEbl5ix4HGkqesYnMAmbOTj+f4BDc7DZ3mOjf2m7GUJVbJfomKhNg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/git-client/-/git-client-1.11.0.tgz",
+      "integrity": "sha512-bUcIZrJSwmzlRUhDX8vE0FBu4mKXQrxEFnskhKCdsRD7wBJTDgAfVjzkAQR1RJJ7Wqp6gXyaMbk3K34RoL/MOA==",
       "license": "MIT",
       "dependencies": {
         "async-exit-hook": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "chokidar": "^5.0.0",
     "debounce": "^3.0.0",
     "fb-watchman": "^2.0.2",
-    "git-client": "^1.10.1",
+    "git-client": "^1.11.0",
     "hab-client": "^1.1.3",
     "handlebars": "^4.7.8",
     "minimatch": "^10.2.4",


### PR DESCRIPTION
## Summary

- Update to git-client@1.11.0 `$` naming convention for native methods
- Replace `catFile -p` subprocess calls with `git.$getBlob()` via persistent `cat-file --batch` process (BlobObject.read, Lens.js spec reads)
- Replace non-recursive `lsTree` calls with `git.$getTree()` via `cat-file --batch` with binary tree parsing (TreeObject._loadBaseChildren)
- Replace `catFile -t` with `git.$objectExists()` via persistent `cat-file --batch-check` (Repo.hasCommit)
- Recursive `ls-tree -r -t` calls left as-is (one subprocess to load entire tree hierarchy is already efficient)

## Cumulative benchmark results

Tested on codeforphilly.org `emergence-site` projection:

| Metric | Original (pre-optimization) | After write opts (v1.10.1) | After read opts (this PR) |
|--------|---------------------------|---------------------------|--------------------------|
| Git subprocess calls | ~3,718 | 517 | 350 |
| Wall time | 7,269ms | 5,547ms | ~5,720ms |

91% total reduction in git subprocess calls. The read-side gains are incremental since `cat-file --batch` still has IPC overhead, but the subprocess count reduction helps on systems with higher process spawn costs.

## Test plan

- [x] All 38 existing tests pass
- [x] Real-world projection produces identical output hash: `a28e895d71a568ae5af05914103793d8f77b0d11`
- [x] Benchmark confirms hash match between baseline and optimized

Depends on git-client@1.11.0 (JarvusInnovations/git-client#52)