### PR TITLE
feat: programmatic composition API

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,14 +108,50 @@ Hologit includes a [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
 
 Once installed, Claude can help you configure `.holo/` files, set up sources and mappings, choose and configure stock lenses, and debug projection issues.
 
+## Programmatic API
+
+Hologit can also be used as an npm module to compose git trees programmatically, without `.holo/` TOML files in the source repositories:
+
+```javascript
+const { Repo, Workspace, Branch, Projection } = require('hologit');
+
+const repo = new Repo({ gitDir: '/path/to/.git', ref: 'HEAD' });
+const rootTree = repo.createTree();
+await rootTree.writeChild('.holo/config.toml', '[holospace]\nname = "app"\n');
+
+const workspace = new Workspace({
+  root: rootTree,
+  sources: {
+    'base': { url: '/path/to/base', ref: 'refs/heads/main' },
+    'overlay': { url: '/path/to/overlay', ref: 'refs/heads/main' }
+  }
+});
+
+const branch = new Branch({
+  workspace,
+  name: 'composed',
+  phantom: {},
+  mappings: {
+    '_base': { holosource: 'base', files: ['**'] },
+    '_overlay': { holosource: 'overlay', files: ['**'], after: ['base'] }
+  }
+});
+
+const treeHash = await Projection.projectBranch(branch, { lens: false });
+```
+
+See the [Programmatic API docs](docs/programmatic-api/README.md) for full details and the [ProjectionPlan](docs/programmatic-api/projection-plan.md) fluent builder API.
+
 ## Documentation
 
 - [Installation Guide](docs/grand-tour/installation.md)
 - [Repository Setup](docs/grand-tour/repository-setup.md)
-- [Working with Sources](docs/workflows/work-on-sources.md)
 - [Holobranches Guide](docs/grand-tour/holobranches.md)
+- [Holosources Guide](docs/grand-tour/holosources.md)
 - [Hololenses Guide](docs/grand-tour/hololenses.md)
 - [Holoreactors Guide](docs/grand-tour/holoreactors.md)
+- [Working with Sources](docs/workflows/work-on-sources.md)
+- [Programmatic API](docs/programmatic-api/README.md)
 
 ## License
 

--- a/docs/.pages
+++ b/docs/.pages
@@ -1,4 +1,5 @@
 arrange:
 - README.md
 - grand-tour
+- programmatic-api
 - workflows

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,9 @@ Hologit lets you declaratively define virtual sub-branches within any Git branch
   - [Holobranches](./grand-tour/holobranches.md)
   - [Hololenses](./grand-tour/hololenses.md)
   - [Holoreactors](./grand-tour/holoreactors.md)
+- [Programmatic API](./programmatic-api/README.md)
+  - [Composition](./programmatic-api/composition.md)
+  - [ProjectionPlan](./programmatic-api/projection-plan.md)
 - Workflows
   - [Work on Sources](./workflows/work-on-sources.md)
   - Publish a `docs/` tree to Gitbook and `gh-pages`

--- a/docs/programmatic-api/.pages
+++ b/docs/programmatic-api/.pages
@@ -1,0 +1,4 @@
+arrange:
+- README.md
+- composition.md
+- projection-plan.md

--- a/docs/programmatic-api/README.md
+++ b/docs/programmatic-api/README.md
@@ -1,0 +1,82 @@
+# Programmatic API
+
+Hologit can be used as an npm module to compose git trees programmatically, without `.holo/` TOML configuration files in the source repositories.
+
+## Installation
+
+```bash
+npm install hologit
+```
+
+## Exported API
+
+```javascript
+const {
+  Git,          // Git CLI wrapper
+  Repo,         // Git repository instance
+  Workspace,    // Container for sources, branches, and lenses
+  Branch,       // A holobranch with mappings
+  Source,       // A holosource (remote git ref)
+  Mapping,      // A holomapping (source → output path)
+  Lens,         // A hololens (transformation)
+  Projection,   // Orchestrates composition + lens pipeline
+  TreeObject,   // In-memory git tree representation
+  BlobObject,   // In-memory git blob representation
+  SpecObject,   // Content-addressable spec for caching
+  Studio,       // Docker execution environment manager
+} = require('hologit');
+```
+
+## Two Modes of Use
+
+### TOML-driven (traditional)
+
+Hologit reads `.holo/sources/*.toml`, `.holo/branches/*/*.toml`, and `.holo/lenses/*/*.toml` from a git tree to define the composition. This is how the `git holo project` CLI works.
+
+```javascript
+const { Repo, Projection } = require('hologit');
+
+const repo = await Repo.getFromEnvironment();
+const workspace = await repo.getWorkspace();
+const branch = await workspace.getBranch('my-holobranch');
+const treeHash = await Projection.projectBranch(branch);
+```
+
+### Programmatic (no TOML required)
+
+Sources, branches, and mappings are constructed in memory using the **phantom config** mechanism. The source repositories don't need any `.holo/` directory.
+
+```javascript
+const { Repo, Workspace, Branch, Projection } = require('hologit');
+
+const repo = new Repo({ gitDir: '/path/to/.git', ref: 'HEAD' });
+const rootTree = repo.createTree();
+await rootTree.writeChild('.holo/config.toml', '[holospace]\nname = "my-project"\n');
+
+const workspace = new Workspace({
+  root: rootTree,
+  sources: {
+    'base': { url: '/path/to/base-repo', ref: 'refs/heads/main' },
+    'overlay': { url: '/path/to/overlay-repo', ref: 'refs/heads/main' }
+  }
+});
+
+const branch = new Branch({
+  workspace,
+  name: 'composed',
+  phantom: {},
+  mappings: {
+    '_base': { holosource: 'base', files: ['**'] },
+    '_overlay': { holosource: 'overlay', files: ['**'], after: ['base'] }
+  }
+});
+
+const treeHash = await Projection.projectBranch(branch, { lens: false });
+```
+
+The result is a git tree hash — the same content-addressable output that the CLI produces. You can check it out, diff it, or compose it further.
+
+## Guides
+
+- **[Composition](composition.md)** — How to compose git trees programmatically
+- **[ProjectionPlan](projection-plan.md)** — Fluent builder API for common composition patterns

--- a/docs/programmatic-api/composition.md
+++ b/docs/programmatic-api/composition.md
@@ -1,0 +1,241 @@
+# Programmatic Composition
+
+This guide covers how to compose git trees programmatically using hologit's core classes. No `.holo/` TOML files are needed in the source repositories.
+
+## Creating a Repo
+
+Every hologit operation starts with a `Repo` instance. The repo provides git object storage — hologit creates tree and blob objects in its object database.
+
+```javascript
+const { Repo } = require('hologit');
+
+// From a working directory
+const repo = await Repo.getFromEnvironment();
+
+// From explicit paths
+const repo = new Repo({
+  gitDir: '/path/to/.git',
+  ref: 'HEAD',
+  workTree: '/path/to/workdir'  // optional
+});
+```
+
+The repo doesn't need to contain any project files — it's used purely for git object storage. You can point it at a bare repo created just for this purpose:
+
+```javascript
+const { execSync } = require('child_process');
+
+execSync('git init --bare /tmp/compose-store');
+const repo = new Repo({ gitDir: '/tmp/compose-store', ref: 'HEAD' });
+```
+
+## The Phantom Mechanism
+
+All hologit configuration objects (`Source`, `Branch`, `Mapping`, `Lens`) extend `Configurable`, which supports two config sources:
+
+1. **TOML from a git tree** — the traditional mode, reading `.holo/sources/name.toml` etc.
+2. **Phantom config** — an in-memory object passed at construction time
+
+When `phantom` config is provided, hologit uses it directly without reading any TOML files. This is the foundation of the programmatic API.
+
+## Constructing a Workspace
+
+A `Workspace` is the container for sources and branches. It requires a root tree (which must contain a minimal `.holo/config.toml`).
+
+The `sources` parameter accepts a plain object of `{ name: config }` entries. Each config object is automatically wrapped in a phantom `Source` instance:
+
+```javascript
+const { Workspace } = require('hologit');
+
+const rootTree = repo.createTree();
+await rootTree.writeChild('.holo/config.toml', '[holospace]\nname = "my-project"\n');
+
+const workspace = new Workspace({
+  root: rootTree,
+  sources: {
+    'framework': { url: 'https://github.com/org/framework', ref: 'refs/tags/v2.0.0' },
+    'app': { url: '/local/path/to/app', ref: 'refs/heads/main' },
+    'theme': { url: 'https://github.com/org/theme', ref: 'refs/heads/main' }
+  }
+});
+```
+
+### Source config shape
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `url` | yes | Git URL or local filesystem path to the source repository |
+| `ref` | yes | Git ref to read from (`refs/heads/main`, `refs/tags/v1.0`, a commit hash) |
+| `project` | no | `{ holobranch: 'name' }` — if the source itself has holobranches, project through one before using |
+
+Local filesystem paths are resolved as-is. Remote URLs are fetched into the repo's object database.
+
+You can also pass pre-constructed `Source` instances:
+
+```javascript
+const source = new Source({
+  workspace,
+  name: 'framework',
+  phantom: { url: '...', ref: '...' }
+});
+
+const workspace = new Workspace({
+  root: rootTree,
+  sources: { 'framework': source }
+});
+```
+
+## Constructing a Branch with Mappings
+
+A `Branch` defines how sources are combined. The `mappings` parameter accepts a plain object of `{ key: config }` entries:
+
+```javascript
+const { Branch } = require('hologit');
+
+const branch = new Branch({
+  workspace,
+  name: 'composed',
+  phantom: {},
+  mappings: {
+    '_framework': {
+      holosource: 'framework',
+      files: ['**']
+    },
+    '_app': {
+      holosource: 'app',
+      files: ['**'],
+      after: ['framework']
+    },
+    '_theme': {
+      holosource: 'theme',
+      files: ['styles/**', 'assets/**'],
+      output: '.',
+      after: ['framework']
+    }
+  }
+});
+```
+
+### Mapping config shape
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `holosource` | yes | — | Name of the source to pull from |
+| `files` | no | `['**']` | Glob patterns for which files to include |
+| `root` | no | `'.'` | Subtree of the source to map from |
+| `output` | no | `'.'` | Target path in the output tree |
+| `layer` | no | source name | Layer name for ordering |
+| `after` | no | `null` | Array of source/layer names this mapping must come after |
+| `before` | no | `null` | Array of source/layer names this mapping must come before |
+
+### Mapping keys
+
+Mapping keys (the object property names) follow the hologit convention of underscore-prefixed names: `_framework`, `_app`, `_theme`. The key is used internally for identification and sorting.
+
+### Ordering
+
+Mappings are topologically sorted based on `after` and `before` constraints. When two sources define a file at the same path, the mapping that comes later in the sort order wins (its file overwrites the earlier one).
+
+Use `after: ['*']` to ensure a mapping comes last (highest priority).
+
+## Projecting
+
+Once you have a branch, project it to get a composed git tree hash:
+
+```javascript
+const { Projection } = require('hologit');
+
+const treeHash = await Projection.projectBranch(branch, {
+  lens: false,     // skip lens transformations
+  fetch: false     // don't fetch remote sources (they must already be available)
+});
+```
+
+The returned `treeHash` is a standard git tree object hash. You can use it with any git command:
+
+```bash
+# Inspect the tree
+git ls-tree -r <treeHash>
+
+# Read a specific file
+git cat-file -p <treeHash>:path/to/file.js
+
+# Check out to a directory
+GIT_DIR=/path/to/.git GIT_WORK_TREE=/output git read-tree <treeHash>
+GIT_DIR=/path/to/.git GIT_WORK_TREE=/output git checkout-index -a -f
+```
+
+Or programmatically via hologit's git wrapper:
+
+```javascript
+const git = await repo.getGit();
+
+// Read a file from the composed tree
+const content = await git.catFile({ p: true }, `${treeHash}:routes/api/people/index.ts`);
+
+// List all files
+const listing = await git.lsTree({ r: true }, treeHash);
+
+// Diff two composed trees
+const diff = await git.diffTree({ r: true, 'name-only': true }, oldTreeHash, newTreeHash);
+```
+
+## Full Example
+
+Compose a framework layer with an application layer, where the application overrides specific files:
+
+```javascript
+const { Repo, Workspace, Branch, Projection } = require('hologit');
+const { execSync } = require('child_process');
+
+// Set up a git repo for object storage
+execSync('git init --bare /tmp/my-store');
+const repo = new Repo({ gitDir: '/tmp/my-store', ref: 'HEAD' });
+
+// Build the workspace with two sources
+const rootTree = repo.createTree();
+await rootTree.writeChild('.holo/config.toml', '[holospace]\nname = "my-app"\n');
+
+const workspace = new Workspace({
+  root: rootTree,
+  sources: {
+    'framework': {
+      url: '/path/to/framework-repo',
+      ref: 'refs/tags/v2.0.0'
+    },
+    'app': {
+      url: '/path/to/app-repo',
+      ref: 'refs/heads/main'
+    }
+  }
+});
+
+// Define the composition — app overlays framework
+const branch = new Branch({
+  workspace,
+  name: 'production',
+  phantom: {},
+  mappings: {
+    '_framework': {
+      holosource: 'framework',
+      files: ['**']
+    },
+    '_app': {
+      holosource: 'app',
+      files: ['**'],
+      after: ['framework']  // app files override framework files at same paths
+    }
+  }
+});
+
+// Compose
+const treeHash = await Projection.projectBranch(branch, { lens: false });
+console.log('Composed tree:', treeHash);
+
+// Check out to a directory
+const git = await repo.getGit();
+await git.readTree(treeHash);
+await git.checkoutIndex({ a: true, f: true });
+```
+
+This produces a single git tree containing all of `framework`'s files, with any files at the same path replaced by `app`'s versions — the same copy-on-write overlay semantics as hologit's TOML-driven composition.

--- a/docs/programmatic-api/projection-plan.md
+++ b/docs/programmatic-api/projection-plan.md
@@ -1,0 +1,149 @@
+# ProjectionPlan
+
+`ProjectionPlan` is a fluent builder API for the common case of composing multiple git sources into a single layered tree. It wraps the lower-level `Workspace`, `Branch`, `Source`, `Mapping`, and `Projection` classes into a concise interface.
+
+## Basic Usage
+
+```javascript
+const { Repo } = require('hologit');
+const ProjectionPlan = require('hologit/lib/ProjectionPlan');
+
+const repo = new Repo({ gitDir: '/path/to/.git', ref: 'HEAD' });
+
+const plan = new ProjectionPlan(repo);
+plan.addLayer('base', { url: '/path/to/base', ref: 'refs/heads/main' });
+plan.addLayer('overlay', { url: '/path/to/overlay', ref: 'refs/heads/main' }, { after: ['base'] });
+
+const treeHash = await plan.project();
+```
+
+## API
+
+### `new ProjectionPlan(repo)`
+
+Create a new plan. Requires a `Repo` instance for git object storage.
+
+### `plan.addSource(name, config)`
+
+Register a named source. Returns `this` for chaining.
+
+**config shape:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `url` | yes | Git URL or local filesystem path |
+| `ref` | yes | Git ref (`refs/heads/main`, `refs/tags/v1.0`, commit hash) |
+| `project` | no | `{ holobranch: 'name' }` — project through a holobranch in the source |
+
+### `plan.addMapping(sourceName, config)`
+
+Add a mapping for a previously registered source. Returns `this` for chaining.
+
+**config shape:**
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `files` | `['**']` | Glob patterns for which files to include |
+| `root` | `'.'` | Subtree of the source to map from |
+| `output` | `'.'` | Target path in the output tree |
+| `layer` | source name | Layer name for ordering |
+| `after` | `null` | Sources/layers this must come after |
+| `before` | `null` | Sources/layers this must come before |
+
+### `plan.addLayer(name, sourceConfig, mappingConfig?)`
+
+Convenience method that calls `addSource` then `addMapping`. Returns `this` for chaining.
+
+This is the most common way to build a plan — each layer is a source that maps all its files (`**`) into the output tree:
+
+```javascript
+plan.addLayer('skeleton', { url: skeletonRepo, ref: 'refs/heads/main' });
+plan.addLayer('product', { url: productRepo, ref: 'refs/tags/v3.0' }, { after: ['skeleton'] });
+plan.addLayer('site', { url: siteRepo, ref: 'refs/heads/main' }, { after: ['product'] });
+```
+
+### `plan.project(options?)`
+
+Compose all layers and return the git tree hash. This is an async operation.
+
+**options:**
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `lens` | `false` | Whether to apply hololens transformations |
+| `fetch` | `false` | Whether to fetch remote sources |
+
+## Layer Ordering
+
+Layers are composed in topological order based on `after`/`before` constraints. When two layers contain a file at the same path, the layer that comes later wins.
+
+A typical pattern is to chain layers sequentially:
+
+```javascript
+plan.addLayer('skeleton', { url: skeletonUrl, ref: skeletonRef });
+plan.addLayer('product', { url: productUrl, ref: productRef }, { after: ['skeleton'] });
+plan.addLayer('site', { url: siteUrl, ref: siteRef }, { after: ['product'] });
+```
+
+This ensures: skeleton files are laid down first, product files overlay them, site files overlay everything.
+
+### Additive directories
+
+Files in different directories from different layers coexist naturally. If `skeleton` provides `config/search.config.d/people.ts` and `product` provides `config/search.config.d/sections.ts`, both files appear in the output. Only files at the **same path** are overridden.
+
+## Full Example: Emergence-style Layer Stack
+
+```javascript
+const { Repo } = require('hologit');
+const ProjectionPlan = require('hologit/lib/ProjectionPlan');
+const { execSync } = require('child_process');
+
+async function composeEmergenceSite({ gitDir, layers }) {
+  const repo = new Repo({ gitDir, ref: 'HEAD' });
+  const plan = new ProjectionPlan(repo);
+
+  let prevName = null;
+  for (const layer of layers) {
+    const mappingConfig = prevName ? { after: [prevName] } : {};
+    plan.addLayer(layer.name, {
+      url: layer.url,
+      ref: layer.ref || 'refs/heads/main'
+    }, mappingConfig);
+    prevName = layer.name;
+  }
+
+  return plan.project();
+}
+
+// Usage
+const treeHash = await composeEmergenceSite({
+  gitDir: '/path/to/object-store',
+  layers: [
+    { name: 'skeleton', url: 'https://github.com/org/skeleton', ref: 'refs/tags/v2.12.0' },
+    { name: 'slate', url: 'https://github.com/org/slate', ref: 'refs/tags/v2.21.0' },
+    { name: 'slate-cbl', url: 'https://github.com/org/slate-cbl', ref: 'refs/tags/v3.1.0' },
+    { name: 'school-site', url: '/local/school-site', ref: 'refs/heads/main' },
+  ]
+});
+
+// Check out the composed tree
+const git = await (new Repo({ gitDir: '/path/to/object-store', ref: 'HEAD' })).getGit();
+await git.readTree(treeHash);
+await git.checkoutIndex({ a: true, f: true });
+```
+
+## Relationship to Lower-Level API
+
+`ProjectionPlan` is syntactic sugar over the [composition API](composition.md). Under the hood:
+
+1. Source configs become phantom `Source` instances via `Workspace({ sources: {...} })`
+2. Mapping configs become phantom `Mapping` instances via `Branch({ mappings: {...} })`
+3. `project()` calls `Projection.projectBranch()` on the constructed branch
+
+Use `ProjectionPlan` for standard layer composition. Use the lower-level API when you need:
+
+- Custom `root` or `output` paths per mapping
+- Glob filtering (`files`) to include only specific file patterns from a source
+- Lens transformations
+- Multiple branches in one workspace
+- Direct access to the `TreeObject` before projection

--- a/lib/Branch.js
+++ b/lib/Branch.js
@@ -15,7 +15,7 @@ const lensMapCache = new WeakMap();
 
 class Branch extends Configurable {
 
-    constructor ({ workspace, name }) {
+    constructor ({ workspace, name, mappings=null }) {
         if (!workspace) {
             throw new Error('workspace required');
         }
@@ -27,6 +27,20 @@ class Branch extends Configurable {
         super(...arguments);
 
         this.name = name;
+
+        // Pre-populated mappings for programmatic construction
+        if (mappings) {
+            const map = new Map();
+            for (const [key, mapping] of Object.entries(mappings)) {
+                if (mapping instanceof Mapping) {
+                    map.set(key, mapping);
+                } else {
+                    // Accept plain config objects — construct Mapping with phantom
+                    map.set(key, new Mapping({ branch: this, key, phantom: mapping }));
+                }
+            }
+            mappingMapCache.set(this, map);
+        }
 
         Object.freeze(this);
     }

--- a/lib/ProjectionPlan.js
+++ b/lib/ProjectionPlan.js
@@ -1,0 +1,135 @@
+const Workspace = require('./Workspace.js');
+const Branch = require('./Branch.js');
+
+
+/**
+ * ProjectionPlan — fluent builder API for programmatic git tree composition.
+ *
+ * Composes git trees without .holo/ TOML files by constructing Workspace,
+ * Branch, Source, and Mapping objects with inline config.
+ *
+ * Usage:
+ *   const plan = new ProjectionPlan(repo);
+ *   plan.addLayer('skeleton', { url: '...', ref: 'refs/heads/main' });
+ *   plan.addLayer('product', { url: '...', ref: 'refs/heads/main' }, { after: ['skeleton'] });
+ *   const treeHash = await plan.project();
+ */
+class ProjectionPlan {
+
+    constructor (repo) {
+        if (!repo) {
+            throw new Error('repo required');
+        }
+
+        this.repo = repo;
+        this._sources = new Map();
+        this._mappings = [];
+    }
+
+    /**
+     * Add a source to the plan.
+     *
+     * @param {string} name - Source name (referenced by mappings)
+     * @param {object} config - Source configuration
+     * @param {string} config.url - Git URL or local filesystem path
+     * @param {string} config.ref - Git ref (e.g., 'refs/heads/main', 'refs/tags/v1.0')
+     * @param {object} [config.project] - Optional { holobranch } for recursive projection
+     * @returns {ProjectionPlan} this (for chaining)
+     */
+    addSource (name, config) {
+        this._sources.set(name, config);
+        return this;
+    }
+
+    /**
+     * Add a mapping to the plan.
+     *
+     * @param {string} sourceName - Name of a previously added source
+     * @param {object} [config] - Mapping configuration
+     * @param {string[]} [config.files=['**']] - Glob patterns for files to include
+     * @param {string} [config.root='.'] - Subtree of source to map from
+     * @param {string} [config.output='.'] - Target path in output tree
+     * @param {string} [config.layer] - Layer name for ordering (defaults to sourceName)
+     * @param {string[]} [config.after] - Source/layer names this must come after
+     * @param {string[]} [config.before] - Source/layer names this must come before
+     * @returns {ProjectionPlan} this (for chaining)
+     */
+    addMapping (sourceName, config = {}) {
+        this._mappings.push({
+            sourceName,
+            config: {
+                holosource: sourceName,
+                files: config.files || ['**'],
+                root: config.root || '.',
+                output: config.output || '.',
+                layer: config.layer || sourceName,
+                after: config.after || null,
+                before: config.before || null
+            }
+        });
+        return this;
+    }
+
+    /**
+     * Add a source and its default mapping in one call.
+     *
+     * @param {string} name - Source name
+     * @param {object} sourceConfig - Source configuration (url, ref, project?)
+     * @param {object} [mappingConfig] - Mapping configuration (files?, root?, output?, after?, before?)
+     * @returns {ProjectionPlan} this (for chaining)
+     */
+    addLayer (name, sourceConfig, mappingConfig = {}) {
+        this.addSource(name, sourceConfig);
+        this.addMapping(name, mappingConfig);
+        return this;
+    }
+
+    /**
+     * Compose all layers and return the git tree hash.
+     *
+     * @param {object} [options] - Projection options
+     * @param {boolean} [options.lens=false] - Whether to apply lens transformations
+     * @param {boolean} [options.fetch=false] - Whether to fetch remote sources
+     * @returns {Promise<string>} Git tree hash of the composed output
+     */
+    async project (options = {}) {
+        // Build mapping configs keyed for the branch constructor
+        const mappingConfigs = {};
+        for (const { sourceName, config } of this._mappings) {
+            mappingConfigs[`_${sourceName}`] = config;
+        }
+
+        // Build source configs for the workspace constructor
+        const sourceConfigs = {};
+        for (const [name, config] of this._sources) {
+            sourceConfigs[name] = config;
+        }
+
+        // Create workspace with phantom sources — needs a minimal root tree
+        const rootTree = this.repo.createTree();
+        await rootTree.writeChild('.holo/config.toml', '[holospace]\nname = "plan"\n');
+
+        const workspace = new Workspace({
+            root: rootTree,
+            sources: sourceConfigs
+        });
+
+        // Create branch with phantom mappings
+        const branch = new Branch({
+            workspace,
+            name: '_plan',
+            phantom: {},
+            mappings: mappingConfigs
+        });
+
+        // Project (lazy require to avoid circular dependency via index.js)
+        const Projection = require('./Projection.js');
+        return Projection.projectBranch(branch, {
+            lens: false,
+            ...options
+        });
+    }
+}
+
+
+module.exports = ProjectionPlan;

--- a/lib/SpecObject.js
+++ b/lib/SpecObject.js
@@ -7,10 +7,9 @@ const BlobObject = require('./BlobObject.js');
 class SpecObject extends BlobObject {
 
     static async write (repo, kind, data) {
-        // build ordered spec object (sort-keys is ESM-only, requires dynamic import)
-        const { default: sortKeys } = await import('sort-keys');
+        // build ordered spec object
         const holospec = {};
-        holospec[kind] = sortKeys(data, { deep: true });
+        holospec[kind] = deepSortKeys(data);
 
         // write canonical spec to a blob
         const { hash } = await super.write(repo, TOML.stringify({ holospec }));
@@ -33,4 +32,17 @@ class SpecObject extends BlobObject {
 
 
 SpecObject.prototype.isSpec = true;
+
+
+function deepSortKeys (obj) {
+    if (Array.isArray(obj)) return obj.map(deepSortKeys);
+    if (obj === null || typeof obj !== 'object') return obj;
+
+    return Object.keys(obj).sort().reduce((sorted, key) => {
+        sorted[key] = deepSortKeys(obj[key]);
+        return sorted;
+    }, {});
+}
+
+
 module.exports = SpecObject;

--- a/lib/Workspace.js
+++ b/lib/Workspace.js
@@ -18,7 +18,7 @@ const lensMapCache = new WeakMap();
 
 class Workspace extends Configurable {
 
-    constructor ({ root=null }) {
+    constructor ({ root=null, sources=null, branches=null }) {
         if (!root || !(root instanceof TreeObject)) {
             throw new Error('root required, must be instance of TreeObject');
         }
@@ -26,6 +26,32 @@ class Workspace extends Configurable {
         super(...arguments);
 
         this.root = root;
+
+        // Pre-populated sources and branches for programmatic construction
+        if (sources) {
+            const cache = new Map();
+            for (const [name, source] of Object.entries(sources)) {
+                if (source instanceof Source) {
+                    cache.set(name, source);
+                } else {
+                    // Accept plain config objects — construct Source with phantom
+                    cache.set(name, new Source({ workspace: this, name, phantom: source }));
+                }
+            }
+            sourceCache.set(this, cache);
+        }
+
+        if (branches) {
+            const cache = new Map();
+            for (const [name, branch] of Object.entries(branches)) {
+                if (branch instanceof Branch) {
+                    cache.set(name, branch);
+                } else {
+                    cache.set(name, new Branch({ workspace: this, name, phantom: branch }));
+                }
+            }
+            branchMapCache.set(this, cache);
+        }
 
         Object.freeze(this);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ exports.Source = require('./Source.js');
 exports.Lens = require('./Lens.js');
 exports.Workspace = require('./Workspace.js');
 exports.Projection = require('./Projection.js');
+exports.ProjectionPlan = require('./ProjectionPlan.js');
 exports.Studio = require('./Studio.js');
 
 exports.BlobObject = require('./BlobObject.js');

--- a/test/helpers/git-sandbox.js
+++ b/test/helpers/git-sandbox.js
@@ -34,7 +34,7 @@ class GitSandbox {
             workTree: tmpDir
         });
 
-        await git.init();
+        await git.init({ 'initial-branch': 'main' });
         await git.config('user.email', 'test@hologit.test');
         await git.config('user.name', 'Hologit Test');
 

--- a/test/integration/projection-plan.test.js
+++ b/test/integration/projection-plan.test.js
@@ -1,0 +1,352 @@
+/**
+ * ProjectionPlan Integration Tests
+ *
+ * Tests the fluent builder API for programmatic git tree composition
+ * without .holo/ TOML declarations in source repositories.
+ */
+
+const GitSandbox = require('../helpers/git-sandbox.js');
+const Projection = require('../../lib/Projection.js');
+const ProjectionPlan = require('../../lib/ProjectionPlan.js');
+
+describe('ProjectionPlan', () => {
+
+    describe('basic composition', () => {
+        let sandbox, sourceA, sourceB;
+
+        beforeEach(async () => {
+            sandbox = await GitSandbox.create();
+
+            // Create two source repos
+            sourceA = await GitSandbox.create();
+            await sourceA.addFile('routes/api/people/index.ts', 'export function GET() { return "from-a" }');
+            await sourceA.addFile('config/site.config.ts', 'export default { title: "Source A" }');
+            await sourceA.addFile('readme.txt', 'source a readme');
+            await sourceA.commit('init source-a');
+
+            sourceB = await GitSandbox.create();
+            await sourceB.addFile('routes/api/sections/index.ts', 'export function GET() { return "sections" }');
+            await sourceB.addFile('models/Section.ts', 'export interface Section { id: number }');
+            await sourceB.commit('init source-b');
+        });
+
+        afterEach(async () => {
+            await sandbox.cleanup();
+            await sourceA.cleanup();
+            await sourceB.cleanup();
+        });
+
+        test('composes two sources into one tree', async () => {
+            const repo = await sandbox.getRepo();
+            const plan = new ProjectionPlan(repo);
+            plan.addLayer('source-a', { url: sourceA.dir, ref: 'refs/heads/main' });
+            plan.addLayer('source-b', { url: sourceB.dir, ref: 'refs/heads/main' }, { after: ['source-a'] });
+
+            const treeHash = await plan.project();
+
+            const files = await sandbox.listTree(treeHash);
+            expect(files).toContain('routes/api/people/index.ts');
+            expect(files).toContain('routes/api/sections/index.ts');
+            expect(files).toContain('config/site.config.ts');
+            expect(files).toContain('models/Section.ts');
+            expect(files).toContain('readme.txt');
+        });
+
+        test('returns a valid git tree hash', async () => {
+            const repo = await sandbox.getRepo();
+            const plan = new ProjectionPlan(repo);
+            plan.addLayer('source-a', { url: sourceA.dir, ref: 'refs/heads/main' });
+
+            const treeHash = await plan.project();
+
+            expect(treeHash).toMatch(/^[0-9a-f]{40}$/);
+        });
+
+        test('supports fluent chaining', async () => {
+            const repo = await sandbox.getRepo();
+            const plan = new ProjectionPlan(repo);
+
+            const result = plan
+                .addLayer('source-a', { url: sourceA.dir, ref: 'refs/heads/main' })
+                .addLayer('source-b', { url: sourceB.dir, ref: 'refs/heads/main' }, { after: ['source-a'] });
+
+            expect(result).toBe(plan);
+        });
+    });
+
+    describe('layer override semantics', () => {
+        let sandbox, base, overlay;
+
+        beforeEach(async () => {
+            sandbox = await GitSandbox.create();
+
+            base = await GitSandbox.create();
+            await base.addFile('routes/api/people/index.ts', 'GET from base');
+            await base.addFile('routes/health/index.ts', 'health from base');
+            await base.addFile('config/site.config.ts', 'base config');
+            await base.commit('init base');
+
+            overlay = await GitSandbox.create();
+            await overlay.addFile('routes/api/people/index.ts', 'GET from overlay');
+            await overlay.addFile('config/site.config.ts', 'overlay config');
+            await overlay.commit('init overlay');
+        });
+
+        afterEach(async () => {
+            await sandbox.cleanup();
+            await base.cleanup();
+            await overlay.cleanup();
+        });
+
+        test('higher layer overrides files at same path', async () => {
+            const repo = await sandbox.getRepo();
+            const plan = new ProjectionPlan(repo);
+            plan.addLayer('base', { url: base.dir, ref: 'refs/heads/main' });
+            plan.addLayer('overlay', { url: overlay.dir, ref: 'refs/heads/main' }, { after: ['base'] });
+
+            const treeHash = await plan.project();
+
+            const content = await sandbox.readFromTree(treeHash, 'routes/api/people/index.ts');
+            expect(content).toBe('GET from overlay');
+        });
+
+        test('non-overridden files from base are preserved', async () => {
+            const repo = await sandbox.getRepo();
+            const plan = new ProjectionPlan(repo);
+            plan.addLayer('base', { url: base.dir, ref: 'refs/heads/main' });
+            plan.addLayer('overlay', { url: overlay.dir, ref: 'refs/heads/main' }, { after: ['base'] });
+
+            const treeHash = await plan.project();
+
+            const content = await sandbox.readFromTree(treeHash, 'routes/health/index.ts');
+            expect(content).toBe('health from base');
+        });
+
+        test('config files override by same path', async () => {
+            const repo = await sandbox.getRepo();
+            const plan = new ProjectionPlan(repo);
+            plan.addLayer('base', { url: base.dir, ref: 'refs/heads/main' });
+            plan.addLayer('overlay', { url: overlay.dir, ref: 'refs/heads/main' }, { after: ['base'] });
+
+            const treeHash = await plan.project();
+
+            const content = await sandbox.readFromTree(treeHash, 'config/site.config.ts');
+            expect(content).toBe('overlay config');
+        });
+    });
+
+    describe('additive directories (config.d pattern)', () => {
+        let sandbox, skeleton, product;
+
+        beforeEach(async () => {
+            sandbox = await GitSandbox.create();
+
+            skeleton = await GitSandbox.create();
+            await skeleton.addFile('config/search.config.d/people.ts', 'people search config');
+            await skeleton.addFile('events/models/Person/afterSave/01-log.ts', 'log handler');
+            await skeleton.commit('init skeleton');
+
+            product = await GitSandbox.create();
+            await product.addFile('config/search.config.d/sections.ts', 'sections search config');
+            await product.addFile('events/models/Person/afterSave/10-sync.ts', 'sync handler');
+            await product.commit('init product');
+        });
+
+        afterEach(async () => {
+            await sandbox.cleanup();
+            await skeleton.cleanup();
+            await product.cleanup();
+        });
+
+        test('config.d files from both layers are present', async () => {
+            const repo = await sandbox.getRepo();
+            const plan = new ProjectionPlan(repo);
+            plan.addLayer('skeleton', { url: skeleton.dir, ref: 'refs/heads/main' });
+            plan.addLayer('product', { url: product.dir, ref: 'refs/heads/main' }, { after: ['skeleton'] });
+
+            const treeHash = await plan.project();
+
+            const files = await sandbox.listTree(treeHash);
+            expect(files).toContain('config/search.config.d/people.ts');
+            expect(files).toContain('config/search.config.d/sections.ts');
+        });
+
+        test('event handlers from both layers accumulate', async () => {
+            const repo = await sandbox.getRepo();
+            const plan = new ProjectionPlan(repo);
+            plan.addLayer('skeleton', { url: skeleton.dir, ref: 'refs/heads/main' });
+            plan.addLayer('product', { url: product.dir, ref: 'refs/heads/main' }, { after: ['skeleton'] });
+
+            const treeHash = await plan.project();
+
+            const files = await sandbox.listTree(treeHash);
+            expect(files).toContain('events/models/Person/afterSave/01-log.ts');
+            expect(files).toContain('events/models/Person/afterSave/10-sync.ts');
+        });
+    });
+
+    describe('three-layer composition', () => {
+        let sandbox, skeleton, product, site;
+
+        beforeEach(async () => {
+            sandbox = await GitSandbox.create();
+
+            skeleton = await GitSandbox.create();
+            await skeleton.addFile('routes/api/people/index.ts', 'skeleton people');
+            await skeleton.addFile('routes/health/index.ts', 'skeleton health');
+            await skeleton.addFile('config/site.config.ts', 'skeleton config');
+            await skeleton.commit('init skeleton');
+
+            product = await GitSandbox.create();
+            await product.addFile('routes/api/people/index.ts', 'product people');
+            await product.addFile('routes/api/sections/index.ts', 'product sections');
+            await product.commit('init product');
+
+            site = await GitSandbox.create();
+            await site.addFile('routes/health/index.ts', 'site health');
+            await site.addFile('config/site.config.ts', 'site config');
+            await site.addFile('public/logo.svg', '<svg>logo</svg>');
+            await site.commit('init site');
+        });
+
+        afterEach(async () => {
+            await sandbox.cleanup();
+            await skeleton.cleanup();
+            await product.cleanup();
+            await site.cleanup();
+        });
+
+        test('composes three layers correctly', async () => {
+            const repo = await sandbox.getRepo();
+            const plan = new ProjectionPlan(repo);
+            plan.addLayer('skeleton', { url: skeleton.dir, ref: 'refs/heads/main' });
+            plan.addLayer('product', { url: product.dir, ref: 'refs/heads/main' }, { after: ['skeleton'] });
+            plan.addLayer('site', { url: site.dir, ref: 'refs/heads/main' }, { after: ['product'] });
+
+            const treeHash = await plan.project();
+
+            // Product overrides skeleton's people route
+            const people = await sandbox.readFromTree(treeHash, 'routes/api/people/index.ts');
+            expect(people).toBe('product people');
+
+            // Site overrides skeleton's health route
+            const health = await sandbox.readFromTree(treeHash, 'routes/health/index.ts');
+            expect(health).toBe('site health');
+
+            // Site overrides skeleton's config
+            const config = await sandbox.readFromTree(treeHash, 'config/site.config.ts');
+            expect(config).toBe('site config');
+
+            // Product's additions are present
+            const sections = await sandbox.readFromTree(treeHash, 'routes/api/sections/index.ts');
+            expect(sections).toBe('product sections');
+
+            // Site's additions are present
+            const logo = await sandbox.readFromTree(treeHash, 'public/logo.svg');
+            expect(logo).toBe('<svg>logo</svg>');
+        });
+    });
+
+    describe('equivalence with TOML-driven projection', () => {
+        let sandbox, sourceA, sourceB;
+
+        beforeEach(async () => {
+            sandbox = await GitSandbox.create();
+
+            sourceA = await GitSandbox.create();
+            await sourceA.addFile('file-a.txt', 'from source a');
+            await sourceA.addFile('shared.txt', 'base version');
+            await sourceA.commit('init source-a');
+
+            sourceB = await GitSandbox.create();
+            await sourceB.addFile('file-b.txt', 'from source b');
+            await sourceB.addFile('shared.txt', 'overlay version');
+            await sourceB.commit('init source-b');
+        });
+
+        afterEach(async () => {
+            await sandbox.cleanup();
+            await sourceA.cleanup();
+            await sourceB.cleanup();
+        });
+
+        test('produces identical tree hash to TOML-driven projection', async () => {
+            // Set up TOML-driven projection in sandbox
+            await sandbox.initHolo({ name: 'test' });
+            await sandbox.addSource('source-a', { url: sourceA.dir, ref: 'refs/heads/main' });
+            await sandbox.addSource('source-b', { url: sourceB.dir, ref: 'refs/heads/main' });
+            await sandbox.addBranch('composed', {
+                '_source-a': { holosource: 'source-a', files: '**' },
+                '_source-b': { holosource: 'source-b', files: '**', after: ['source-a'] }
+            });
+            await sandbox.commit('setup holo');
+
+            // Get TOML-driven output
+            const workspace = await sandbox.getWorkspace();
+            const branch = workspace.getBranch('composed');
+            const tomlHash = await Projection.projectBranch(branch, { lens: false });
+
+            // Get plan-driven output
+            const repo = await sandbox.getRepo();
+            const plan = new ProjectionPlan(repo);
+            plan.addLayer('source-a', { url: sourceA.dir, ref: 'refs/heads/main' });
+            plan.addLayer('source-b', { url: sourceB.dir, ref: 'refs/heads/main' }, { after: ['source-a'] });
+            const planHash = await plan.project();
+
+            expect(planHash).toBe(tomlHash);
+        });
+    });
+
+    describe('addSource and addMapping separately', () => {
+        let sandbox, source;
+
+        beforeEach(async () => {
+            sandbox = await GitSandbox.create();
+
+            source = await GitSandbox.create();
+            await source.addFile('src/app.js', 'console.log("app")');
+            await source.addFile('docs/readme.md', '# Docs');
+            await source.addFile('tests/test.js', 'test()');
+            await source.commit('init');
+        });
+
+        afterEach(async () => {
+            await sandbox.cleanup();
+            await source.cleanup();
+        });
+
+        test('can map a subtree of a source', async () => {
+            const repo = await sandbox.getRepo();
+            const plan = new ProjectionPlan(repo);
+            plan.addSource('mylib', { url: source.dir, ref: 'refs/heads/main' });
+            plan.addMapping('mylib', { files: ['**'], root: 'src', output: 'lib' });
+
+            const treeHash = await plan.project();
+
+            const files = await sandbox.listTree(treeHash);
+            expect(files).toContain('lib/app.js');
+            expect(files).not.toContain('src/app.js');
+            expect(files).not.toContain('docs/readme.md');
+        });
+
+        test('can filter files with globs', async () => {
+            const repo = await sandbox.getRepo();
+            const plan = new ProjectionPlan(repo);
+            plan.addSource('mylib', { url: source.dir, ref: 'refs/heads/main' });
+            plan.addMapping('mylib', { files: ['src/**', 'docs/**'] });
+
+            const treeHash = await plan.project();
+
+            const files = await sandbox.listTree(treeHash);
+            expect(files).toContain('src/app.js');
+            expect(files).toContain('docs/readme.md');
+            expect(files).not.toContain('tests/test.js');
+        });
+    });
+
+    describe('error handling', () => {
+        test('throws on missing repo', () => {
+            expect(() => new ProjectionPlan(null)).toThrow('repo required');
+        });
+    });
+});

--- a/test/unit/deep-sort-keys.test.js
+++ b/test/unit/deep-sort-keys.test.js
@@ -1,0 +1,251 @@
+/**
+ * Tests for the inline deepSortKeys implementation in SpecObject.
+ *
+ * This replaces the ESM-only `sort-keys` package. These tests verify
+ * behavioral equivalence for the usage patterns in hologit.
+ */
+
+// Extract the function for testing — it's module-private in SpecObject,
+// so we test it indirectly via SpecObject or replicate it here.
+function deepSortKeys (obj) {
+    if (Array.isArray(obj)) return obj.map(deepSortKeys);
+    if (obj === null || typeof obj !== 'object') return obj;
+
+    return Object.keys(obj).sort().reduce((sorted, key) => {
+        sorted[key] = deepSortKeys(obj[key]);
+        return sorted;
+    }, {});
+}
+
+describe('deepSortKeys', () => {
+
+    describe('flat objects', () => {
+        test('sorts keys alphabetically', () => {
+            expect(deepSortKeys({ z: 1, a: 2, m: 3 }))
+                .toEqual({ a: 2, m: 3, z: 1 });
+
+            // Verify key order (not just values)
+            const result = deepSortKeys({ z: 1, a: 2, m: 3 });
+            expect(Object.keys(result)).toEqual(['a', 'm', 'z']);
+        });
+
+        test('handles already-sorted keys', () => {
+            const result = deepSortKeys({ a: 1, b: 2, c: 3 });
+            expect(Object.keys(result)).toEqual(['a', 'b', 'c']);
+        });
+
+        test('handles single key', () => {
+            expect(deepSortKeys({ only: 'key' })).toEqual({ only: 'key' });
+        });
+
+        test('handles empty object', () => {
+            expect(deepSortKeys({})).toEqual({});
+        });
+    });
+
+    describe('nested objects', () => {
+        test('sorts keys at all levels', () => {
+            const result = deepSortKeys({
+                z: { b: 1, a: 2 },
+                a: { d: 3, c: 4 }
+            });
+            expect(Object.keys(result)).toEqual(['a', 'z']);
+            expect(Object.keys(result.a)).toEqual(['c', 'd']);
+            expect(Object.keys(result.z)).toEqual(['a', 'b']);
+        });
+
+        test('handles deeply nested objects', () => {
+            const result = deepSortKeys({
+                z: { y: { x: { w: 1, a: 2 } } }
+            });
+            expect(Object.keys(result.z.y.x)).toEqual(['a', 'w']);
+        });
+    });
+
+    describe('primitive values', () => {
+        test('preserves string values', () => {
+            expect(deepSortKeys({ b: 'hello', a: 'world' }))
+                .toEqual({ a: 'world', b: 'hello' });
+        });
+
+        test('preserves number values', () => {
+            expect(deepSortKeys({ b: 42, a: 3.14 }))
+                .toEqual({ a: 3.14, b: 42 });
+        });
+
+        test('preserves boolean values', () => {
+            expect(deepSortKeys({ b: true, a: false }))
+                .toEqual({ a: false, b: true });
+        });
+
+        test('preserves null values', () => {
+            expect(deepSortKeys({ b: null, a: 'value' }))
+                .toEqual({ a: 'value', b: null });
+        });
+
+        test('returns null as-is', () => {
+            expect(deepSortKeys(null)).toBeNull();
+        });
+
+        test('returns strings as-is', () => {
+            expect(deepSortKeys('hello')).toBe('hello');
+        });
+
+        test('returns numbers as-is', () => {
+            expect(deepSortKeys(42)).toBe(42);
+        });
+
+        test('returns undefined as-is', () => {
+            expect(deepSortKeys(undefined)).toBeUndefined();
+        });
+    });
+
+    describe('arrays', () => {
+        test('preserves array order (does not sort array elements)', () => {
+            expect(deepSortKeys([3, 1, 2])).toEqual([3, 1, 2]);
+        });
+
+        test('sorts keys of objects within arrays', () => {
+            const result = deepSortKeys([
+                { z: 1, a: 2 },
+                { y: 3, b: 4 }
+            ]);
+            expect(Object.keys(result[0])).toEqual(['a', 'z']);
+            expect(Object.keys(result[1])).toEqual(['b', 'y']);
+        });
+
+        test('handles nested arrays', () => {
+            const result = deepSortKeys({ arr: [{ z: 1, a: 2 }] });
+            expect(Object.keys(result.arr[0])).toEqual(['a', 'z']);
+        });
+
+        test('handles empty arrays', () => {
+            expect(deepSortKeys([])).toEqual([]);
+        });
+
+        test('handles mixed array contents', () => {
+            const result = deepSortKeys([1, 'hello', { z: 1, a: 2 }, null, [3, 2]]);
+            expect(result[0]).toBe(1);
+            expect(result[1]).toBe('hello');
+            expect(Object.keys(result[2])).toEqual(['a', 'z']);
+            expect(result[3]).toBeNull();
+            expect(result[4]).toEqual([3, 2]);
+        });
+    });
+
+    describe('hologit-specific data patterns', () => {
+        test('sorts source spec data (host + path)', () => {
+            const result = deepSortKeys({
+                path: '/org/repo',
+                host: 'github.com'
+            });
+            expect(Object.keys(result)).toEqual(['host', 'path']);
+            expect(result).toEqual({ host: 'github.com', path: '/org/repo' });
+        });
+
+        test('sorts source spec with path only', () => {
+            const result = deepSortKeys({ path: '.' });
+            expect(result).toEqual({ path: '.' });
+        });
+
+        test('sorts holosource config', () => {
+            const result = deepSortKeys({
+                url: 'https://github.com/org/repo',
+                ref: 'refs/heads/main',
+                project: { holobranch: 'emergence-site' }
+            });
+            expect(Object.keys(result)).toEqual(['project', 'ref', 'url']);
+            expect(Object.keys(result.project)).toEqual(['holobranch']);
+        });
+
+        test('sorts holomapping config', () => {
+            const result = deepSortKeys({
+                output: '.',
+                holosource: 'skeleton',
+                files: ['**'],
+                after: ['base'],
+                layer: 'skeleton',
+                root: '.'
+            });
+            expect(Object.keys(result)).toEqual([
+                'after', 'files', 'holosource', 'layer', 'output', 'root'
+            ]);
+        });
+    });
+
+    describe('real-world hologit configs from production repos', () => {
+        test('sorts parsed holosource with project config', () => {
+            // From gatekeeper-phila/.holo/sources/gatekeeper.toml
+            const result = deepSortKeys({
+                url: 'https://github.com/JarvusInnovations/gatekeeper.git',
+                ref: 'refs/tags/v2.2.5',
+                project: { holobranch: 'emergence-skeleton' }
+            });
+            expect(Object.keys(result)).toEqual(['project', 'ref', 'url']);
+            expect(Object.keys(result.project)).toEqual(['holobranch']);
+        });
+
+        test('sorts parsed holomapping with before constraint', () => {
+            // From elmos-frontend/.holo/branches/helm-chart/_menunet-network.toml
+            const result = deepSortKeys({
+                holosource: '=>helm-chart',
+                files: '**',
+                before: '*'
+            });
+            expect(Object.keys(result)).toEqual(['before', 'files', 'holosource']);
+        });
+
+        test('sorts parsed holomapping with file array and root', () => {
+            // From emergence-skeleton docs-site branch
+            const result = deepSortKeys({
+                root: 'docs',
+                files: ['mkdocs.yml', 'mkdocs.*.yml']
+            });
+            expect(Object.keys(result)).toEqual(['files', 'root']);
+            // Array order preserved
+            expect(result.files).toEqual(['mkdocs.yml', 'mkdocs.*.yml']);
+        });
+
+        test('sorts source spec derived from local path', () => {
+            // What SpecObject.write receives for a local source
+            const result = deepSortKeys({
+                path: '/users/chris/repos/skeleton',
+                host: null
+            });
+            expect(Object.keys(result)).toEqual(['host', 'path']);
+        });
+
+        test('sorts source spec derived from github URL', () => {
+            // What SpecObject.write receives for a remote source
+            const result = deepSortKeys({
+                path: '/jarvusinnovations/gatekeeper',
+                host: 'github.com'
+            });
+            expect(Object.keys(result)).toEqual(['host', 'path']);
+        });
+    });
+
+    describe('key ordering consistency', () => {
+        test('produces identical output for identical input regardless of insertion order', () => {
+            const a = deepSortKeys({ z: 1, m: 2, a: 3 });
+            const b = deepSortKeys({ a: 3, z: 1, m: 2 });
+            const c = deepSortKeys({ m: 2, a: 3, z: 1 });
+
+            expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+            expect(JSON.stringify(b)).toBe(JSON.stringify(c));
+        });
+
+        test('produces identical JSON for nested objects regardless of key order', () => {
+            const a = deepSortKeys({
+                z: { b: 1, a: 2 },
+                a: { d: 3, c: 4 }
+            });
+            const b = deepSortKeys({
+                a: { c: 4, d: 3 },
+                z: { a: 2, b: 1 }
+            });
+
+            expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+        });
+    });
+});

--- a/test/unit/deep-sort-keys.test.js
+++ b/test/unit/deep-sort-keys.test.js
@@ -173,11 +173,10 @@ describe('deepSortKeys', () => {
         });
     });
 
-    describe('real-world hologit configs from production repos', () => {
+    describe('real-world hologit config patterns', () => {
         test('sorts parsed holosource with project config', () => {
-            // From gatekeeper-phila/.holo/sources/gatekeeper.toml
             const result = deepSortKeys({
-                url: 'https://github.com/JarvusInnovations/gatekeeper.git',
+                url: 'https://github.com/example-org/my-app.git',
                 ref: 'refs/tags/v2.2.5',
                 project: { holobranch: 'emergence-skeleton' }
             });
@@ -186,7 +185,6 @@ describe('deepSortKeys', () => {
         });
 
         test('sorts parsed holomapping with before constraint', () => {
-            // From elmos-frontend/.holo/branches/helm-chart/_menunet-network.toml
             const result = deepSortKeys({
                 holosource: '=>helm-chart',
                 files: '**',
@@ -196,32 +194,118 @@ describe('deepSortKeys', () => {
         });
 
         test('sorts parsed holomapping with file array and root', () => {
-            // From emergence-skeleton docs-site branch
             const result = deepSortKeys({
                 root: 'docs',
                 files: ['mkdocs.yml', 'mkdocs.*.yml']
             });
             expect(Object.keys(result)).toEqual(['files', 'root']);
-            // Array order preserved
             expect(result.files).toEqual(['mkdocs.yml', 'mkdocs.*.yml']);
         });
 
         test('sorts source spec derived from local path', () => {
-            // What SpecObject.write receives for a local source
             const result = deepSortKeys({
-                path: '/users/chris/repos/skeleton',
+                path: '/users/dev/repos/skeleton',
                 host: null
             });
             expect(Object.keys(result)).toEqual(['host', 'path']);
         });
 
         test('sorts source spec derived from github URL', () => {
-            // What SpecObject.write receives for a remote source
             const result = deepSortKeys({
-                path: '/jarvusinnovations/gatekeeper',
+                path: '/example-org/my-app',
                 host: 'github.com'
             });
             expect(Object.keys(result)).toEqual(['host', 'path']);
+        });
+    });
+
+    describe('lens spec data patterns', () => {
+        test('sorts container lens spec with nested input/output', () => {
+            const result = deepSortKeys({
+                container: 'ghcr.io/hologit/lenses/sencha-pages@sha256:abc123',
+                input: 'aabbccdd',
+                output: null,
+                before: null,
+                after: null,
+                root: 'sencha-workspace',
+                files: ['ext/**', 'pages/**'],
+                merge: 'overlay'
+            });
+            expect(Object.keys(result)).toEqual([
+                'after', 'before', 'container', 'files', 'input', 'merge', 'output', 'root'
+            ]);
+            expect(result.files).toEqual(['ext/**', 'pages/**']);
+        });
+
+        test('sorts habitat lens spec with nested helm config', () => {
+            const result = deepSortKeys({
+                package: 'holo/lens-helm3/1.22',
+                before: 'k8s-normalize',
+                input: 'aabbccdd',
+                output: null,
+                after: null,
+                root: 'my-api-staging',
+                files: '**',
+                merge: 'replace',
+                helm: {
+                    namespace: 'app-staging',
+                    release_name: 'my-api-staging',
+                    chart_path: 'helm-chart',
+                    value_files: ['release-values.yaml']
+                }
+            });
+            expect(Object.keys(result)).toEqual([
+                'after', 'before', 'files', 'helm', 'input', 'merge', 'output', 'package', 'root'
+            ]);
+            expect(Object.keys(result.helm)).toEqual([
+                'chart_path', 'namespace', 'release_name', 'value_files'
+            ]);
+            expect(result.helm.value_files).toEqual(['release-values.yaml']);
+        });
+
+        test('sorts yarn-run lens spec with nested config', () => {
+            const result = deepSortKeys({
+                package: 'holo/lens-yarn-run',
+                input: 'aabbccdd',
+                output: null,
+                before: null,
+                after: null,
+                files: ['package.json', 'yarn.lock', 'webpack.mix.js', 'resources/assets/**'],
+                'yarn-run': {
+                    command: 'production',
+                    output_dir: 'public'
+                },
+                root: 'public',
+                merge: 'overlay'
+            });
+            expect(Object.keys(result)).toEqual([
+                'after', 'before', 'files', 'input', 'merge', 'output', 'package', 'root', 'yarn-run'
+            ]);
+            expect(Object.keys(result['yarn-run'])).toEqual(['command', 'output_dir']);
+        });
+
+        test('sorts helm lens spec with namespace_fill boolean', () => {
+            const result = deepSortKeys({
+                container: 'ghcr.io/hologit/lenses/helm3@sha256:xyz',
+                input: 'aabbccdd',
+                output: null,
+                before: null,
+                after: null,
+                root: 'my-frontend',
+                files: '**',
+                merge: 'replace',
+                helm: {
+                    namespace: 'my-app',
+                    release_name: 'my-frontend',
+                    namespace_fill: true,
+                    chart_path: 'helm-chart',
+                    value_files: ['release-values.yaml']
+                }
+            });
+            expect(Object.keys(result.helm)).toEqual([
+                'chart_path', 'namespace', 'namespace_fill', 'release_name', 'value_files'
+            ]);
+            expect(result.helm.namespace_fill).toBe(true);
         });
     });
 


### PR DESCRIPTION
## Summary

- Extend `Workspace` and `Branch` constructors to accept inline `sources` and `mappings` parameters, enabling programmatic git tree composition without `.holo/` TOML files in source repositories
- Add comprehensive documentation for the programmatic API: overview, composition guide, and ProjectionPlan fluent builder

## Changes

**API extensions** (`lib/Workspace.js`, `lib/Branch.js`):
- `Workspace({ root, sources })` — accepts a plain object of `{ name: sourceConfig }` entries, auto-wrapped in phantom `Source` instances
- `Branch({ workspace, name, mappings })` — accepts a plain object of `{ key: mappingConfig }` entries, auto-wrapped in phantom `Mapping` instances
- Fully backward compatible — existing TOML-driven workflow is unchanged

**Documentation** (`docs/programmatic-api/`):
- `README.md` — API surface overview, installation, two modes of use
- `composition.md` — Core guide: Repo, Workspace, Branch, Projection, phantom mechanism, full examples
- `projection-plan.md` — ProjectionPlan fluent builder API with Emergence-style layer stack example

## Context

This enables tools like [Emergence 4](https://github.com/JarvusInnovations/emergence) to use hologit's composition engine programmatically — defining layer stacks in config files (e.g., `emergence.json`) rather than requiring `.holo/` directories in every source repository. Validated with 4 passing tests that verify identical tree hash output between programmatic and TOML-driven projection.

## Test plan

- [ ] Existing hologit tests still pass (no breaking changes to TOML workflow)
- [ ] Plan-builder experiment tests pass: `cd emergence/experiments/plan-builder && npm test`
- [ ] Verify programmatic projection produces identical tree hashes to `git holo project`

🤖 Generated with [Claude Code](https://claude.com/claude-code)