### PR TITLE
fix: disable auto-gc during source fetches to avoid shallow-file race

### DIFF
--- a/github-actions/projector/index.js
+++ b/github-actions/projector/index.js
@@ -59,6 +59,10 @@ async function run() {
                 'origin',
                 `https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git`
             ]);
+            // Disable auto-gc to prevent races on .git/shallow during shallow
+            // source fetches. See https://github.com/JarvusInnovations/hologit/issues/450
+            await gitExec('config', ['gc.auto', '0']);
+            await gitExec('config', ['maintenance.auto', 'false']);
         } catch (err) {
             core.setFailed(`Failed to initialize git repository: ${err.message}`);
             return;

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -404,7 +404,20 @@ class Source extends Configurable {
 
         const git = await repo.getGit();
         const { ref: specRef } = await this.getCachedSpec();
-        await git.fetch({ depth, unshallow, tags: false }, url, ...refs.map(ref => `+${ref}:${specRef}/${ref.substr(5)}`));
+
+        // Disable auto-gc for this fetch: git's background `gc --auto` may rewrite
+        // .git/shallow concurrently with a later shallow fetch, causing
+        // `fatal: shallow file has changed since we read it`. See issue #450.
+        await git.fetch(
+            {
+                depth,
+                unshallow,
+                tags: false,
+                $config: { 'gc.auto': '0', 'maintenance.auto': 'false' },
+            },
+            url,
+            ...refs.map(ref => `+${ref}:${specRef}/${ref.substr(5)}`),
+        );
 
         return {
             refs: refs.map(ref => `${specRef}/${ref.substr(5)}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "chokidar": "^5.0.0",
         "debounce": "^3.0.0",
         "fb-watchman": "^2.0.2",
-        "git-client": "^1.11.1",
+        "git-client": "^1.12.0",
         "hab-client": "^1.1.3",
         "handlebars": "^4.7.9",
         "minimatch": "^10.2.4",
@@ -2660,9 +2660,9 @@
       }
     },
     "node_modules/git-client": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/git-client/-/git-client-1.11.1.tgz",
-      "integrity": "sha512-N3tsTCjaELPf3HiAI+Fg4ua74hRl6AT1v6EICbhvykg0pnAXfWqdjGXOY5TgA99r555N2SOtqIgKuwluB9F5kQ==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/git-client/-/git-client-1.12.1.tgz",
+      "integrity": "sha512-Px7HE2ug+IKiOhNE/vezkwpDE7IUYHnoRHQfds2BlRf6CZglNq7lmlxVoRtprJ4ZHTq0ZWrQLZtrcMxFw18zvw==",
       "license": "MIT",
       "dependencies": {
         "async-exit-hook": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "chokidar": "^5.0.0",
     "debounce": "^3.0.0",
     "fb-watchman": "^2.0.2",
-    "git-client": "^1.11.1",
+    "git-client": "^1.12.0",
     "hab-client": "^1.1.3",
     "handlebars": "^4.7.9",
     "minimatch": "^10.2.4",


### PR DESCRIPTION
## Summary

Closes #450.

`fatal: shallow file has changed since we read it` was failing most CFP CI runs. The original issue suggested a mutex around `Source.fetch()` to serialize concurrent fetches — but tracing the failing log against `Branch.composite()` shows fetches are already sequential within a single Node.js process. The race isn't between hologit's own fetches.

It's between a fetch and git's **background auto-gc**:

1. Each `git fetch` ends by invoking `git maintenance run --auto` / `gc --auto`.
2. With `gc.autoDetach=true` (the default), gc forks to the background and `fetch` returns.
3. The next shallow `git fetch` starts and reads `.git/shallow`.
4. Background gc rewrites `.git/shallow` while pruning unreachable shallow commits.
5. The new fetch goes to commit its shallow update, re-reads, sees the file changed, aborts.

This matches every observed symptom: intermittent; rate climbs with source count (loose objects accumulate faster, crossing `gc.auto=6700`); got worse after container-lens introduction (lens server push/fetch dumps more loose objects into the same git-dir); retries always pass because gc finishes between runs.

## Changes

- **`lib/Source.js`** — pass `$config: { 'gc.auto': '0', 'maintenance.auto': 'false' }` to `git.fetch(...)`. Process-local, no on-disk config mutation. Requires git-client `^1.12.0` ([JarvusInnovations/git-client#58](https://github.com/JarvusInnovations/git-client/pull/58)).
- **`github-actions/projector/index.js`** — set `gc.auto=0` and `maintenance.auto=false` on the bare repo right after `git init --bare`. Belt-and-suspenders for the GitHub action wrapper.
- **`package.json`** — bump git-client floor to `^1.12.0`.

## Dependency

This PR depends on a published [`git-client@1.12.0`](https://github.com/JarvusInnovations/git-client/pull/58). Hold the merge until that lands and is on npm.

## Test plan

- [x] `npx jest` — all 85 tests pass with a locally-linked git-client@1.12.0
- [x] `node bin/cli.js project github-action-projector` — projection succeeds
- [x] `node bin/cli.js project docs-site --lens=false` — projection succeeds
- [ ] On the next CFP CI run after release: confirm shallow-file errors are gone
- [ ] Manually verify `test-cli` workflow in `.github/workflows/pr-test.yml` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)