### PR TITLE
chore(ci): try publishing via a newer node version

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -15,13 +15,11 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
-        node-version: '22.x'
+        node-version: '24'
         registry-url: 'https://registry.npmjs.org'
-
-    - name: Upgrade npm for trusted publishing
-      run: npm install -g npm@latest
+        package-manager-cache: false  # never use caching in release builds
 
     - name: Place tag in environment
       run: |


### PR DESCRIPTION
The bundled npm in the Node 22 toolcache is broken — `npm install -g npm@latest` in the publish workflow fails with `Cannot find module 'promise-retry'`. Already bit gitsheets and git-client.

Same fix as [JarvusInnovations/gitsheets@4784e80](https://github.com/JarvusInnovations/gitsheets/commit/4784e803b0965e166387366b5e87bb4977259755) and [JarvusInnovations/git-client#59](https://github.com/JarvusInnovations/git-client/pull/59):

- `actions/setup-node` v4 → v6
- `node-version` 22.x → 24 (ships a working npm new enough for trusted publishing)
- `package-manager-cache: false` (never cache in release builds)
- Drop the `npm install -g npm@latest` step — no longer needed

## Order of operations

This needs to land on `develop` **before** the v0.50.0 release PR (#426) merges to master, otherwise the v0.50.0 tag commit won't include the fix and `publish-npm` will fail (it runs the workflow file at the tag's ref).

After merge: rebase #426 onto the new `develop`, then merge #426 → tag → publish succeeds.