### PR TITLE
feat(tree): O(1) clearChildren() — point a subtree at the empty-tree

### DIFF
--- a/lib/TreeObject.js
+++ b/lib/TreeObject.js
@@ -294,6 +294,32 @@ class TreeObject {
         }
     }
 
+    /**
+     * Drop every child of this tree — both pending and base — in O(1).
+     *
+     * Semantically equivalent to calling `deleteChild` for each entry, but
+     * operates on the in-memory child maps directly so it doesn't pay for
+     * N tree mutations to produce a state that just says "this subtree is
+     * empty." The serialized result is the canonical empty-tree hash
+     * (`4b825dc642cb6eb9a060e54bf8d69288fbee4904`) — what `write()` already
+     * skips when emitting parent entries.
+     *
+     * Consumers that "clear then rewrite" — snapshot importers in
+     * particular — get a constant-time clear regardless of the prior size
+     * of the subtree.
+     */
+    clearChildren () {
+        // Replace _children with a fresh map AND set _baseChildren to an
+        // empty object so a subsequent getChildren() / write() doesn't
+        // lazy-load the previous git tree's entries through the prototype
+        // chain. Object.seal in the constructor permits value reassignment;
+        // it only blocks add/remove of properties.
+        this._baseChildren = {};
+        this._children = {};
+        Object.setPrototypeOf(this._children, this._baseChildren);
+        this.markDirty();
+    }
+
     async getSubtree (subtreePath, create = false) {
         const stack = await this.getSubtreeStack(...arguments);
         return stack && stack[stack.length - 1] || null;

--- a/test/unit/tree-clear-children.test.js
+++ b/test/unit/tree-clear-children.test.js
@@ -1,0 +1,134 @@
+/**
+ * TreeObject.clearChildren() Unit Tests
+ *
+ * Covers the O(1) "drop everything under this subtree" operation —
+ * semantically equivalent to deleteChild per-entry but constant-time
+ * regardless of subtree size.
+ */
+
+const GitSandbox = require('../helpers/git-sandbox.js');
+
+const EMPTY_TREE_HASH = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+
+// TreeObject._children stores pending edits as own properties and lazy-
+// loaded base children on the prototype chain. `Object.keys` only sees
+// own properties; this helper walks the chain via `for...in` to surface
+// every name an entry has, then filters out names with falsy (null /
+// deleted) values — matching what `write()` does internally.
+function visibleNames(children) {
+    const names = [];
+    for (const name in children) {
+        if (children[name]) names.push(name);
+    }
+    return names.sort();
+}
+
+describe('TreeObject.clearChildren', () => {
+    let sandbox;
+
+    beforeEach(async () => {
+        sandbox = await GitSandbox.create();
+    });
+
+    afterEach(async () => {
+        await sandbox.cleanup();
+    });
+
+    test('serialized hash of a cleared tree is EMPTY_TREE_HASH', async () => {
+        await sandbox.addFile('a.txt', 'a');
+        await sandbox.addFile('b.txt', 'b');
+        await sandbox.addFile('c.txt', 'c');
+        await sandbox.commit('three files');
+
+        const repo = await sandbox.getRepo();
+        const tree = await repo.createTreeFromRef('HEAD');
+
+        // Sanity: tree is non-empty before clearing.
+        const before = await tree.getChildren();
+        expect(visibleNames(before).length).toBeGreaterThanOrEqual(3);
+
+        tree.clearChildren();
+        const hash = await tree.getHash();
+
+        expect(hash).toBe(EMPTY_TREE_HASH);
+    });
+
+    test('getChildren returns no entries after clearChildren', async () => {
+        await sandbox.addFile('a.txt', 'a');
+        await sandbox.addFile('b.txt', 'b');
+        await sandbox.commit('two files');
+
+        const repo = await sandbox.getRepo();
+        const tree = await repo.createTreeFromRef('HEAD');
+
+        tree.clearChildren();
+        const children = await tree.getChildren();
+
+        expect(visibleNames(children)).toEqual([]);
+    });
+
+    test('does not depend on _baseChildren having been loaded first', async () => {
+        // Important: this test calls clearChildren BEFORE any operation
+        // that would have loaded the base children from the git tree.
+        // The clear should still produce an empty result.
+        await sandbox.addFile('a.txt', 'a');
+        await sandbox.addFile('b.txt', 'b');
+        await sandbox.commit('two files');
+
+        const repo = await sandbox.getRepo();
+        const tree = await repo.createTreeFromRef('HEAD');
+
+        // No prior getChildren / getBlobMap / getChild — base children
+        // were never lazy-loaded.
+        tree.clearChildren();
+        expect(await tree.getHash()).toBe(EMPTY_TREE_HASH);
+    });
+
+    test('writeChild after clearChildren leaves only the new content', async () => {
+        await sandbox.addFile('old-a.txt', 'a');
+        await sandbox.addFile('old-b.txt', 'b');
+        await sandbox.commit('old');
+
+        const repo = await sandbox.getRepo();
+        const tree = await repo.createTreeFromRef('HEAD');
+
+        tree.clearChildren();
+        await tree.writeChild('new.txt', 'new content');
+
+        const children = await tree.getChildren();
+        expect(visibleNames(children)).toEqual(['new.txt']);
+    });
+
+    test('subtree clear propagates dirty to parent', async () => {
+        await sandbox.addFile('keep/keep.txt', 'k');
+        await sandbox.addFile('drop/a.txt', 'a');
+        await sandbox.addFile('drop/b.txt', 'b');
+        await sandbox.commit('seed');
+
+        const repo = await sandbox.getRepo();
+        const root = await repo.createTreeFromRef('HEAD');
+        const drop = await root.getSubtree('drop', false);
+        expect(drop).not.toBeNull();
+
+        drop.clearChildren();
+        expect(drop.dirty).toBe(true);
+        expect(root.dirty).toBe(true);
+
+        // Writing the parent produces a tree containing only 'keep/'.
+        const rootHash = await root.getHash();
+        const rebuilt = await repo.createTreeFromRef(rootHash);
+        const rebuiltChildren = await rebuilt.getChildren();
+        expect(visibleNames(rebuiltChildren)).toEqual(['keep']);
+    });
+
+    test('clearing an already-empty tree is a safe no-op', async () => {
+        await sandbox.commit('empty');
+
+        const repo = await sandbox.getRepo();
+        const tree = await repo.createTreeFromRef('HEAD');
+
+        // Should not throw, and the hash stays at the empty-tree value.
+        tree.clearChildren();
+        expect(await tree.getHash()).toBe(EMPTY_TREE_HASH);
+    });
+});


### PR DESCRIPTION
## Summary

Adds `TreeObject.clearChildren()` — an O(1) "drop everything under this subtree" operation, semantically equivalent to enumerating and deleteChild-ing each entry but constant-time regardless of size.

Motivated by [JarvusInnovations/gitsheets#178](https://github.com/JarvusInnovations/gitsheets/issues/178): `Sheet#clear()` currently walks the sheet's subtree and does ~N tree mutations to produce a state that's semantically just "the empty tree." For snapshot-importer workflows on multi-tens-of-thousands-of-records sheets (the laddr ingest case in #178), the throwaway tree work dominates the import. With `clearChildren()` available, gitsheets's `Sheet#clear()` reduces to a one-line call.

## How it works

```js
clearChildren () {
    this._baseChildren = {};
    this._children = {};
    Object.setPrototypeOf(this._children, this._baseChildren);
    this.markDirty();
}
```

Three things in concert:

- **`_baseChildren = {}`** prevents `_loadBaseChildren()` from repopulating the previous git tree's entries through the prototype chain.
- **`_children = {}`** clears any pending edits.
- **`setPrototypeOf`** restores the `_children` → `_baseChildren` link so subsequent `for...in` enumeration (which `write()` uses) sees no entries.
- **`markDirty()`** propagates dirty up the parent chain so a subtree clear shows up in the rebuilt parent tree.

`Object.seal()` in the constructor permits these reassignments — it only blocks add/remove of properties, not value changes.

## What it produces

The serialized result is `4b825dc642cb6eb9a060e54bf8d69288fbee4904` (git's canonical empty-tree hash), which `write()` already skips when emitting parent entries. So a cleared subtree disappears from the committed tree, same as if it had been emptied via repeated `deleteChild`.

## Tests

6 unit tests in `test/unit/tree-clear-children.test.js`:

- Serialized hash equals `EMPTY_TREE_HASH`
- `getChildren()` returns no entries after clear (walks prototype chain via for...in, which `write()` does too)
- Works without prior `_baseChildren` lazy-load (i.e. clear on a fresh `createTreeFromRef` without any `getChildren` first)
- `writeChild` after clear leaves only the new content
- Subtree clear propagates dirty to parent (verified by rebuilding the parent's hash and confirming only sibling subtrees remain)
- Clearing an already-empty tree is a safe no-op

## Test plan

- [x] `npm test` — 91 tests pass (85 prior + 6 new)
- [x] No existing tests touched
- [x] CI green on this PR

Pairs with a small follow-up PR on gitsheets that swaps `Sheet#clear()`'s `deleteChild` loop for `await sheetTree.clearChildren()`. That PR will wait on this landing + a hologit release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)