### PR TITLE
fix(types): declare TreeObject.clearChildren() in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -136,6 +136,7 @@ declare module 'hologit' {
         getChildren(): Promise<{ [key: string]: TreeObject | BlobObject | CommitObject }>;
         getBlobMap(): Promise<{ [key: string]: BlobObject }>;
         deleteChild(childPath: string): Promise<void>;
+        clearChildren(): void;
         getSubtree(subtreePath: string, create?: boolean): Promise<TreeObject | null>;
         getSubtreeStack(subtreePath: string, create?: boolean): Promise<TreeObject[] | null>;
         write(): Promise<string>;


### PR DESCRIPTION
## Summary

Follow-up to #455 — the JS method shipped without a corresponding type declaration in the bundled \`index.d.ts\`, so TypeScript consumers (e.g. gitsheets) get \`Property 'clearChildren' does not exist on type 'TreeObject'\` and have to add a local module-augmentation block or cast to \`any\`.

Two-line fix; no behavior change. Ready to release as v0.50.2.

## Test plan

- [x] \`npm test\` — 91 tests still pass (no behavioral surface touched)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)