### PR TITLE
fix(holo-tree): root-level write_child panics on lazily-loaded tree

### DIFF
--- a/holo-tree/src/tree.rs
+++ b/holo-tree/src/tree.rs
@@ -338,6 +338,14 @@ impl MutableTree {
         path: &str,
     ) -> Result<&mut MutableTree> {
         if path == "." || path.is_empty() {
+            // Destination is the root itself. Mark dirty and load its children
+            // so a mutating caller (e.g. write_child_bytes for a repo-root file
+            // like "a.toml", whose dir is ".") can insert alongside existing
+            // entries — rather than panic on `children.as_mut().unwrap()` when
+            // the root was lazily loaded from a ref. Same postcondition as the
+            // deep-path return below.
+            self.dirty = true;
+            self.ensure_children(repo)?;
             return Ok(self);
         }
 

--- a/holo-tree/tests/write_child.rs
+++ b/holo-tree/tests/write_child.rs
@@ -55,3 +55,46 @@ fn write_child_into_fresh_subtree_still_works() {
         Some(&b"id = 1\n"[..]),
     );
 }
+
+/// Regression: writing a file at the REPO ROOT (dir = ".") into a lazily-loaded
+/// tree must load the root's children rather than panic on
+/// `children.as_mut().unwrap()`. The earlier fix only covered deep paths; the
+/// `path == "."` early-return in get_or_create_subtree bypassed it. Surfaced by
+/// install-testing the published binding with a root-level `writeChild`.
+#[test]
+fn write_child_at_repo_root_preserves_siblings() {
+    let sb = Sandbox::new();
+
+    // Committed tree with a root-level file; reload it lazily (children: None).
+    let base = sb.write_tree(&[("existing.toml", "id = 0\n")]);
+    let mut tree = MutableTree::new(base);
+
+    tree.write_child(&sb.repo, "new.toml", "id = 1\n").unwrap();
+    let hash = tree.write(&sb.repo).unwrap();
+    assert_ne!(hash, base, "a root-level write must change the tree hash");
+
+    let mut reloaded = MutableTree::new(hash);
+    assert_eq!(
+        reloaded.read_blob(&sb.repo, "existing.toml").unwrap().as_deref(),
+        Some(&b"id = 0\n"[..]),
+        "existing root sibling must be preserved",
+    );
+    assert_eq!(
+        reloaded.read_blob(&sb.repo, "new.toml").unwrap().as_deref(),
+        Some(&b"id = 1\n"[..]),
+    );
+}
+
+#[test]
+fn write_child_at_repo_root_into_empty() {
+    let sb = Sandbox::new();
+    let mut tree = MutableTree::empty();
+    tree.write_child(&sb.repo, "only.toml", "id = 1\n").unwrap();
+    let hash = tree.write(&sb.repo).unwrap();
+
+    let mut reloaded = MutableTree::new(hash);
+    assert_eq!(
+        reloaded.read_blob(&sb.repo, "only.toml").unwrap().as_deref(),
+        Some(&b"id = 1\n"[..]),
+    );
+}


### PR DESCRIPTION
## The bug

`get_or_create_subtree`'s `path == "."` early-return returned `self` without
loading its children. So `write_child` for a **repo-root** file (e.g. `a.toml`,
whose dir is `"."`) hit `children.as_mut().unwrap()` on a `None` — and since it's
called across the napi FFI boundary, the panic **aborts the host process**.

The earlier subtree fix (#465) only covered *deep* paths; the `"."` early-return
bypassed it.

## How it surfaced

Install-testing the freshly published `@hologit/holo-tree@0.1.0`: a clean
`npm install` + a **root-level** `writeChild('a.toml', ...)` round-trip aborted
with `fatal runtime error`. Every prior test (unit, smoke, parity, bench) wrote
a *deep* path (`data/x.toml`, `widgets/1.toml`), so the `"."` case was never
exercised. The publishing flow itself worked perfectly — this is a latent code
bug the functional validation caught.

## The fix

The `"."` branch now marks dirty + `ensure_children` (the same postcondition as
the deep-path return), so root-level writes insert alongside existing entries
instead of panicking. Adds root-level regression tests (fresh tree + lazily-
loaded tree with existing siblings), and verified the repro now passes through
the napi binding.

Ships in `@hologit/holo-tree@0.1.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)