### PR TITLE
fix(holo-tree-napi): skip napi GitHub release to avoid v* tag collision

### DIFF
--- a/.github/workflows/holo-tree-napi.yml
+++ b/.github/workflows/holo-tree-napi.yml
@@ -16,7 +16,10 @@
 # for this repo + this workflow. One-time bootstrap (the package can't get a
 # trusted publisher until it exists): publish an early version of all 4 manually,
 # then add the trusted publishers. See holo-tree-napi/README "Publishing".
-# (`napi prepublish` also cuts a GitHub release via GITHUB_TOKEN.)
+#
+# The release marker is the `holo-tree-v*` git tag itself; napi prepublish runs
+# with --skip-gh-release so it does NOT create a bare `v<version>` GitHub release
+# + tag (those collide with hologit's own `v*` JS-package release namespace).
 name: holo-tree-napi
 
 on:
@@ -87,7 +90,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # napi prepublish cuts a GitHub release
+      contents: read    # no GitHub release is created (see --skip-gh-release)
       id-token: write   # npm provenance attestation
     steps:
       - uses: actions/checkout@v4
@@ -123,6 +126,6 @@ jobs:
       - name: Publish (platform packages via prepublishOnly hook, then main)
         # Tokenless: OIDC trusted publishing. Requires all 4 packages to exist
         # with a trusted publisher configured (see the bootstrap note up top).
+        # prepublishOnly runs `napi prepublish ... --skip-gh-release`, so no
+        # GitHub release/tag is created and no GITHUB_TOKEN is needed.
         run: npm publish --provenance --access public
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/holo-tree-napi/README.md
+++ b/holo-tree-napi/README.md
@@ -102,7 +102,7 @@ exist on npm before trusted publishing can be turned on.
    # platform packages first, then the main package:
    for d in npm/*/ ; do ( cd "$d" && npm publish --access public ); done
    npm publish --access public --ignore-scripts          # main; skip the napi
-                                                         # prepublish GH-release hook
+                                                         # prepublish hook
    ```
 
 3. **Turn on trusted publishing** on npmjs.com for **each** of the four packages
@@ -112,11 +112,14 @@ exist on npm before trusted publishing can be turned on.
 ### Releases (after bootstrap — fully automated, tokenless)
 
 ```sh
-git tag holo-tree-v0.1.0 && git push origin holo-tree-v0.1.0
+git tag holo-tree-v0.1.1 && git push origin holo-tree-v0.1.1
 ```
 
 The tag drives the published version; CI builds all three platforms, then
-publishes via OIDC (provenance + a GitHub release). No secret needed.
+publishes via OIDC (provenance). No secret needed. The `holo-tree-v*` tag is the
+release marker — napi runs with `--skip-gh-release` so it does **not** create a
+bare `v<version>` GitHub release/tag (which would collide with hologit's own
+`v*` JS-package release namespace).
 
 To add or drop a platform later, edit `napi.triples.additional` +
 `optionalDependencies` in `package.json`, run `napi create-npm-dir -t .`, add the

--- a/holo-tree-napi/package.json
+++ b/holo-tree-napi/package.json
@@ -37,7 +37,7 @@
     "artifacts": "napi artifacts",
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "prepublishOnly": "napi prepublish -t npm",
+    "prepublishOnly": "napi prepublish -t npm --skip-gh-release",
     "test": "node --test test/",
     "version": "napi version"
   },


### PR DESCRIPTION
## Problem

Publishing `@hologit/holo-tree@0.1.0`/`0.1.1` via `napi prepublish` also created
**bare `v0.1.0` / `v0.1.1` GitHub releases + git tags**. Those collide with
hologit's own `v*` JS-package release namespace (v0.50.x) and match
`publish-npm.yml`'s `v*` trigger. They didn't actually fire `publish-npm` only
because GitHub suppresses workflow triggers for `GITHUB_TOKEN`-created tags — a
footgun, not a safe design.

## Fix

`napi prepublish ... --skip-gh-release` — the **`holo-tree-v*` git tag** is the
binding's release marker and the npm publish is the release; no separate
GitHub release/tag is needed. Also drops the now-unused `GITHUB_TOKEN` and
narrows the publish job permission to `contents: read`.

## Note on cleanup

The already-created stray `v0.1.0` / `v0.1.1` releases + bare tags should be
deleted separately (destructive external writes — left for a human to run):

```sh
gh release delete v0.1.0 --cleanup-tag --yes
gh release delete v0.1.1 --cleanup-tag --yes
```

The intentional `holo-tree-v0.1.0` / `holo-tree-v0.1.1` tags stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)