### PR TITLE
feat(holo-tree-napi): expose tree/ref ops for gitsheets migration

### DIFF
--- a/holo-tree-napi/README.md
+++ b/holo-tree-napi/README.md
@@ -39,13 +39,25 @@ blob content crosses as `Buffer` (binary-safe).
 | `repo.createTreeFromRef(ref)` → `Tree` | `repo::create_tree_from_ref` | resolves ref→commit→tree |
 | `repo.createTree()` → `Tree` | `MutableTree::empty` | |
 | `repo.commitTree(treeHash, parents[], msg)` → hash | `repo::commit_tree` | uses git-config identity |
-| `repo.updateRef(ref, hash)` | `repo::update_ref` | |
+| `repo.updateRef(ref, hash, expectedOldHash?)` | `repo::update_ref` | compare-and-swap when `expectedOldHash` given; force otherwise |
+| `repo.resolveRef(ref)` → `hash\|null` | `repo::resolve_ref` | peels tags; `null` if unresolved |
+| `repo.writeBlob(buf)` → hash | `gix write_blob` | hash bytes into the ODB, no tree |
 | `tree.writeChild(path, text)` → hash | `MutableTree::write_child` | UTF-8 text |
 | `tree.writeChildBytes(path, buf)` → hash | `MutableTree::write_child_bytes` | binary |
 | `tree.readBlob(path)` → `Buffer\|null` | `MutableTree::read_blob` | |
+| `tree.getChild(path)` → `{type,hash,mode}\|null` | `MutableTree::get_child` | read-only; deep path |
+| `tree.getChildren(path)` → `[{name,type,hash,mode}]` | `get_subtree`+`ensure_children` | read-only; direct children |
+| `tree.getBlobMap(path?)` → `[{path,hash,mode}]` | `get_subtree`+`get_blob_map` | read-only; paths relative to subtree |
 | `tree.deleteChildDeep(path)` → bool | `MutableTree::delete_child_deep` | |
+| `tree.clearChildren(path)` | `MutableTree::clear_children` | O(1) subtree wipe |
+| `tree.merge(other, {files?, mode})` | `MutableTree::merge` | `mode`: `overlay`/`replace`/`underlay` |
 | `tree.write()` → treeHash | `MutableTree::write` | |
 | `emptyTreeHash()` → hash | `tree::empty_tree_id` | module fn |
+
+`mode` values are the git filemode as a number (e.g. `33188` = `0o100644`). Tree
+hashes reported by the read-only navigators reflect the last `write()`/load and
+are stale for a subtree mutated since — flush with `write()` for canonical
+hashes.
 
 ## Building
 

--- a/holo-tree-napi/index.d.ts
+++ b/holo-tree-napi/index.d.ts
@@ -18,6 +18,41 @@ export interface Signature {
   offsetMinutes?: number
 }
 /**
+ * A child entry returned by read-only navigation. `type` is `"tree"`,
+ * `"blob"`, or `"commit"`; `mode` is the git filemode as a number
+ * (e.g. `33188` = `0o100644`, `16384` = `0o040000` for a tree).
+ */
+export interface ChildInfo {
+  type: string
+  hash: string
+  mode: number
+}
+/** A named child entry, returned by `getChildren`. */
+export interface NamedChildInfo {
+  name: string
+  type: string
+  hash: string
+  mode: number
+}
+/**
+ * A blob entry in a flattened blob map, returned by `getBlobMap`. `path` is
+ * relative to the navigated subtree.
+ */
+export interface BlobEntry {
+  path: string
+  hash: string
+  mode: number
+}
+/**
+ * Options for `Tree.merge`. `mode` is `"overlay"`, `"replace"`, or
+ * `"underlay"`; `files` is an optional list of glob patterns restricting which
+ * paths merge (omit to merge everything).
+ */
+export interface MergeOpts {
+  files?: Array<string>
+  mode: string
+}
+/**
  * A handle to a git repository, backed by gix.
  *
  * Stored as a `ThreadSafeRepository` so the handle is `Send + Sync` and can be
@@ -43,8 +78,28 @@ export declare class Repo {
    * identity, then a "holo-tree" default. Returns the new commit hash.
    */
   commitTree(treeHash: string, parents: Array<string>, message: string, author?: Signature | undefined | null, committer?: Signature | undefined | null): string
-  /** Point a ref at an object hash. */
-  updateRef(refname: string, hash: string): void
+  /**
+   * Point a ref at an object hash.
+   *
+   * When `expectedOldHash` is provided this is a **compare-and-swap**: the
+   * update only succeeds if the ref currently resolves to exactly that hash,
+   * so a concurrent writer who moved the ref makes the swap fail rather than
+   * silently clobbering their commit. Omit it to force the ref (the prior
+   * unconditional behavior).
+   */
+  updateRef(refname: string, hash: string, expectedOldHash?: string | undefined | null): void
+  /**
+   * Resolve a ref / rev-spec (branch, tag, `HEAD`, hash, …) to its commit
+   * hash, peeling annotated tags. Returns `null` when the ref does not
+   * resolve — the natural "does this ref exist?" probe before a CAS
+   * `updateRef`.
+   */
+  resolveRef(gitRef: string): string | null
+  /**
+   * Hash raw bytes as a loose blob in the ODB and return its hash, without
+   * inserting it into any tree. Binary-safe.
+   */
+  writeBlob(content: Buffer): string
 }
 /**
  * A mutable, in-memory git tree.
@@ -70,8 +125,37 @@ export declare class Tree {
   writeChildBytes(path: string, content: Buffer): string
   /** Read a blob's bytes at `path`, or `null` if no blob exists there. */
   readBlob(path: string): Buffer | null
+  /**
+   * Read-only: look up the child at a deep `path` and report its type,
+   * hash, and mode, or `null` if nothing exists there.
+   */
+  getChild(path: string): ChildInfo | null
+  /**
+   * Read-only: list the direct children of the subtree at `path` (use `"."`
+   * for the root). Returns an empty array if `path` is missing or not a tree.
+   */
+  getChildren(path: string): Array<NamedChildInfo>
+  /**
+   * Read-only: recursively collect every blob under the subtree at `path`
+   * (defaults to the whole tree) into a flat list. Each `path` is relative
+   * to the navigated subtree. Returns an empty array if `path` is missing.
+   */
+  getBlobMap(path?: string | undefined | null): Array<BlobEntry>
   /** Delete a child at a deep `path`. Returns whether it existed. */
   deleteChildDeep(path: string): boolean
+  /**
+   * Clear all children under a deep `path` in O(1) — replace the subtree
+   * there with the empty tree (and dirty its ancestors) without loading the
+   * cleared subtree's contents. `path == "."` clears the whole tree. Used to
+   * wipe a directory before a full rewrite.
+   */
+  clearChildren(path: string): void
+  /**
+   * Merge another tree into this one in place, per `options.mode`
+   * (`overlay`/`replace`/`underlay`) and optional `options.files` globs.
+   * `other` must be a *different* `Tree` instance.
+   */
+  merge(other: Tree, options: MergeOpts): void
   /** Flush dirty subtrees to the ODB and return the resulting tree hash. */
   write(): string
 }

--- a/holo-tree-napi/package-lock.json
+++ b/holo-tree-napi/package-lock.json
@@ -1,16 +1,69 @@
 {
-  "name": "holo-tree-napi",
+  "name": "@hologit/holo-tree",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "holo-tree-napi",
+      "name": "@hologit/holo-tree",
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"
       },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@hologit/holo-tree-darwin-arm64": "0.0.1",
+        "@hologit/holo-tree-linux-x64-gnu": "0.0.1",
+        "@hologit/holo-tree-win32-x64-msvc": "0.0.1"
+      }
+    },
+    "node_modules/@hologit/holo-tree-darwin-arm64": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-darwin-arm64/-/holo-tree-darwin-arm64-0.0.1.tgz",
+      "integrity": "sha512-Ix1ynaV7N5gbhgc6u74nZRW3GjypN4kB2U8pbxlKgj3LFhbMaZoJKa0WuqgeZvaVHdDQE+FGh05Y1wV2JudAUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@hologit/holo-tree-linux-x64-gnu": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-linux-x64-gnu/-/holo-tree-linux-x64-gnu-0.0.1.tgz",
+      "integrity": "sha512-GHF02JK3XTKlR3joEw4iMhakFMXUrd/JBpC1YiyRhxM8K484lgGEDY7BLoZT3Fqxk7S/2JVDzOBu9ePrGyApfg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@hologit/holo-tree-win32-x64-msvc": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-win32-x64-msvc/-/holo-tree-win32-x64-msvc-0.0.1.tgz",
+      "integrity": "sha512-JFlD7PDpfqiUnAOVYvPasjGoT0bUVBdXYTzL050kywCIB2wWk38GUK0i7qQdHqpfKj8TM1Oomh4VIw7rIEwMfw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">=20"
       }

--- a/holo-tree-napi/src/lib.rs
+++ b/holo-tree-napi/src/lib.rs
@@ -168,11 +168,99 @@ impl Repo {
     }
 
     /// Point a ref at an object hash.
+    ///
+    /// When `expectedOldHash` is provided this is a **compare-and-swap**: the
+    /// update only succeeds if the ref currently resolves to exactly that hash,
+    /// so a concurrent writer who moved the ref makes the swap fail rather than
+    /// silently clobbering their commit. Omit it to force the ref (the prior
+    /// unconditional behavior).
     #[napi]
-    pub fn update_ref(&self, refname: String, hash: String) -> napi::Result<()> {
+    pub fn update_ref(
+        &self,
+        refname: String,
+        hash: String,
+        expected_old_hash: Option<String>,
+    ) -> napi::Result<()> {
         let local = self.inner.to_thread_local();
         let oid = parse_oid(&hash)?;
-        ht_repo::update_ref(&local, &refname, oid).map_err(ht_err)
+        let expected = expected_old_hash.as_deref().map(parse_oid).transpose()?;
+        ht_repo::update_ref(&local, &refname, oid, expected).map_err(ht_err)
+    }
+
+    /// Resolve a ref / rev-spec (branch, tag, `HEAD`, hash, …) to its commit
+    /// hash, peeling annotated tags. Returns `null` when the ref does not
+    /// resolve — the natural "does this ref exist?" probe before a CAS
+    /// `updateRef`.
+    #[napi]
+    pub fn resolve_ref(&self, git_ref: String) -> napi::Result<Option<String>> {
+        let local = self.inner.to_thread_local();
+        let oid = ht_repo::resolve_ref(&local, &git_ref).map_err(ht_err)?;
+        Ok(oid.map(oid_hex))
+    }
+
+    /// Hash raw bytes as a loose blob in the ODB and return its hash, without
+    /// inserting it into any tree. Binary-safe.
+    #[napi]
+    pub fn write_blob(&self, content: Buffer) -> napi::Result<String> {
+        let local = self.inner.to_thread_local();
+        let oid = local
+            .write_blob(content.as_ref())
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?
+            .detach();
+        Ok(oid_hex(oid))
+    }
+}
+
+// ── Tree read-models ─────────────────────────────────────────────────────────
+
+/// A child entry returned by read-only navigation. `type` is `"tree"`,
+/// `"blob"`, or `"commit"`; `mode` is the git filemode as a number
+/// (e.g. `33188` = `0o100644`, `16384` = `0o040000` for a tree).
+#[napi(object)]
+pub struct ChildInfo {
+    pub r#type: String,
+    pub hash: String,
+    pub mode: u32,
+}
+
+/// A named child entry, returned by `getChildren`.
+#[napi(object)]
+pub struct NamedChildInfo {
+    pub name: String,
+    pub r#type: String,
+    pub hash: String,
+    pub mode: u32,
+}
+
+/// A blob entry in a flattened blob map, returned by `getBlobMap`. `path` is
+/// relative to the navigated subtree.
+#[napi(object)]
+pub struct BlobEntry {
+    pub path: String,
+    pub hash: String,
+    pub mode: u32,
+}
+
+/// Options for `Tree.merge`. `mode` is `"overlay"`, `"replace"`, or
+/// `"underlay"`; `files` is an optional list of glob patterns restricting which
+/// paths merge (omit to merge everything).
+#[napi(object)]
+pub struct MergeOpts {
+    pub files: Option<Vec<String>>,
+    pub mode: String,
+}
+
+/// Classify a holo-tree `Child` into `(type, hash, mode)` for the read-models.
+///
+/// Note: for a `Tree` child the reported `hash` is the child's *stored* tree
+/// hash, which is stale if that subtree has been mutated but not yet
+/// `write()`-flushed. Read-only navigation on a freshly loaded/written tree
+/// reports accurate hashes.
+fn classify(child: &holo_tree::Child) -> (&'static str, String, u32) {
+    match child {
+        holo_tree::Child::Tree(t) => ("tree", oid_hex(t.hash), 0o040000),
+        holo_tree::Child::Blob { mode, hash } => ("blob", oid_hex(*hash), u32::from(*mode)),
+        holo_tree::Child::Commit { hash } => ("commit", oid_hex(*hash), 0o160000),
     }
 }
 
@@ -229,12 +317,109 @@ impl Tree {
         Ok(bytes.map(Buffer::from))
     }
 
+    /// Read-only: look up the child at a deep `path` and report its type,
+    /// hash, and mode, or `null` if nothing exists there.
+    #[napi]
+    pub fn get_child(&mut self, path: String) -> napi::Result<Option<ChildInfo>> {
+        let local = self.repo.to_thread_local();
+        let info = self
+            .inner
+            .get_child(&local, &path)
+            .map_err(ht_err)?
+            .map(|child| {
+                let (ty, hash, mode) = classify(child);
+                ChildInfo {
+                    r#type: ty.to_string(),
+                    hash,
+                    mode,
+                }
+            });
+        Ok(info)
+    }
+
+    /// Read-only: list the direct children of the subtree at `path` (use `"."`
+    /// for the root). Returns an empty array if `path` is missing or not a tree.
+    #[napi]
+    pub fn get_children(&mut self, path: String) -> napi::Result<Vec<NamedChildInfo>> {
+        let local = self.repo.to_thread_local();
+        let subtree = match self.inner.get_subtree(&local, &path).map_err(ht_err)? {
+            Some(t) => t,
+            None => return Ok(vec![]),
+        };
+        subtree.ensure_children(&local).map_err(ht_err)?;
+        let mut out = Vec::new();
+        for (name, child) in subtree.children.as_ref().unwrap().iter() {
+            let (ty, hash, mode) = classify(child);
+            out.push(NamedChildInfo {
+                name: name.clone(),
+                r#type: ty.to_string(),
+                hash,
+                mode,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Read-only: recursively collect every blob under the subtree at `path`
+    /// (defaults to the whole tree) into a flat list. Each `path` is relative
+    /// to the navigated subtree. Returns an empty array if `path` is missing.
+    #[napi]
+    pub fn get_blob_map(&mut self, path: Option<String>) -> napi::Result<Vec<BlobEntry>> {
+        let local = self.repo.to_thread_local();
+        let path = path.unwrap_or_else(|| ".".to_string());
+        let map = match self.inner.get_subtree(&local, &path).map_err(ht_err)? {
+            Some(subtree) => subtree.get_blob_map(&local).map_err(ht_err)?,
+            None => return Ok(vec![]),
+        };
+        let out = map
+            .into_iter()
+            .map(|(p, info)| BlobEntry {
+                path: p,
+                hash: oid_hex(info.hash),
+                mode: u32::from(info.mode),
+            })
+            .collect();
+        Ok(out)
+    }
+
     /// Delete a child at a deep `path`. Returns whether it existed.
     #[napi]
     pub fn delete_child_deep(&mut self, path: String) -> napi::Result<bool> {
         let local = self.repo.to_thread_local();
         self.inner
             .delete_child_deep(&local, &path)
+            .map_err(ht_err)
+    }
+
+    /// Clear all children under a deep `path` in O(1) — replace the subtree
+    /// there with the empty tree (and dirty its ancestors) without loading the
+    /// cleared subtree's contents. `path == "."` clears the whole tree. Used to
+    /// wipe a directory before a full rewrite.
+    #[napi]
+    pub fn clear_children(&mut self, path: String) -> napi::Result<()> {
+        let local = self.repo.to_thread_local();
+        self.inner.clear_children(&local, &path).map_err(ht_err)
+    }
+
+    /// Merge another tree into this one in place, per `options.mode`
+    /// (`overlay`/`replace`/`underlay`) and optional `options.files` globs.
+    /// `other` must be a *different* `Tree` instance.
+    #[napi]
+    pub fn merge(&mut self, other: &mut Tree, options: MergeOpts) -> napi::Result<()> {
+        let local = self.repo.to_thread_local();
+        let mode = match options.mode.as_str() {
+            "overlay" => holo_tree::MergeMode::Overlay,
+            "replace" => holo_tree::MergeMode::Replace,
+            "underlay" => holo_tree::MergeMode::Underlay,
+            other => {
+                return Err(napi::Error::from_reason(format!(
+                    "invalid merge mode '{other}', expected 'overlay', 'replace', or 'underlay'"
+                )))
+            }
+        };
+        let opts = holo_tree::MergeOptions::new(options.files.as_deref(), mode).map_err(ht_err)?;
+        self.inner
+            .merge(&local, &mut other.inner, &opts, ".")
             .map_err(ht_err)
     }
 

--- a/holo-tree-napi/test/ops.mjs
+++ b/holo-tree-napi/test/ops.mjs
@@ -1,0 +1,222 @@
+// Smoke tests for the tree/ref ops added for the gitsheets migration:
+//   writeBlob, resolveRef, updateRef (CAS), getChild, getChildren,
+//   getBlobMap, clearChildren, merge.
+//
+// Requires the addon to be built first: `npm run build:debug` (or `build`).
+// Run with: `npm test` (node --test).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+let binding;
+try {
+  binding = require('../index.js');
+} catch (err) {
+  throw new Error(
+    `holo-tree-napi addon not built — run \`npm run build:debug\` first.\n  cause: ${err.message}`,
+  );
+}
+const { Repo } = binding;
+
+function git(cwd, ...args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function scratchRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'holo-tree-napi-ops-'));
+  git(dir, 'init', '-q');
+  git(dir, 'config', 'user.name', 'Test');
+  git(dir, 'config', 'user.email', 'test@example.com');
+  git(dir, 'commit', '--allow-empty', '-q', '-m', 'init');
+  return dir;
+}
+
+test('writeBlob hashes bytes without touching any tree', () => {
+  const dir = scratchRepo();
+  try {
+    const repo = Repo.open(join(dir, '.git'));
+    const hash = repo.writeBlob(Buffer.from('hello\n'));
+    assert.match(hash, /^[0-9a-f]{40}$/);
+    // Parity oracle: git's own object hash for the same content.
+    const oracle = execFileSync('git', ['hash-object', '-t', 'blob', '--stdin'], {
+      cwd: dir,
+      input: 'hello\n',
+      encoding: 'utf8',
+    }).trim();
+    assert.equal(hash, oracle, 'writeBlob must match git hash-object');
+    // And the object is actually present in the ODB.
+    assert.equal(git(dir, 'cat-file', '-p', hash), 'hello');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveRef resolves branches and returns null for unknown refs', () => {
+  const dir = scratchRepo();
+  try {
+    const repo = Repo.open(join(dir, '.git'));
+    const branchRef = git(dir, 'symbolic-ref', 'HEAD');
+    const head = git(dir, 'rev-parse', 'HEAD');
+
+    assert.equal(repo.resolveRef(branchRef), head);
+    assert.equal(repo.resolveRef('HEAD'), head);
+    assert.equal(repo.resolveRef('refs/heads/does-not-exist'), null);
+    assert.equal(repo.resolveRef('totally-bogus'), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('updateRef compare-and-swap: succeeds on match, rejects on mismatch', () => {
+  const dir = scratchRepo();
+  try {
+    const repo = Repo.open(join(dir, '.git'));
+    const branchRef = git(dir, 'symbolic-ref', 'HEAD');
+    const c1 = git(dir, 'rev-parse', 'HEAD');
+
+    // Build C2 (child of C1).
+    const t2 = repo.createTreeFromRef('HEAD');
+    t2.writeChild('a.toml', 'id = 1\n');
+    const c2 = repo.commitTree(t2.write(), [c1], 'c2');
+
+    // CAS from C1 → C2 succeeds.
+    repo.updateRef(branchRef, c2, c1);
+    assert.equal(repo.resolveRef(branchRef), c2);
+
+    // Build C3 (child of C2).
+    const t3 = repo.createTreeFromRef(c2);
+    t3.writeChild('b.toml', 'id = 2\n');
+    const c3 = repo.commitTree(t3.write(), [c2], 'c3');
+
+    // CAS claiming the ref is still at C1 must fail (it's at C2 now).
+    assert.throws(() => repo.updateRef(branchRef, c3, c1), /.*/);
+    assert.equal(repo.resolveRef(branchRef), c2, 'ref must be unchanged after a failed CAS');
+
+    // Force (no expected) succeeds.
+    repo.updateRef(branchRef, c3);
+    assert.equal(repo.resolveRef(branchRef), c3);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('getChild / getChildren navigate read-only', () => {
+  const dir = scratchRepo();
+  try {
+    const repo = Repo.open(join(dir, '.git'));
+    const tree = repo.createTree();
+    const blobHash = tree.writeChild('data/widgets/1.toml', 'id = 1\n');
+    tree.writeChild('data/widgets/2.toml', 'id = 2\n');
+    tree.write();
+
+    // Deep blob lookup.
+    const child = tree.getChild('data/widgets/1.toml');
+    assert.ok(child);
+    assert.equal(child.type, 'blob');
+    assert.equal(child.hash, blobHash);
+    assert.equal(child.mode, 0o100644);
+
+    // Subtree lookup.
+    const sub = tree.getChild('data/widgets');
+    assert.equal(sub.type, 'tree');
+
+    // Missing path.
+    assert.equal(tree.getChild('data/widgets/nope.toml'), null);
+
+    // Direct children of a subtree.
+    const names = tree.getChildren('data/widgets').map((c) => c.name).sort();
+    assert.deepEqual(names, ['1.toml', '2.toml']);
+    assert.ok(tree.getChildren('data/widgets').every((c) => c.type === 'blob'));
+
+    // Missing subtree → empty.
+    assert.deepEqual(tree.getChildren('data/gadgets'), []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('getBlobMap flattens a subtree, paths relative to it', () => {
+  const dir = scratchRepo();
+  try {
+    const repo = Repo.open(join(dir, '.git'));
+    const tree = repo.createTree();
+    tree.writeChild('data/widgets/1.toml', 'id = 1\n');
+    tree.writeChild('data/widgets/2.toml', 'id = 2\n');
+    tree.writeChild('README.md', 'hi\n');
+    tree.write();
+
+    const all = tree.getBlobMap().map((b) => b.path).sort();
+    assert.deepEqual(all, ['README.md', 'data/widgets/1.toml', 'data/widgets/2.toml']);
+
+    const scoped = tree.getBlobMap('data/widgets').map((b) => b.path).sort();
+    assert.deepEqual(scoped, ['1.toml', '2.toml'], 'paths are relative to the navigated subtree');
+
+    assert.deepEqual(tree.getBlobMap('data/missing'), []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('clearChildren wipes a subtree but preserves siblings', () => {
+  const dir = scratchRepo();
+  try {
+    const repo = Repo.open(join(dir, '.git'));
+    const tree = repo.createTree();
+    tree.writeChild('data/widgets/1.toml', 'id = 1\n');
+    tree.writeChild('data/gadgets/9.toml', 'id = 9\n');
+    tree.writeChild('README.md', 'hi\n');
+    tree.write();
+
+    tree.clearChildren('data/widgets');
+    tree.writeChild('data/widgets/fresh.toml', 'id = 3\n');
+    tree.write();
+
+    const paths = tree.getBlobMap().map((b) => b.path).sort();
+    assert.deepEqual(paths, [
+      'README.md',
+      'data/gadgets/9.toml',
+      'data/widgets/fresh.toml',
+    ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('merge overlays another tree in place', () => {
+  const dir = scratchRepo();
+  try {
+    const repo = Repo.open(join(dir, '.git'));
+
+    const base = repo.createTree();
+    base.writeChild('a.toml', 'base-a\n');
+    base.writeChild('shared.toml', 'base-shared\n');
+    base.write();
+
+    const incoming = repo.createTree();
+    incoming.writeChild('shared.toml', 'incoming-shared\n');
+    incoming.writeChild('b.toml', 'incoming-b\n');
+    incoming.write();
+
+    base.merge(incoming, { mode: 'overlay' });
+    base.write();
+
+    const map = Object.fromEntries(base.getBlobMap().map((b) => [b.path, b.hash]));
+    assert.deepEqual(Object.keys(map).sort(), ['a.toml', 'b.toml', 'shared.toml']);
+
+    // shared.toml must now hold the incoming content's hash.
+    const incomingShared = incoming.getChild('shared.toml').hash;
+    assert.equal(map['shared.toml'], incomingShared, 'overlay must overwrite shared.toml');
+
+    // An invalid mode is rejected.
+    assert.throws(() => base.merge(incoming, { mode: 'bogus' }), /invalid merge mode/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/holo-tree/src/error.rs
+++ b/holo-tree/src/error.rs
@@ -18,6 +18,24 @@ pub enum Error {
     Toml { path: String, message: String },
 }
 
+impl Error {
+    /// A stable, machine-matchable code for this error variant.
+    ///
+    /// Unlike the human-readable `Display` string (which embeds variable
+    /// context), these codes are part of the API contract: downstream
+    /// consumers — notably the napi binding and gitsheets — match on them to
+    /// map substrate failures onto their own typed errors. Keep them stable.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Error::Git(_) => "GIT",
+            Error::NotATree(_) => "NOT_A_TREE",
+            Error::PathNotFound { .. } => "PATH_NOT_FOUND",
+            Error::Glob(_) => "GLOB",
+            Error::Toml { .. } => "TOML",
+        }
+    }
+}
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 // ── gix error conversions ──────────────────────────────────────────────────

--- a/holo-tree/src/error.rs
+++ b/holo-tree/src/error.rs
@@ -63,3 +63,29 @@ impl From<gix::reference::find::existing::Error> for Error {
         Error::Git(e.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+
+    #[test]
+    fn codes_are_stable_per_variant() {
+        assert_eq!(Error::Git("x".into()).code(), "GIT");
+        assert_eq!(Error::NotATree("x".into()).code(), "NOT_A_TREE");
+        assert_eq!(
+            Error::PathNotFound {
+                component: "x".into()
+            }
+            .code(),
+            "PATH_NOT_FOUND"
+        );
+        assert_eq!(
+            Error::Toml {
+                path: "p".into(),
+                message: "m".into()
+            }
+            .code(),
+            "TOML"
+        );
+    }
+}

--- a/holo-tree/src/repo.rs
+++ b/holo-tree/src/repo.rs
@@ -134,6 +134,37 @@ pub fn commit_tree(
     Ok(id.detach())
 }
 
+/// Resolve a ref / rev-spec (branch, tag, `HEAD`, hash, …) to its object hash,
+/// peeling annotated tags down to the object they point at (typically a commit).
+///
+/// Returns `Ok(None)` when the ref does not resolve — an unknown name, an
+/// unborn branch, or any spec gix can't parse to a single object. That is the
+/// natural "does this ref exist?" contract a caller wants from a resolver
+/// (gitsheets uses it to discover the current commit before a compare-and-swap
+/// `update_ref`). Genuine ODB failures *after* a spec resolves still surface as
+/// `Err`.
+pub fn resolve_ref(repo: &gix::Repository, git_ref: &str) -> Result<Option<ObjectId>> {
+    let spec = match repo.rev_parse_single(git_ref) {
+        Ok(s) => s,
+        Err(_) => return Ok(None),
+    };
+    let mut obj = spec.object().map_err(|e| Error::Git(e.to_string()))?;
+
+    // Peel annotated tags to their target object.
+    while obj.kind == gix::object::Kind::Tag {
+        let tag = obj
+            .try_into_tag()
+            .map_err(|_| Error::Git("failed to parse tag".into()))?;
+        let target = tag
+            .target_id()
+            .map_err(|e| Error::Git(e.to_string()))?
+            .detach();
+        obj = repo.find_object(target)?;
+    }
+
+    Ok(Some(obj.id))
+}
+
 /// Update a git ref to point at a new object.
 ///
 /// Accepts the same leniency as `git update-ref`: a bare branch name (e.g.
@@ -142,19 +173,28 @@ pub fn commit_tree(
 /// (e.g. `HEAD`) pass through unchanged. Without this, gix's `reference()`
 /// rejects a standalone lowercase name ("Standalone references must be all
 /// uppercased").
+///
+/// When `expected_old` is `Some`, this is a **compare-and-swap**: the update
+/// only succeeds if the ref currently resolves to exactly that object
+/// (`PreviousValue::MustExistAndMatch`), so a concurrent writer that moved the
+/// ref out from under the caller makes the swap fail loudly rather than clobber
+/// their commit. When `None`, the ref is set unconditionally
+/// (`PreviousValue::Any`), matching the original force behavior.
 pub fn update_ref(
     repo: &gix::Repository,
     refname: &str,
     target: ObjectId,
+    expected_old: Option<ObjectId>,
 ) -> Result<()> {
     let qualified = qualify_ref(refname);
-    repo.reference(
-        qualified.as_ref(),
-        target,
-        gix::refs::transaction::PreviousValue::Any,
-        "holo-tree",
-    )
-    .map_err(|e| Error::Git(e.to_string()))?;
+    let previous = match expected_old {
+        Some(old) => gix::refs::transaction::PreviousValue::MustExistAndMatch(
+            gix::refs::Target::Object(old),
+        ),
+        None => gix::refs::transaction::PreviousValue::Any,
+    };
+    repo.reference(qualified.as_ref(), target, previous, "holo-tree")
+        .map_err(|e| Error::Git(e.to_string()))?;
     Ok(())
 }
 

--- a/holo-tree/src/tree.rs
+++ b/holo-tree/src/tree.rs
@@ -524,6 +524,44 @@ impl MutableTree {
         }
     }
 
+    /// Clear all children under a deep `path`, replacing the subtree there
+    /// with the empty tree and marking the ancestor chain dirty.
+    ///
+    /// This is an **O(1)** clear: it does not load the cleared subtree's own
+    /// contents from the ODB — only the ancestor trees needed to navigate to
+    /// its parent. Intermediate trees along `path` are created if absent; since
+    /// an empty subtree is pruned on `write()`, clearing a path that doesn't
+    /// exist is a no-op in the written result.
+    ///
+    /// `path == "."` (or empty) clears the root tree itself.
+    pub fn clear_children(&mut self, repo: &gix::Repository, path: &str) -> Result<()> {
+        if path == "." || path.is_empty() {
+            self.children = Some(BTreeMap::new());
+            self.hash = empty_tree_id();
+            self.dirty = true;
+            return Ok(());
+        }
+
+        let (dir, name) = match path.rsplit_once('/') {
+            Some((d, f)) => (d, f),
+            None => (".", path),
+        };
+
+        // get_or_create_subtree marks the whole navigated path (root included)
+        // dirty, which is exactly what we need: every ancestor's serialized
+        // form changes once the cleared subtree is pruned on write().
+        let parent = self.get_or_create_subtree(repo, dir)?;
+        let mut empty = MutableTree::empty();
+        empty.dirty = true;
+        parent
+            .children
+            .as_mut()
+            .unwrap()
+            .insert(name.to_string(), Child::Tree(empty));
+        parent.dirty = true;
+        Ok(())
+    }
+
     /// Recursively collect all blobs into a flat map.
     pub fn get_blob_map(
         &mut self,

--- a/holo-tree/tests/clear_children.rs
+++ b/holo-tree/tests/clear_children.rs
@@ -1,0 +1,95 @@
+//! Tests for `MutableTree::clear_children` — the O(1) subtree clear that
+//! gitsheets uses to wipe a sheet directory before a full rewrite.
+
+mod helpers;
+
+use helpers::Sandbox;
+use holo_tree::MutableTree;
+
+fn list_tree(repo: &gix::Repository, hash: gix::ObjectId) -> Vec<String> {
+    let mut tree = MutableTree::new(hash);
+    let mut out = Vec::new();
+    for (path, _) in tree.get_blob_map(repo).unwrap() {
+        out.push(path);
+    }
+    out.sort();
+    out
+}
+
+#[test]
+fn clears_a_deep_subtree_but_preserves_siblings() {
+    let sb = Sandbox::new();
+    let base = sb.write_tree(&[
+        ("data/widgets/1.toml", "id = 1\n"),
+        ("data/widgets/2.toml", "id = 2\n"),
+        ("data/gadgets/9.toml", "id = 9\n"),
+        ("README.md", "hi\n"),
+    ]);
+
+    let mut tree = MutableTree::new(base);
+    tree.clear_children(&sb.repo, "data/widgets").unwrap();
+    let hash = tree.write(&sb.repo).unwrap();
+
+    assert_ne!(hash, base, "clearing a populated subtree must change the hash");
+    assert_eq!(
+        list_tree(&sb.repo, hash),
+        vec![
+            "README.md".to_string(),
+            "data/gadgets/9.toml".to_string(),
+        ],
+        "only the widgets/ subtree should be gone",
+    );
+}
+
+#[test]
+fn cleared_subtree_can_be_repopulated_in_the_same_pass() {
+    let sb = Sandbox::new();
+    let base = sb.write_tree(&[
+        ("data/widgets/old-a.toml", "id = 1\n"),
+        ("data/widgets/old-b.toml", "id = 2\n"),
+    ]);
+
+    let mut tree = MutableTree::new(base);
+    tree.clear_children(&sb.repo, "data/widgets").unwrap();
+    tree.write_child(&sb.repo, "data/widgets/new.toml", "id = 3\n")
+        .unwrap();
+    let hash = tree.write(&sb.repo).unwrap();
+
+    assert_eq!(
+        list_tree(&sb.repo, hash),
+        vec!["data/widgets/new.toml".to_string()],
+        "old entries cleared, new entry present",
+    );
+}
+
+#[test]
+fn clearing_the_root_yields_the_empty_tree() {
+    let sb = Sandbox::new();
+    let base = sb.write_tree(&[("a.toml", "1\n"), ("b/c.toml", "2\n")]);
+
+    let mut tree = MutableTree::new(base);
+    tree.clear_children(&sb.repo, ".").unwrap();
+    let hash = tree.write(&sb.repo).unwrap();
+
+    assert_eq!(
+        hash,
+        holo_tree::tree::empty_tree_id(),
+        "clearing the root must produce git's empty tree",
+    );
+}
+
+#[test]
+fn clearing_a_missing_path_is_a_noop_on_write() {
+    let sb = Sandbox::new();
+    let base = sb.write_tree(&[("data/widgets/1.toml", "id = 1\n")]);
+
+    let mut tree = MutableTree::new(base);
+    // Path doesn't exist yet; an empty subtree is pruned on write().
+    tree.clear_children(&sb.repo, "data/never").unwrap();
+    let hash = tree.write(&sb.repo).unwrap();
+
+    assert_eq!(
+        hash, base,
+        "clearing a non-existent subtree must not change the written tree",
+    );
+}

--- a/holo-tree/tests/repo_ops.rs
+++ b/holo-tree/tests/repo_ops.rs
@@ -1,0 +1,74 @@
+//! Tests for repo-level helpers used by the napi binding / gitsheets:
+//! `resolve_ref` and the compare-and-swap variant of `update_ref`.
+
+mod helpers;
+
+use helpers::Sandbox;
+use holo_tree::repo::{resolve_ref, update_ref};
+
+/// Build two distinct commits (A then B, B child of A) on an empty tree.
+fn two_commits(sb: &Sandbox) -> (gix::ObjectId, gix::ObjectId) {
+    let tree_a = sb.write_tree(&[("a.toml", "id = 1\n")]);
+    let a = sb.commit(tree_a, None, "a");
+    let tree_b = sb.write_tree(&[("b.toml", "id = 2\n")]);
+    let b = sb.commit(tree_b, Some(a), "b");
+    (a, b)
+}
+
+#[test]
+fn resolve_ref_returns_commit_hash_for_a_branch() {
+    let sb = Sandbox::new();
+    let (a, _) = two_commits(&sb);
+    sb.set_ref("refs/heads/work", a);
+
+    assert_eq!(resolve_ref(&sb.repo, "refs/heads/work").unwrap(), Some(a));
+    // A bare object id resolves to itself.
+    assert_eq!(resolve_ref(&sb.repo, &a.to_string()).unwrap(), Some(a));
+}
+
+#[test]
+fn resolve_ref_returns_none_for_unknown_ref() {
+    let sb = Sandbox::new();
+    let (a, _) = two_commits(&sb);
+    sb.set_ref("refs/heads/work", a);
+
+    assert_eq!(resolve_ref(&sb.repo, "refs/heads/nope").unwrap(), None);
+    assert_eq!(resolve_ref(&sb.repo, "does-not-exist").unwrap(), None);
+}
+
+#[test]
+fn update_ref_cas_succeeds_when_expected_matches() {
+    let sb = Sandbox::new();
+    let (a, b) = two_commits(&sb);
+    sb.set_ref("refs/heads/work", a);
+
+    update_ref(&sb.repo, "refs/heads/work", b, Some(a)).unwrap();
+    assert_eq!(resolve_ref(&sb.repo, "refs/heads/work").unwrap(), Some(b));
+}
+
+#[test]
+fn update_ref_cas_fails_when_expected_does_not_match() {
+    let sb = Sandbox::new();
+    let (a, b) = two_commits(&sb);
+    sb.set_ref("refs/heads/work", b); // ref is at B...
+
+    // ...but we claim it should be at A — the swap must be rejected.
+    let err = update_ref(&sb.repo, "refs/heads/work", a, Some(a)).unwrap_err();
+    assert!(
+        matches!(err, holo_tree::Error::Git(_)),
+        "CAS mismatch should surface as a git error, got {err:?}",
+    );
+    // Ref is unchanged.
+    assert_eq!(resolve_ref(&sb.repo, "refs/heads/work").unwrap(), Some(b));
+}
+
+#[test]
+fn update_ref_without_expected_forces() {
+    let sb = Sandbox::new();
+    let (a, b) = two_commits(&sb);
+    sb.set_ref("refs/heads/work", a);
+
+    // No expected_old → unconditional set, even though current != target's parent.
+    update_ref(&sb.repo, "refs/heads/work", b, None).unwrap();
+    assert_eq!(resolve_ref(&sb.repo, "refs/heads/work").unwrap(), Some(b));
+}


### PR DESCRIPTION
Extends the `@hologit/holo-tree` napi binding (and the underlying `holo-tree`
crate) with the operations the gitsheets tree-op migration needs
(JarvusInnovations/gitsheets#127).

**Design principle:** no mutable subtree handles. Rather than hand JS a second
`Tree` that writes through to a parent's subtree (which would alias owned data
across the FFI boundary), this exposes **deep-path operations** on the root
`Tree` plus **read-only** navigation. gitsheets adapts to deep paths.

## New binding methods (`holo-tree-napi`)

**Repo**
- `resolveRef(ref)` → `hash | null` — resolve a ref/rev-spec to a commit hash,
  peeling tags; `null` when it doesn't resolve.
- `writeBlob(buf: Buffer)` → `hash` — hash bytes into the ODB without a tree.
- `updateRef(ref, hash, expectedOldHash?)` — **compare-and-swap** when
  `expectedOldHash` is given (`PreviousValue::MustExistAndMatch`), unconditional
  force when omitted (prior behavior).

**Tree** (read-only navigation + deep-path mutation)
- `getChild(path)` → `{ type, hash, mode } | null`
- `getChildren(path)` → `[{ name, type, hash, mode }]`
- `getBlobMap(path?)` → `[{ path, hash, mode }]` (paths relative to the
  navigated subtree)
- `clearChildren(path)` — O(1) subtree wipe (point at empty tree + dirty
  ancestors, without loading the cleared subtree's contents)
- `merge(other: Tree, { files?, mode })` — `overlay` | `replace` | `underlay`;
  `other` is taken as a `&mut Tree` parameter (both owned napi objects).

## New `holo-tree` (Rust) functions

- `MutableTree::clear_children(path)` — O(1) deep-path subtree clear.
- `repo::resolve_ref(ref)` → `Option<ObjectId>` — tag-peeling resolver; `None`
  when unresolved.
- `repo::update_ref` gains `expected_old: Option<ObjectId>` — CAS via
  `PreviousValue::MustExistAndMatch`, else force. (Only caller is the binding,
  updated in lockstep.)
- `Error::code()` — stable per-variant codes (`GIT`, `NOT_A_TREE`,
  `PATH_NOT_FOUND`, `GLOB`, `TOML`).

## Attempted-but-not-shipped (flagged)

- **Non-flushing `tree.getHash()` — not shipped.** An accurate hash is only
  defined *after* serializing a tree's (dirty) subtrees to the ODB — i.e.
  exactly what `write()` does. `MutableTree.hash` is stale after any mutation
  until `write()` flushes, so a "getHash" accessor would either be a footgun
  (authoritative-looking but stale) or just re-do `write()`. Recommendation:
  callers use `write()` for canonical hashes. (Read-only navigators *do* report
  accurate child hashes on a freshly loaded/written tree — see the README note.)

- **Structured error `code` per variant — half-shipped.** The clean upstream
  half landed: `holo_tree::Error::code()` gives a stable, matchable token per
  variant. The binding **can't yet surface it on JS errors**: napi-rs 2.16 only
  implements `ToNapiValue` for `Result<T, napi::Error<Status>>` (the default
  status type) for value-returning methods, so returning `Result<T,
  Error<String>>` to carry a custom `error.code` fails to compile for every
  method that returns a value (verified: a `()`-returning probe compiled and JS
  saw `error.code`, but `Result<String, Error<String>>` does **not** implement
  `ToNapiValue`). Shipping it would require either a napi upgrade or wrapping
  every return — left as upstream follow-up. Binding errors remain
  `Display`-stringified for now; `Error::code()` is in place for when the
  binding can carry it.

## Tests

- `cargo test -p holo-tree -p holo-projector` — green. New Rust tests:
  `holo-tree/tests/clear_children.rs` (4), `holo-tree/tests/repo_ops.rs` (5,
  covering `resolve_ref` + CAS `update_ref` match/mismatch/force), and an inline
  `Error::code()` test.
- `cd holo-tree-napi && npm install && npm run build:debug && npm test` — green
  (10 tests; new `test/ops.mjs` covers writeBlob, resolveRef, updateRef CAS,
  getChild/getChildren, getBlobMap, clearChildren, merge).
- `index.d.ts` regenerated by `napi build` (committed); README surface table
  updated.

No version bump / no publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr8McAaAQC9SPXrzvXejRd
