### PR TITLE
fix(holo-tree): delete_child_deep must dirty the ancestor chain

### DIFF
--- a/holo-tree/src/tree.rs
+++ b/holo-tree/src/tree.rs
@@ -518,10 +518,29 @@ impl MutableTree {
             None => return self.delete_child(repo, path),
         };
 
-        match self.get_subtree(repo, dir)? {
-            Some(tree) => tree.delete_child(repo, name),
-            None => Ok(false),
+        // Mark the path to `dir` dirty as we descend: removing a descendant
+        // changes every ancestor's serialized form, so all must be rewritten by
+        // write(). The previous read-only `get_subtree` navigation dirtied only
+        // the leaf dir, so a clean root short-circuited in write() and the
+        // deletion was silently dropped. (If the path doesn't fully exist there
+        // is nothing to delete; the few nodes dirtied along the way re-serialize
+        // to identical hashes, so over-dirtying on a miss is harmless.)
+        self.dirty = true;
+        let mut cur = self;
+        for part in dir.split('/') {
+            if part.is_empty() || part == "." {
+                continue;
+            }
+            cur.ensure_children(repo)?;
+            match cur.children.as_mut().unwrap().get_mut(part) {
+                Some(Child::Tree(t)) => {
+                    t.dirty = true;
+                    cur = t;
+                }
+                _ => return Ok(false),
+            }
         }
+        cur.delete_child(repo, name)
     }
 
     /// Clear all children under a deep `path`, replacing the subtree there

--- a/holo-tree/tests/write_child.rs
+++ b/holo-tree/tests/write_child.rs
@@ -98,3 +98,46 @@ fn write_child_at_repo_root_into_empty() {
         Some(&b"id = 1\n"[..]),
     );
 }
+
+/// Regression: deleting a child deep inside a lazily-loaded tree must dirty the
+/// ancestor chain, or `write()` short-circuits on a clean root and silently
+/// drops the deletion (returns the original tree hash). Surfaced by the
+/// gitsheets migration (#127): every Sheet delete/rename-cleanup hit this once
+/// the working tree was binding-backed.
+#[test]
+fn delete_child_deep_into_existing_tree_persists() {
+    let sb = Sandbox::new();
+
+    // Committed tree with two records in a directory; reload it lazily.
+    let base = sb.write_tree(&[("data/a.toml", "id = 1\n"), ("data/b.toml", "id = 2\n")]);
+    let mut tree = MutableTree::new(base);
+
+    let deleted = tree.delete_child_deep(&sb.repo, "data/a.toml").unwrap();
+    assert!(deleted, "the record existed and should report deleted");
+
+    let new_hash = tree.write(&sb.repo).unwrap();
+    assert_ne!(new_hash, base, "deletion must change the tree hash (the bug: it didn't)");
+
+    let mut reloaded = MutableTree::new(new_hash);
+    assert!(
+        reloaded.read_blob(&sb.repo, "data/a.toml").unwrap().is_none(),
+        "deleted record must be gone after write()",
+    );
+    assert_eq!(
+        reloaded.read_blob(&sb.repo, "data/b.toml").unwrap().as_deref(),
+        Some(&b"id = 2\n"[..]),
+        "sibling must be preserved",
+    );
+}
+
+/// Deleting a non-existent deep path is a clean no-op: returns false and leaves
+/// the tree hash unchanged.
+#[test]
+fn delete_child_deep_missing_is_noop() {
+    let sb = Sandbox::new();
+    let base = sb.write_tree(&[("data/a.toml", "id = 1\n")]);
+    let mut tree = MutableTree::new(base);
+
+    assert!(!tree.delete_child_deep(&sb.repo, "data/missing.toml").unwrap());
+    assert_eq!(tree.write(&sb.repo).unwrap(), base, "no-op delete must not change the hash");
+}


### PR DESCRIPTION
## The bug

`delete_child_deep` navigated to the parent directory via the read-only
`get_subtree` and dirtied only that leaf dir. So when deleting from a
lazily-loaded tree (`createTreeFromRef`), the **ancestors stayed clean**, the
root short-circuited in `write()` (`if !self.dirty { return self.hash }`), and
the deletion was **silently dropped** — `write()` returned the original tree
hash. `writeChild`/`clearChildren` flush fine; only `deleteChildDeep` was broken.

Same dirty-propagation class as the earlier `get_or_create_subtree` fixes, but
on the delete path — which the write-only regression tests didn't exercise.

## Fix

Mark the path to the target dir dirty as we descend (mirrors
`get_or_create_subtree`). Over-dirtying on a missing path is harmless — those
nodes re-serialize to identical hashes. Adds two regression tests
(`delete_child_deep_into_existing_tree_persists`, `delete_child_deep_missing_is_noop`).

## How it surfaced

The gitsheets migration agent (gitsheets#202) found it: every binding-backed
`Sheet` delete / rename-cleanup / attachment-cascade dropped its deletion. It
correctly **reverted** the working-tree migration rather than hack around it, and
flagged this as the upstream blocker. Verified the fix end-to-end through the
napi binding (delete round-trip: hash changes, record gone, sibling kept).

Ships in `@hologit/holo-tree@0.2.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)