### PR TITLE
feat(holo-tree-napi): 6-platform prebuilds (arm64-linux, musl, darwin-x64)

### DIFF
--- a/.github/workflows/holo-tree-napi.yml
+++ b/.github/workflows/holo-tree-napi.yml
@@ -62,7 +62,7 @@ jobs:
           # the smoke test is skipped (the logic is covered by the native runs).
           - target: x86_64-unknown-linux-musl
             host: ubuntu-latest
-            setup: sudo apt-get update && sudo apt-get install -y musl-tools
+            zig: true
             test: false
           - target: x86_64-apple-darwin
             host: macos-latest
@@ -81,9 +81,15 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Target setup
-        if: ${{ matrix.setup }}
-        run: ${{ matrix.setup }}
+      # zig cc bundles libc/libgcc and links musl cleanly — napi-rs's
+      # recommended cross path. (musl-gcc fails on `libgcc_s.so.1`.)
+      - name: Setup zig (musl cross-link)
+        if: ${{ matrix.zig }}
+        working-directory: ${{ runner.temp }}
+        run: |
+          ZIG=zig-linux-x86_64-0.13.0
+          curl -fsSL "https://ziglang.org/download/0.13.0/${ZIG}.tar.xz" | tar -xJ
+          echo "${{ runner.temp }}/${ZIG}" >> "$GITHUB_PATH"
 
       - name: Configure git identity (the smoke test commits to scratch repos)
         if: ${{ matrix.test }}
@@ -94,11 +100,7 @@ jobs:
       - run: npm install
 
       - name: Build (release)
-        run: npm run build -- --target ${{ matrix.target }}
-        env:
-          # Only consulted when building the musl target; harmless otherwise.
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
-          CC_x86_64_unknown_linux_musl: musl-gcc
+        run: npm run build -- --target ${{ matrix.target }}${{ matrix.zig && ' --zig' || '' }}
 
       - name: Smoke test
         if: ${{ matrix.test }}

--- a/.github/workflows/holo-tree-napi.yml
+++ b/.github/workflows/holo-tree-napi.yml
@@ -45,12 +45,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Native — build + smoke-test on a matching runner.
           - target: x86_64-unknown-linux-gnu
             host: ubuntu-latest
+            test: true
+          - target: aarch64-unknown-linux-gnu
+            host: ubuntu-24.04-arm
+            test: true
           - target: aarch64-apple-darwin
             host: macos-latest
+            test: true
           - target: x86_64-pc-windows-msvc
             host: windows-latest
+            test: true
+          # Cross — build only; the .node can't run on the host arch/libc, so
+          # the smoke test is skipped (the logic is covered by the native runs).
+          - target: x86_64-unknown-linux-musl
+            host: ubuntu-latest
+            setup: sudo apt-get update && sudo apt-get install -y musl-tools
+            test: false
+          - target: x86_64-apple-darwin
+            host: macos-latest
+            test: false
     runs-on: ${{ matrix.host }}
     steps:
       - uses: actions/checkout@v4
@@ -65,17 +81,27 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Target setup
+        if: ${{ matrix.setup }}
+        run: ${{ matrix.setup }}
+
       - name: Configure git identity (the smoke test commits to scratch repos)
+        if: ${{ matrix.test }}
         run: |
           git config --global user.name "holo-tree CI"
           git config --global user.email "ci@hologit.local"
 
       - run: npm install
 
-      - name: Build (native, release)
+      - name: Build (release)
         run: npm run build -- --target ${{ matrix.target }}
+        env:
+          # Only consulted when building the musl target; harmless otherwise.
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
+          CC_x86_64_unknown_linux_musl: musl-gcc
 
       - name: Smoke test
+        if: ${{ matrix.test }}
         run: npm test
 
       - uses: actions/upload-artifact@v7

--- a/holo-tree-napi/README.md
+++ b/holo-tree-napi/README.md
@@ -78,16 +78,20 @@ git-ignored (built per-platform in CI).
 Published as the scoped package **`@hologit/holo-tree`** with per-platform
 prebuilt binaries shipped as `optionalDependencies`:
 
-| Platform package | Triple | Built on |
-| --- | --- | --- |
-| `@hologit/holo-tree-linux-x64-gnu` | `x86_64-unknown-linux-gnu` | ubuntu-latest |
-| `@hologit/holo-tree-darwin-arm64` | `aarch64-apple-darwin` | macos-latest |
-| `@hologit/holo-tree-win32-x64-msvc` | `x86_64-pc-windows-msvc` | windows-latest |
+| Platform package | Triple | Built on | Smoke-tested |
+| --- | --- | --- | --- |
+| `@hologit/holo-tree-linux-x64-gnu` | `x86_64-unknown-linux-gnu` | ubuntu-latest | ✓ native |
+| `@hologit/holo-tree-linux-arm64-gnu` | `aarch64-unknown-linux-gnu` | ubuntu-24.04-arm | ✓ native |
+| `@hologit/holo-tree-linux-x64-musl` | `x86_64-unknown-linux-musl` | ubuntu-latest (musl cross) | build-only |
+| `@hologit/holo-tree-darwin-arm64` | `aarch64-apple-darwin` | macos-latest | ✓ native |
+| `@hologit/holo-tree-darwin-x64` | `x86_64-apple-darwin` | macos-latest (cross) | build-only |
+| `@hologit/holo-tree-win32-x64-msvc` | `x86_64-pc-windows-msvc` | windows-latest | ✓ native |
 
-Each target builds **natively** on its runner — no cross-compilation. The
-`.github/workflows/holo-tree-napi.yml` workflow builds + smoke-tests all three on
-every PR touching the binding, and on a `holo-tree-v*` tag it builds then
-publishes.
+Native targets build + smoke-test on a matching runner; cross targets (musl,
+darwin-x64) build only, since their `.node` can't run on the host arch/libc (the
+logic is covered by the native runs). The `.github/workflows/holo-tree-napi.yml`
+workflow builds all six on every PR touching the binding, and on a
+`holo-tree-v*` tag it builds then publishes.
 
 Auth is **npm trusted publishing (OIDC)** — no tokens, matching hologit's
 `publish-npm.yml`. Trusted publishing is configured *per package*, and a package

--- a/holo-tree-napi/npm/darwin-x64/README.md
+++ b/holo-tree-napi/npm/darwin-x64/README.md
@@ -1,0 +1,3 @@
+# `@hologit/holo-tree-darwin-x64`
+
+This is the **x86_64-apple-darwin** binary for `@hologit/holo-tree`

--- a/holo-tree-napi/npm/darwin-x64/package.json
+++ b/holo-tree-napi/npm/darwin-x64/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@hologit/holo-tree-darwin-x64",
+  "version": "0.0.1",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "holo-tree.darwin-x64.node",
+  "files": [
+    "holo-tree.darwin-x64.node"
+  ],
+  "description": "Node.js native binding for holo-tree — mutable in-memory git trees via gix",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JarvusInnovations/hologit.git",
+    "directory": "holo-tree-napi"
+  }
+}

--- a/holo-tree-napi/npm/linux-arm64-gnu/README.md
+++ b/holo-tree-napi/npm/linux-arm64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@hologit/holo-tree-linux-arm64-gnu`
+
+This is the **aarch64-unknown-linux-gnu** binary for `@hologit/holo-tree`

--- a/holo-tree-napi/npm/linux-arm64-gnu/package.json
+++ b/holo-tree-napi/npm/linux-arm64-gnu/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@hologit/holo-tree-linux-arm64-gnu",
+  "version": "0.0.1",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "holo-tree.linux-arm64-gnu.node",
+  "files": [
+    "holo-tree.linux-arm64-gnu.node"
+  ],
+  "description": "Node.js native binding for holo-tree — mutable in-memory git trees via gix",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JarvusInnovations/hologit.git",
+    "directory": "holo-tree-napi"
+  },
+  "libc": [
+    "glibc"
+  ]
+}

--- a/holo-tree-napi/npm/linux-x64-musl/README.md
+++ b/holo-tree-napi/npm/linux-x64-musl/README.md
@@ -1,0 +1,3 @@
+# `@hologit/holo-tree-linux-x64-musl`
+
+This is the **x86_64-unknown-linux-musl** binary for `@hologit/holo-tree`

--- a/holo-tree-napi/npm/linux-x64-musl/package.json
+++ b/holo-tree-napi/npm/linux-x64-musl/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@hologit/holo-tree-linux-x64-musl",
+  "version": "0.0.1",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "holo-tree.linux-x64-musl.node",
+  "files": [
+    "holo-tree.linux-x64-musl.node"
+  ],
+  "description": "Node.js native binding for holo-tree — mutable in-memory git trees via gix",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JarvusInnovations/hologit.git",
+    "directory": "holo-tree-napi"
+  },
+  "libc": [
+    "musl"
+  ]
+}

--- a/holo-tree-napi/package.json
+++ b/holo-tree-napi/package.json
@@ -19,7 +19,10 @@
       "defaults": false,
       "additional": [
         "x86_64-unknown-linux-gnu",
+        "aarch64-unknown-linux-gnu",
+        "x86_64-unknown-linux-musl",
         "aarch64-apple-darwin",
+        "x86_64-apple-darwin",
         "x86_64-pc-windows-msvc"
       ]
     }
@@ -30,7 +33,10 @@
   ],
   "optionalDependencies": {
     "@hologit/holo-tree-linux-x64-gnu": "0.0.1",
+    "@hologit/holo-tree-linux-arm64-gnu": "0.0.1",
+    "@hologit/holo-tree-linux-x64-musl": "0.0.1",
     "@hologit/holo-tree-darwin-arm64": "0.0.1",
+    "@hologit/holo-tree-darwin-x64": "0.0.1",
     "@hologit/holo-tree-win32-x64-msvc": "0.0.1"
   },
   "scripts": {


### PR DESCRIPTION
Expands the binding from 3 → 6 prebuilt platforms so gitsheets can adopt it as
its **sole tree substrate** (dropping hologit) without breaking common Node
deployment targets. Decided as the path forward for the holo-tree migration
(gitsheets#127): expand coverage, then drop hologit (vs. permanent dual-path).

## Platforms

| Triple | Runner | Smoke-tested |
| --- | --- | --- |
| x86_64-unknown-linux-gnu | ubuntu-latest | ✓ native |
| **aarch64-unknown-linux-gnu** | ubuntu-24.04-arm | ✓ native |
| **x86_64-unknown-linux-musl** | ubuntu-latest (musl cross) | build-only |
| aarch64-apple-darwin | macos-latest | ✓ native |
| **x86_64-apple-darwin** | macos-latest (cross) | build-only |
| x86_64-pc-windows-msvc | windows-latest | ✓ native |

Cross targets build only — their `.node` can't run on the host arch/libc; the
logic is covered by the native runs. This PR's matrix validates all six compile.

## Follow-up needed before a 6-platform release

The 3 new platform packages (`-linux-arm64-gnu`, `-linux-x64-musl`, `-darwin-x64`)
are **new npm packages** → they need the same one-time trusted-publishing
bootstrap (manual first publish with the CI artifacts + trusted-publisher config)
the original four had, before an automated `holo-tree-v*` tag can publish them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)