### PR TITLE
fix(holo-tree): derive update_ref reflog identity from the commit's committer

### DIFF
--- a/holo-tree/src/repo.rs
+++ b/holo-tree/src/repo.rs
@@ -180,12 +180,25 @@ pub fn resolve_ref(repo: &gix::Repository, git_ref: &str) -> Result<Option<Objec
 /// ref out from under the caller makes the swap fail loudly rather than clobber
 /// their commit. When `None`, the ref is set unconditionally
 /// (`PreviousValue::Any`), matching the original force behavior.
+///
+/// The reflog identity is derived from the **committer of the commit the ref now
+/// points at**, falling back to a stable `holo-tree` default for non-commit
+/// targets or unreadable commits. It never reads ambient git config
+/// (`user.name` / `user.email`). gix's convenience `reference()` does reach for
+/// ambient config to stamp the reflog, and fails with "The reflog could not be
+/// created or updated" when none is set — so an embedding consumer that supplies
+/// a fully-specified commit (matching [`commit_tree`]'s explicit-identity
+/// contract) could still see the *ref update* fail on an unconfigured runner.
+/// Sourcing the identity from the commit itself keeps the whole operation
+/// independent of machine config.
 pub fn update_ref(
     repo: &gix::Repository,
     refname: &str,
     target: ObjectId,
     expected_old: Option<ObjectId>,
 ) -> Result<()> {
+    use gix::refs::transaction::{Change, LogChange, RefEdit, RefLog};
+
     let qualified = qualify_ref(refname);
     let previous = match expected_old {
         Some(old) => gix::refs::transaction::PreviousValue::MustExistAndMatch(
@@ -193,7 +206,41 @@ pub fn update_ref(
         ),
         None => gix::refs::transaction::PreviousValue::Any,
     };
-    repo.reference(qualified.as_ref(), target, previous, "holo-tree")
+
+    let name: gix::refs::FullName = qualified
+        .as_ref()
+        .try_into()
+        .map_err(|e: gix::refs::name::Error| Error::Git(e.to_string()))?;
+
+    // Reflog identity: the target commit's committer, else a stable default.
+    // Read the commit up front so its data outlives the borrowed `SignatureRef`
+    // we hand to the transaction below.
+    let commit = repo
+        .find_object(target)
+        .ok()
+        .and_then(|obj| obj.try_into_commit().ok());
+    let fallback = default_signature();
+    let mut time_buf = gix::date::parse::TimeBuf::default();
+    let committer = commit
+        .as_ref()
+        .and_then(|c| c.committer().ok())
+        .unwrap_or_else(|| fallback.to_ref(&mut time_buf));
+
+    let edit = RefEdit {
+        change: Change::Update {
+            log: LogChange {
+                mode: RefLog::AndReference,
+                force_create_reflog: false,
+                message: "holo-tree".into(),
+            },
+            expected: previous,
+            new: gix::refs::Target::Object(target),
+        },
+        name,
+        deref: false,
+    };
+
+    repo.edit_references_as(Some(edit), Some(committer))
         .map_err(|e| Error::Git(e.to_string()))?;
     Ok(())
 }

--- a/holo-tree/tests/helpers/mod.rs
+++ b/holo-tree/tests/helpers/mod.rs
@@ -85,6 +85,31 @@ impl Sandbox {
         self.repo.write_object(&commit).unwrap().detach()
     }
 
+    /// Enable reflog writes on this repo's local config (`core.logAllRefUpdates`).
+    ///
+    /// A bare repo defaults this off, so ref updates write no reflog — but a
+    /// normal checkout / CI runner has it on. Tests that need to exercise the
+    /// reflog path (see #476) turn it on to match that environment. Writes the
+    /// repo's own config file, so it's honored even by an `isolated()` handle
+    /// (which drops ambient global/system/env config but keeps local config).
+    pub fn enable_reflogs(&self) {
+        use std::io::Write;
+        let config_path = self.dir.path().join("config");
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&config_path)
+            .expect("open repo config");
+        writeln!(f, "[core]\n\tlogAllRefUpdates = true").expect("write config");
+    }
+
+    /// Reopen this repo with `isolated()` options — no environment, global, or
+    /// system git config (so no ambient `user.name` / `user.email`), while the
+    /// repo's own local config still applies.
+    pub fn open_isolated(&self) -> gix::Repository {
+        gix::open_opts(self.dir.path(), gix::open::Options::isolated())
+            .expect("reopen sandbox repo with isolated config")
+    }
+
     /// Create a ref pointing to an object.
     pub fn set_ref(&self, name: &str, target: ObjectId) {
         self.repo

--- a/holo-tree/tests/repo_ops.rs
+++ b/holo-tree/tests/repo_ops.rs
@@ -72,3 +72,59 @@ fn update_ref_without_expected_forces() {
     update_ref(&sb.repo, "refs/heads/work", b, None).unwrap();
     assert_eq!(resolve_ref(&sb.repo, "refs/heads/work").unwrap(), Some(b));
 }
+
+/// The reflog identity must come from the committer of the commit the ref now
+/// points at — not from ambient git config. The sandbox commits are stamped
+/// "Test <test@test>", so that is what the reflog entry must record, regardless
+/// of whatever `user.name` / `user.email` the machine running the test has.
+#[test]
+fn update_ref_reflog_identity_comes_from_commit_committer() {
+    let sb = Sandbox::new();
+    let (a, _) = two_commits(&sb);
+    sb.enable_reflogs();
+    let repo = sb.open_isolated();
+
+    update_ref(&repo, "refs/heads/work", a, None).unwrap();
+
+    let reference = repo.find_reference("refs/heads/work").unwrap();
+    let mut platform = reference.log_iter();
+    let iter = platform
+        .all()
+        .unwrap()
+        .expect("update_ref should have written a reflog");
+
+    let mut last = None;
+    for line in iter {
+        let line = line.unwrap();
+        last = Some((
+            line.signature.name.to_string(),
+            line.signature.email.to_string(),
+        ));
+    }
+    let (name, email) = last.expect("reflog should have at least one entry");
+    assert_eq!(name, "Test", "reflog name should be the commit's committer");
+    assert_eq!(
+        email, "test@test",
+        "reflog email should be the commit's committer"
+    );
+}
+
+/// Regression for #476: a ref update on a fully-specified commit must not depend
+/// on ambient git config. We reopen the sandbox repo with `isolated()` options —
+/// which ignore environment and global/system git config, so no `user.name` /
+/// `user.email` is visible — and confirm `update_ref` still succeeds. gix's
+/// convenience `reference()` fails here with "The reflog could not be created or
+/// updated"; deriving the reflog identity from the commit's committer fixes it.
+#[test]
+fn update_ref_succeeds_without_ambient_git_identity() {
+    let sb = Sandbox::new();
+    let (a, b) = two_commits(&sb);
+    sb.set_ref("refs/heads/work", a);
+    // Reproduce a CI checkout: reflogs on (so the reflog identity is actually
+    // needed) but no ambient git identity available.
+    sb.enable_reflogs();
+    let isolated = sb.open_isolated();
+
+    update_ref(&isolated, "refs/heads/work", b, Some(a)).unwrap();
+    assert_eq!(resolve_ref(&isolated, "refs/heads/work").unwrap(), Some(b));
+}


### PR DESCRIPTION
## Summary

Fixes #476. `holo_repo::update_ref` used gix's convenience `reference()`, which stamps the reflog with the committer read from **ambient git config** (`user.name` / `user.email`). When no git identity is configured — a fresh CI runner or an embedded consumer in an unconfigured context — the *commit* succeeds (`commit_tree` already falls back to a stable `holo-tree` identity) but the *ref update* fails with:

```
The reflog could not be created or updated
```

This leaks exactly the ambient-config dependency the explicit-identity API was meant to remove: a consumer that drives fully-specified commits (like `gitsheets-core`) still needs a machine git identity, purely to satisfy the reflog write.

## Fix

Build the `RefEdit` explicitly and pass the reflog committer via `edit_references_as`, sourcing it from the **committer of the commit the ref now points at** (issue #476's preferred option 1), and falling back to the same `default_signature()` that `commit_tree` uses for non-commit targets / unreadable commits. The whole operation is now independent of machine git config.

## Tests

Two regression tests in `holo-tree/tests/repo_ops.rs`, both verified to **fail on the prior code** (the second with the exact `"The reflog could not be created or updated"` error):

- `update_ref_reflog_identity_comes_from_commit_committer` — asserts the reflog entry records the commit's committer (`Test <test@test>`), not ambient config.
- `update_ref_succeeds_without_ambient_git_identity` — reproduces a CI checkout (reflogs enabled, no ambient identity via an `isolated()` repo handle) and confirms the update succeeds.

A `Sandbox::enable_reflogs()` / `open_isolated()` helper pair was added to model that environment (a bare test repo defaults `core.logAllRefUpdates` off, so the reflog path would otherwise never run).

`cargo test` passes across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)