### PR TITLE
feat(holo-tree): add write_child_hash — place a blob by hash without re-reading its bytes

### DIFF
--- a/holo-tree-napi/index.d.ts
+++ b/holo-tree-napi/index.d.ts
@@ -123,6 +123,15 @@ export declare class Tree {
   writeChild(path: string, content: string): string
   /** Hash raw bytes as a blob and insert at `path`. Binary-safe. */
   writeChildBytes(path: string, content: Buffer): string
+  /**
+   * Place an already-written blob at `path` by its `hash`, without reading its
+   * bytes. Unlike `writeChildBytes` (which re-hashes content), this grafts a
+   * blob already in the ODB — validated to exist and be a blob via a header
+   * lookup, so a large attachment isn't read back and re-hashed. `mode` is the
+   * git filemode: `0o100644` regular, `0o100755` executable, `0o120000`
+   * symlink. Returns the placed hash.
+   */
+  writeChildHash(path: string, hash: string, mode: number): string
   /** Read a blob's bytes at `path`, or `null` if no blob exists there. */
   readBlob(path: string): Buffer | null
   /**

--- a/holo-tree-napi/src/lib.rs
+++ b/holo-tree-napi/src/lib.rs
@@ -309,6 +309,29 @@ impl Tree {
         Ok(oid_hex(oid))
     }
 
+    /// Place an already-written blob at `path` by its `hash`, without reading its
+    /// bytes. Unlike `writeChildBytes` (which re-hashes content), this grafts a
+    /// blob already in the ODB — validated to exist and be a blob via a header
+    /// lookup, so a large attachment isn't read back and re-hashed. `mode` is the
+    /// git filemode: `0o100644` regular, `0o100755` executable, `0o120000`
+    /// symlink. Returns the placed hash.
+    #[napi]
+    pub fn write_child_hash(
+        &mut self,
+        path: String,
+        hash: String,
+        mode: u32,
+    ) -> napi::Result<String> {
+        let local = self.repo.to_thread_local();
+        let oid = parse_oid(&hash)?;
+        let mode = u16::try_from(mode)
+            .map_err(|_| napi::Error::from_reason(format!("invalid blob mode {mode:o}")))?;
+        self.inner
+            .write_child_hash(&local, &path, oid, mode)
+            .map_err(ht_err)?;
+        Ok(oid_hex(oid))
+    }
+
     /// Read a blob's bytes at `path`, or `null` if no blob exists there.
     #[napi]
     pub fn read_blob(&mut self, path: String) -> napi::Result<Option<Buffer>> {

--- a/holo-tree-napi/test/ops.mjs
+++ b/holo-tree-napi/test/ops.mjs
@@ -1,6 +1,6 @@
 // Smoke tests for the tree/ref ops added for the gitsheets migration:
-//   writeBlob, resolveRef, updateRef (CAS), getChild, getChildren,
-//   getBlobMap, clearChildren, merge.
+//   writeBlob, writeChildHash, resolveRef, updateRef (CAS), getChild,
+//   getChildren, getBlobMap, clearChildren, merge.
 //
 // Requires the addon to be built first: `npm run build:debug` (or `build`).
 // Run with: `npm test` (node --test).
@@ -216,6 +216,40 @@ test('merge overlays another tree in place', () => {
 
     // An invalid mode is rejected.
     assert.throws(() => base.merge(incoming, { mode: 'bogus' }), /invalid merge mode/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('writeChildHash places an existing blob by hash, matching writeChildBytes', () => {
+  const dir = scratchRepo();
+  try {
+    const repo = Repo.open(join(dir, '.git'));
+    const content = Buffer.from('attachment payload\n');
+    const blob = repo.writeBlob(content);
+
+    // Placing by hash yields the same tree as hashing the same content.
+    const byBytes = repo.createTree();
+    byBytes.writeChildBytes('data/att.bin', content);
+    const byBytesHash = byBytes.write();
+
+    const byHash = repo.createTree();
+    const placed = byHash.writeChildHash('data/att.bin', blob, 0o100644);
+    assert.equal(placed, blob, 'writeChildHash echoes the placed hash');
+    assert.equal(byHash.write(), byBytesHash, 'place-by-hash must match write-by-content');
+
+    // Mode is honored: executable produces a different tree.
+    const exec = repo.createTree();
+    exec.writeChildHash('data/att.bin', blob, 0o100755);
+    assert.notEqual(exec.write(), byBytesHash, 'mode must be reflected in the tree');
+
+    // A non-blob object (a tree hash) is rejected.
+    assert.throws(() => repo.createTree().writeChildHash('x', byBytesHash, 0o100644), /not a blob/);
+    // An absent hash is rejected.
+    assert.throws(
+      () => repo.createTree().writeChildHash('x', '0123456789abcdef0123456789abcdef01234567', 0o100644),
+      /./,
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/holo-tree/src/tree.rs
+++ b/holo-tree/src/tree.rs
@@ -507,6 +507,68 @@ impl MutableTree {
         Ok(blob_id)
     }
 
+    /// Place an already-written blob at a deep path by its hash, without reading
+    /// its bytes.
+    ///
+    /// Unlike [`write_child_bytes`](Self::write_child_bytes), which takes blob
+    /// *content* and writes (re-hashes) it, this grafts a blob that already
+    /// exists in the ODB. A consumer that holds a content-addressed blob hash —
+    /// because it wrote the blob earlier, or received the hash from elsewhere —
+    /// can place it without handing over the bytes again. `mode` is the git entry
+    /// mode for the blob: `0o100644` (regular), `0o100755` (executable), or
+    /// `0o120000` (symlink).
+    ///
+    /// The object is validated to exist and be a blob via an object *header*
+    /// lookup, which does not decode the blob payload — so placing a large
+    /// attachment stays independent of its byte size rather than paying a full
+    /// ODB read + re-hash.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `hash` does not exist in the ODB or is not a blob, if
+    /// `mode` is not a valid blob mode, or if an intermediate path component
+    /// exists but is not a tree (same footgun guard as
+    /// [`write_child_bytes`](Self::write_child_bytes)).
+    pub fn write_child_hash(
+        &mut self,
+        repo: &gix::Repository,
+        path: &str,
+        hash: ObjectId,
+        mode: u16,
+    ) -> Result<()> {
+        if !matches!(mode, 0o100644 | 0o100755 | 0o120000) {
+            return Err(Error::Git(format!(
+                "invalid blob mode {mode:o} for {path}: expected 100644, 100755, or 120000"
+            )));
+        }
+
+        // Validate existence + kind from the object header, without decoding the
+        // blob — that byte-read is exactly what a place-by-hash caller wants to
+        // skip.
+        let header = repo
+            .find_header(hash)
+            .map_err(|e| Error::Git(e.to_string()))?;
+        if header.kind() != gix::object::Kind::Blob {
+            return Err(Error::Git(format!(
+                "object {hash} is not a blob (found {:?})",
+                header.kind()
+            )));
+        }
+
+        let (dir, name) = match path.rsplit_once('/') {
+            Some((d, f)) => (d, f),
+            None => (".", path),
+        };
+
+        let tree = self.get_or_create_subtree(repo, dir)?;
+        tree.children
+            .as_mut()
+            .unwrap()
+            .insert(name.to_string(), Child::Blob { mode, hash });
+        tree.dirty = true;
+        Ok(())
+    }
+
     /// Delete a child at a deep slash-separated path (not just a direct child).
     pub fn delete_child_deep(
         &mut self,

--- a/holo-tree/tests/write_child.rs
+++ b/holo-tree/tests/write_child.rs
@@ -141,3 +141,141 @@ fn delete_child_deep_missing_is_noop() {
     assert!(!tree.delete_child_deep(&sb.repo, "data/missing.toml").unwrap());
     assert_eq!(tree.write(&sb.repo).unwrap(), base, "no-op delete must not change the hash");
 }
+
+// ── write_child_hash (#477): place an existing blob by hash ─────────────────
+
+/// Placing a blob by hash yields a byte-identical tree to writing the same
+/// content via `write_child_bytes` — the whole point is to skip re-hashing while
+/// producing exactly the same result.
+#[test]
+fn write_child_hash_matches_write_child_bytes() {
+    let sb = Sandbox::new();
+    let content = b"attachment payload\n";
+    let blob = sb.repo.write_blob(content).unwrap().detach();
+
+    let mut by_bytes = MutableTree::empty();
+    by_bytes
+        .write_child_bytes(&sb.repo, "data/att.bin", content)
+        .unwrap();
+    let bytes_hash = by_bytes.write(&sb.repo).unwrap();
+
+    let mut by_hash = MutableTree::empty();
+    by_hash
+        .write_child_hash(&sb.repo, "data/att.bin", blob, 0o100644)
+        .unwrap();
+    let hash_hash = by_hash.write(&sb.repo).unwrap();
+
+    assert_eq!(
+        hash_hash, bytes_hash,
+        "place-by-hash must produce the same tree as write-by-content",
+    );
+}
+
+/// Placing a blob by hash into an already-populated, lazily-loaded subtree
+/// preserves the existing siblings (same subtree-loading path as
+/// `write_child_bytes`).
+#[test]
+fn write_child_hash_preserves_siblings() {
+    let sb = Sandbox::new();
+    let base = sb.write_tree(&[("data/a.toml", "id = 1\n")]);
+    let blob = sb.repo.write_blob(b"id = 2\n").unwrap().detach();
+
+    let mut tree = MutableTree::new(base);
+    tree.write_child_hash(&sb.repo, "data/b.toml", blob, 0o100644)
+        .unwrap();
+    let new_hash = tree.write(&sb.repo).unwrap();
+    assert_ne!(new_hash, base);
+
+    let mut reloaded = MutableTree::new(new_hash);
+    assert_eq!(
+        reloaded.read_blob(&sb.repo, "data/a.toml").unwrap().as_deref(),
+        Some(&b"id = 1\n"[..]),
+        "existing sibling must be preserved",
+    );
+    assert_eq!(
+        reloaded.read_blob(&sb.repo, "data/b.toml").unwrap().as_deref(),
+        Some(&b"id = 2\n"[..]),
+        "placed-by-hash blob must be present",
+    );
+}
+
+/// The `mode` argument is honored — placing the same blob as executable records
+/// mode 100755, producing a different tree than the regular-mode placement.
+#[test]
+fn write_child_hash_honors_executable_mode() {
+    let sb = Sandbox::new();
+    let blob = sb.repo.write_blob(b"#!/bin/sh\n").unwrap().detach();
+
+    let mut regular = MutableTree::empty();
+    regular
+        .write_child_hash(&sb.repo, "run", blob, 0o100644)
+        .unwrap();
+    let regular_hash = regular.write(&sb.repo).unwrap();
+
+    let mut exec = MutableTree::empty();
+    exec.write_child_hash(&sb.repo, "run", blob, 0o100755)
+        .unwrap();
+    let exec_hash = exec.write(&sb.repo).unwrap();
+
+    assert_ne!(
+        regular_hash, exec_hash,
+        "executable mode must be reflected in the tree entry",
+    );
+}
+
+/// A hash that isn't in the ODB is rejected — no invalid entry is grafted.
+#[test]
+fn write_child_hash_rejects_missing_object() {
+    let sb = Sandbox::new();
+    // A valid-shaped sha1 that was never written to this repo's ODB.
+    let absent: gix::ObjectId = "0123456789abcdef0123456789abcdef01234567"
+        .parse()
+        .unwrap();
+
+    let mut tree = MutableTree::empty();
+    let err = tree
+        .write_child_hash(&sb.repo, "x", absent, 0o100644)
+        .unwrap_err();
+    assert!(matches!(err, holo_tree::Error::Git(_)), "got {err:?}");
+}
+
+/// A hash pointing at a non-blob object (here a tree) is rejected rather than
+/// silently producing a tree entry that claims a blob mode over a tree object.
+#[test]
+fn write_child_hash_rejects_non_blob() {
+    let sb = Sandbox::new();
+    let tree_oid = sb.write_tree(&[("inner.toml", "id = 1\n")]);
+
+    let mut tree = MutableTree::empty();
+    let err = tree
+        .write_child_hash(&sb.repo, "x", tree_oid, 0o100644)
+        .unwrap_err();
+    match err {
+        holo_tree::Error::Git(msg) => assert!(
+            msg.contains("not a blob"),
+            "expected a not-a-blob error, got: {msg}",
+        ),
+        other => panic!("expected Git error, got {other:?}"),
+    }
+}
+
+/// An invalid (non-blob) mode is rejected up front, before any tree mutation —
+/// it would otherwise panic later in `write()` when mapped to an `EntryMode`.
+#[test]
+fn write_child_hash_rejects_invalid_mode() {
+    let sb = Sandbox::new();
+    let blob = sb.repo.write_blob(b"x\n").unwrap().detach();
+
+    let mut tree = MutableTree::empty();
+    // 040000 is a tree mode, not valid for a blob entry.
+    let err = tree
+        .write_child_hash(&sb.repo, "x", blob, 0o040000)
+        .unwrap_err();
+    assert!(matches!(err, holo_tree::Error::Git(_)), "got {err:?}");
+    // The tree must be untouched by a rejected call.
+    assert_eq!(
+        tree.write(&sb.repo).unwrap(),
+        MutableTree::empty().write(&sb.repo).unwrap(),
+        "a rejected write_child_hash must not mutate the tree",
+    );
+}


### PR DESCRIPTION
## Summary

Closes #477. `MutableTree` had no primitive to place an **already-written blob by its hash** — the only child-writing entry point, `write_child_bytes`, takes blob *content* and writes (re-hashes) it. A consumer that already holds a content-addressed blob hash (because it wrote the blob earlier, or received the hash) had to read the blob back via `find_object` and re-place it with `write_child_bytes`, which re-hashes the same content to the same id: one redundant ODB read + re-hash per blob. In the gitsheets attachment path (`set_attachments`) this happens once per attachment, including large ones.

## Change

`MutableTree::write_child_hash(repo, path, hash, mode)` places an existing blob at a deep path (creating intermediate subtrees) **without reading its bytes**:

- Existence + blob-kind are validated via an object **header** lookup (`find_header`), which does **not** decode the blob payload — so placing a large attachment stays independent of its byte size, which is the whole point.
- `mode` selects the blob filemode (`0o100644` regular / `0o100755` executable / `0o120000` symlink) — a generalization over `write_child_bytes`, which hardcodes `0o100644`. It's validated up front, since an invalid mode would otherwise panic later in `write()` when mapped to an `EntryMode`.

Surfaced through the napi binding as `Tree.writeChildHash(path, hash, mode)` so gitsheets can actually consume it; `index.d.ts` regenerated via `napi build`.

## Tests

- **Rust** (`holo-tree/tests/write_child.rs`): place-by-hash produces a **byte-identical tree** to `write_child_bytes`; preserves siblings in a lazily-loaded subtree; honors executable mode; and rejects a missing object, a non-blob object, and an invalid mode (asserting the tree is left untouched on rejection).
- **JS** (`holo-tree-napi/test/ops.mjs`): end-to-end `writeChildHash` — same-tree parity with `writeChildBytes`, mode honored, non-blob and absent-hash rejected.

`cargo test` (workspace) and `npm test` (napi) both pass; clippy clean. No projection-path code changed, so the `docs-site` / `github-action-projector` / `emergence-site` hash invariants are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)