### PR TITLE
feat(lens): v2 exec/stdio job protocol (one-shot) in the JS engine

### DIFF
--- a/lens-sdk/lens-job.sh
+++ b/lens-sdk/lens-job.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# lens-job.sh — reference SDK entrypoint for the hologit v2 lens job protocol
+#
+# Implements the one-shot mode of the job protocol defined in
+# specs/behaviors/lensing.md (hologit repo). A v2 lens image carries the OCI
+# label `sh.holo.lens.protocol=2` and an entrypoint implementing this contract:
+#
+#   stdin:  a git bundle containing `refs/jobs/<spec-hash>/input` — a commit
+#           whose tree is a wrapper: `.holospec/lens.toml` (the full lens spec)
+#           alongside `input/` (the input tree).
+#   stdout: a git bundle containing exactly one of:
+#             `refs/jobs/<spec-hash>/output` — success: a commit whose FIRST
+#                 PARENT is the input commit and whose tree is the bare result;
+#             `refs/jobs/<spec-hash>/error`  — failure: a commit whose tree
+#                 contains at minimum `exit-code` and `log` entries.
+#   exit:   0 on success; the lens command's exit code on failure. stdout is
+#           reserved for the bundle — ALL logging goes to stderr.
+#
+# Everything between reading the input and emitting the bundle is SDK-internal;
+# this reference SDK runs the spec's `command` with:
+#
+#   cwd                the materialized wrapper tree (so `.holospec/` and
+#                      `input/` are both visible)
+#   HOLOLENS_INPUT     absolute path of the materialized `input/` directory
+#   HOLOLENS_OUTPUT    absolute path of an empty directory the command must
+#                      populate with its result
+#   HOLOLENS_SPEC      absolute path of `.holospec/lens.toml`
+#
+# `{{ input }}` and `{{ output }}` placeholders in `command` are substituted
+# with those paths. The command's stdout+stderr are captured as the job log
+# and relayed to stderr.
+#
+# Requires only git and a POSIX shell (busybox-compatible).
+
+set -eu
+
+log() { echo "lens-job: $*" >&2; }
+
+JOB_DIR=$(mktemp -d)
+LOG_FILE="$JOB_DIR/log"
+: > "$LOG_FILE"
+
+export GIT_DIR="$JOB_DIR/repo.git"
+git init --quiet --bare "$GIT_DIR"
+git config user.name 'hologit lens'
+git config user.email 'lens-job@hologit'
+
+# --- 1. ingest the input bundle from stdin (fetch verifies all objects) ------
+BUNDLE_IN="$JOB_DIR/input.bundle"
+cat > "$BUNDLE_IN"
+git fetch --quiet "$BUNDLE_IN" 'refs/jobs/*:refs/jobs/*' >&2
+
+# --- 2. locate the job ---------------------------------------------------------
+INPUT_REF=$(git for-each-ref --format='%(refname)' 'refs/jobs/*/input' | head -n 1)
+if [ -z "$INPUT_REF" ]; then
+    log 'transport error: no refs/jobs/*/input ref found in bundle'
+    exit 65
+fi
+SPEC_HASH=${INPUT_REF#refs/jobs/}
+SPEC_HASH=${SPEC_HASH%/input}
+INPUT_COMMIT=$(git rev-parse "$INPUT_REF")
+log "job ${SPEC_HASH}: input commit ${INPUT_COMMIT}"
+
+emit_error() {
+    code=$1
+    printf '%s' "$code" > "$JOB_DIR/exit-code"
+    EXIT_BLOB=$(git hash-object -w "$JOB_DIR/exit-code")
+    LOG_BLOB=$(git hash-object -w "$LOG_FILE")
+    ERROR_TREE=$(printf '100644 blob %s\texit-code\n100644 blob %s\tlog\n' "$EXIT_BLOB" "$LOG_BLOB" | git mktree)
+    ERROR_COMMIT=$(git commit-tree "$ERROR_TREE" -m "lens job ${SPEC_HASH} failed with exit code ${code}")
+    git update-ref "refs/jobs/${SPEC_HASH}/error" "$ERROR_COMMIT"
+    git bundle create "$JOB_DIR/error.bundle" "refs/jobs/${SPEC_HASH}/error" >&2
+    cat "$JOB_DIR/error.bundle"
+    log "job ${SPEC_HASH}: emitted error bundle (exit code ${code})"
+    exit "$code"
+}
+
+# --- 3. materialize the wrapper tree ------------------------------------------
+WORK_DIR="$JOB_DIR/work"
+mkdir -p "$WORK_DIR"
+git archive "$INPUT_COMMIT" | tar -x -C "$WORK_DIR"
+
+SPEC_FILE="$WORK_DIR/.holospec/lens.toml"
+if [ ! -f "$SPEC_FILE" ]; then
+    log 'transport error: input commit has no .holospec/lens.toml'
+    exit 65
+fi
+
+INPUT_DIR="$WORK_DIR/input"
+OUTPUT_DIR="$JOB_DIR/output"
+mkdir -p "$INPUT_DIR" "$OUTPUT_DIR"
+
+# --- 4. read `command` from the spec (basic TOML string extraction) ------------
+COMMAND=$(sed -n 's/^command[[:space:]]*=[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' "$SPEC_FILE" | head -n 1)
+if [ -z "$COMMAND" ]; then
+    log "spec ${SPEC_HASH} has no command"
+    echo "spec has no command" >> "$LOG_FILE"
+    emit_error 64
+fi
+# unescape TOML basic-string escapes for quotes and backslashes
+COMMAND=$(printf '%s' "$COMMAND" | sed -e 's/\\"/"/g' -e 's/\\\\/\\/g')
+# substitute {{ input }} / {{ output }} placeholders
+COMMAND=$(printf '%s' "$COMMAND" | sed -e "s|{{ *input *}}|${INPUT_DIR}|g" -e "s|{{ *output *}}|${OUTPUT_DIR}|g")
+
+# --- 5. run the lens command ----------------------------------------------------
+log "executing lens command: $COMMAND"
+set +e
+(
+    cd "$WORK_DIR" \
+    && HOLOLENS_INPUT="$INPUT_DIR" \
+       HOLOLENS_OUTPUT="$OUTPUT_DIR" \
+       HOLOLENS_SPEC="$SPEC_FILE" \
+       sh -c "$COMMAND"
+) >> "$LOG_FILE" 2>&1
+CODE=$?
+set -e
+
+# relay the job log to stderr (never stdout — that's the bundle channel)
+sed 's/^/lens: /' "$LOG_FILE" >&2
+
+if [ "$CODE" -ne 0 ]; then
+    log "lens command failed with exit code ${CODE}"
+    emit_error "$CODE"
+fi
+
+# --- 6. commit the output tree as first-parent child of the input commit -------
+export GIT_INDEX_FILE="$JOB_DIR/index"
+git --work-tree="$OUTPUT_DIR" add -A .
+OUTPUT_TREE=$(git write-tree)
+OUTPUT_COMMIT=$(git commit-tree "$OUTPUT_TREE" -p "$INPUT_COMMIT" -m "lens job ${SPEC_HASH}")
+git update-ref "refs/jobs/${SPEC_HASH}/output" "$OUTPUT_COMMIT"
+log "job ${SPEC_HASH}: output tree ${OUTPUT_TREE}"
+
+# --- 7. emit the output bundle on stdout ----------------------------------------
+# exclude objects reachable from the input commit — the engine already has them
+git bundle create "$JOB_DIR/output.bundle" "refs/jobs/${SPEC_HASH}/output" "^${INPUT_COMMIT}" >&2
+cat "$JOB_DIR/output.bundle"
+log "job ${SPEC_HASH}: emitted output bundle"
+exit 0

--- a/lib/Lens.js
+++ b/lib/Lens.js
@@ -1,5 +1,10 @@
+const crypto = require('crypto');
+const os = require('os');
+const path = require('path');
+
 const axios = require('axios');
 const TOML = require('@iarna/toml');
+const fs = require('mz/fs');
 const handlebars = require('handlebars');
 const mkdirp = require('mz-modules/mkdirp');
 const shellParse = require('shell-quote-word');
@@ -11,6 +16,13 @@ const SpecObject = require('./SpecObject.js');
 const Studio = require('./Studio.js');
 
 const logger = require('./logger');
+
+
+// default job deadline in seconds, overridable via lens config `timeout`
+const DEFAULT_JOB_TIMEOUT = 600;
+
+// OCI image label marking a lens image as implementing the v2 job protocol
+const PROTOCOL_LABEL = 'sh.holo.lens.protocol';
 
 
 class Lens extends Configurable {
@@ -298,7 +310,10 @@ class Lens extends Configurable {
     }
 
     async executeSpec (specHash, options) {
-        return Lens.executeSpec(specHash, {...options, repo: this.workspace.getRepo()});
+        // job deadline comes from lens config (with engine default), never from
+        // the spec object — it cannot change the output
+        const { timeout } = await this.getCachedConfig();
+        return Lens.executeSpec(specHash, { timeout, ...options, repo: this.workspace.getRepo() });
     }
 
     static async executeSpec (specHash, options) {
@@ -348,7 +363,7 @@ class Lens extends Configurable {
         // execute lens in container or with habitat package:
         let lensedTreeHash;
         if (specType == 'container') {
-            lensedTreeHash = await Lens.executeSpecForContainer(repo, specHash);
+            lensedTreeHash = await Lens.executeSpecForContainer(repo, specHash, { timeout: options.timeout });
         } else if (specType == 'habitat') {
             lensedTreeHash = await Lens.executeSpecForHabitatPackage(repo, specHash);
         }
@@ -365,7 +380,206 @@ class Lens extends Configurable {
         return lensedTreeHash;
     }
 
-    static async executeSpecForContainer (repo, specHash) {
+    /**
+     * Execute a container lens spec, dispatching between the v1 (port-9000
+     * git server) and v2 (exec/stdio job protocol) transports based on the
+     * image's `sh.holo.lens.protocol` OCI label.
+     */
+    static async executeSpecForContainer (repo, specHash, options = {}) {
+        const git = await repo.getGit();
+
+        // read and parse spec file
+        const specToml = await git.$getBlob(specHash);
+        const {
+            holospec: {
+                lens: spec
+            }
+        } = TOML.parse(specToml);
+
+        const containerRef = spec.container;
+
+        // ensure image is available locally
+        if (spec.resolved == 'local') {
+            // locally-resolved image (#417): identified by image ID, cannot be pulled
+            try {
+                await Studio.execDocker(['image', 'inspect', containerRef]);
+            } catch (err) {
+                throw new Error(`locally-resolved lens image ${containerRef} is not available in the local engine; rebuild the image or update the lens container config`);
+            }
+        } else {
+            if (!containerRef.match(/^.+@sha256:[a-f0-9]{64}$/)) {
+                throw new Error(`Invalid container format: ${containerRef}`);
+            }
+
+            try {
+                await Studio.execDocker(['image', 'inspect', containerRef]);
+            } catch (err) {
+                // Pull by digest — guarantees we get the exact image version
+                // matching the spec that was used for caching
+                logger.info(`pulling required image: ${containerRef}`);
+                try {
+                    await Studio.execDocker(['pull', containerRef], { $relayStdout: true });
+                } catch (pullErr) {
+                    throw new Error(`failed to pull container image ${containerRef}: ${pullErr.message}`);
+                }
+            }
+        }
+
+        // detect job protocol from image labels
+        let labels;
+        try {
+            labels = JSON.parse(
+                await Studio.execDocker(['image', 'inspect', '--format', '{{json .Config.Labels}}', containerRef])
+            );
+        } catch (err) {
+            logger.warn(`could not read labels from image ${containerRef}: ${err.message}`);
+        }
+
+        if (labels && labels[PROTOCOL_LABEL] === '2') {
+            logger.info(`lens protocol v2 (exec/stdio one-shot): ${containerRef}`);
+            return Lens.executeSpecForContainerV2(repo, specHash, { ...options, spec, containerRef });
+        }
+
+        logger.info(`lens protocol v1 (port-9000 git server): ${containerRef}`);
+        return Lens.executeSpecForContainerV1(repo, specHash);
+    }
+
+    /**
+     * Execute a container lens spec over the one-shot v2 job protocol
+     * (specs/behaviors/lensing.md § Job protocol): pipe a bundle containing
+     * `refs/jobs/<spec-hash>/input` (a wrapper commit: `.holospec/lens.toml`
+     * + `input/`) to the container over stdin, and read back a bundle
+     * containing `refs/jobs/<spec-hash>/output` (success — a commit whose
+     * first parent is the input commit) or `refs/jobs/<spec-hash>/error`
+     * (failure — a tree with `exit-code` and `log` entries) from stdout.
+     */
+    static async executeSpecForContainerV2 (repo, specHash, options = {}) {
+        const git = await repo.getGit();
+        const timeout = options.timeout || DEFAULT_JOB_TIMEOUT;
+
+        // read and parse spec file if not passed through from dispatcher
+        let { spec, containerRef } = options;
+        if (!spec) {
+            ({ holospec: { lens: spec } } = TOML.parse(await git.$getBlob(specHash)));
+        }
+        if (!containerRef) {
+            containerRef = spec.container;
+        }
+
+        // build job input wrapper commit: .holospec/lens.toml + input/
+        const holospecTree = await git.$putTree([
+            { mode: '100644', type: 'blob', hash: specHash, name: 'lens.toml' }
+        ]);
+        const wrapperTree = await git.$putTree([
+            { mode: '40000', type: 'tree', hash: holospecTree, name: '.holospec' },
+            { mode: '40000', type: 'tree', hash: spec.input, name: 'input' }
+        ]);
+        const inputCommitHash = await git.commitTree(wrapperTree, {
+            p: [],
+            m: `lens job ${specHash}`
+        });
+
+        const inputRef = `refs/jobs/${specHash}/input`;
+        const outputRef = `refs/jobs/${specHash}/output`;
+        const errorRef = `refs/jobs/${specHash}/error`;
+
+        await git.updateRef(inputRef, inputCommitHash);
+
+        const scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), 'holo-lens-job-'));
+        const containerName = `holo-lens-job-${specHash.substr(0, 12)}-${crypto.randomBytes(4).toString('hex')}`;
+
+        try {
+            // bundle the input wrapper commit
+            const inputBundlePath = path.join(scratchDir, 'input.bundle');
+            await git.bundle('create', inputBundlePath, inputRef);
+            const inputBundle = await fs.readFile(inputBundlePath);
+
+            // run one-shot job container: bundle on stdin, bundle on stdout,
+            // exit code mirroring; stderr is relayed as logging
+            logger.info(`executing lens job ${specHash} (deadline ${timeout}s)`);
+            const { code, stdout, stderr, timedOut } = await Studio.spawnDockerJob(
+                [
+                    'run', '--rm', '--interactive',
+                    '--name', containerName,
+                    '--label', `sh.holo.lens.job=${specHash}`,
+                    containerRef
+                ],
+                {
+                    input: inputBundle,
+                    timeoutMs: timeout * 1000,
+                    containerName,
+                    onStderrLine: line => process.stderr.write(`\x1b[90m${line}\x1b[0m\n`)
+                }
+            );
+
+            if (timedOut) {
+                const timeoutError = new Error(`lens job ${specHash} exceeded its ${timeout}s deadline and was killed`);
+                timeoutError.code = 'ELENSTIMEOUT';
+                timeoutError.specHash = specHash;
+                timeoutError.timeout = timeout;
+                throw timeoutError;
+            }
+
+            if (!stdout.length) {
+                throw new Error(`lens container exited with code ${code} without returning a bundle (transport error)${stderr ? `:\n${stderr}` : ''}`);
+            }
+
+            // write returned bundle to disk for fetching (fetch verifies all
+            // objects on ingest)
+            const resultBundlePath = path.join(scratchDir, 'result.bundle');
+            await fs.writeFile(resultBundlePath, stdout);
+
+            if (code === 0) {
+                logger.info('fetching result');
+                await git.fetch(resultBundlePath, `+${outputRef}:${outputRef}`);
+
+                // verify the output commit's first parent matches our input commit
+                const outputParent = await git.revParse(`${outputRef}^`);
+                if (outputParent !== inputCommitHash) {
+                    throw new Error(`Output commit parent ${outputParent} does not match input commit ${inputCommitHash}`);
+                }
+
+                return await git.getTreeHash(outputRef);
+            }
+
+            // non-zero exit: expect a structured error bundle
+            let exitCode = code, log = null;
+            try {
+                await git.fetch(resultBundlePath, `+${errorRef}:${errorRef}`);
+                exitCode = parseInt(await git.$getBlob(await git.revParse(`${errorRef}:exit-code`)), 10);
+                log = await git.$getBlob(await git.revParse(`${errorRef}:log`));
+            } catch (fetchErr) {
+                throw new Error(`lens container exited with code ${code} without returning a readable error bundle (transport error): ${fetchErr.message}`);
+            }
+
+            const lensError = new Error(`lens job ${specHash} failed with exit code ${exitCode}${log ? `:\n${log.trimEnd()}` : ''}`);
+            lensError.code = 'ELENSFAILED';
+            lensError.specHash = specHash;
+            lensError.exitCode = exitCode;
+            lensError.log = log;
+            throw lensError;
+        } finally {
+            // input objects stay reachable via the output commit's parent
+            // link, so the input ref is transient
+            try {
+                await git.updateRef({ d: true }, inputRef);
+            } catch (err) {
+                logger.warn(`failed to clean up ${inputRef}: ${err.message}`);
+            }
+
+            await require('fs').promises.rm(scratchDir, { recursive: true, force: true }).catch(
+                err => logger.warn(`failed to clean up ${scratchDir}: ${err.message}`)
+            );
+        }
+    }
+
+    /**
+     * Execute a container lens spec over the legacy v1 transport: a git
+     * server inside the container published on host port 9000. Superseded by
+     * the v2 job protocol, retained while published lens images migrate
+     * (hologit/lenses#32).
+     */
+    static async executeSpecForContainerV1 (repo, specHash) {
         const git = await repo.getGit();
 
         // read and parse spec file

--- a/lib/Lens.js
+++ b/lib/Lens.js
@@ -110,6 +110,53 @@ class Lens extends Configurable {
         }
     }
 
+    /**
+     * Resolve a configured container reference to a stable execution identity,
+     * per the resolution ladder in specs/behaviors/lensing.md:
+     *
+     *   1. Explicit digest pin in config — used as-is, no lookup.
+     *   2. Local engine lookup — the RepoDigests digest of a locally present
+     *      image matching the tag; if the image is local but has never been
+     *      pushed (no repo digest — #417), its image ID is used with an
+     *      explicit `resolved = "local"` marker (honestly non-portable).
+     *   3. Registry lookup — manifest digest via the registry.
+     *
+     * @returns {Promise<{container: string, resolved?: string}>}
+     */
+    async resolveContainerIdentity (containerQuery) {
+        // 1. explicit digest pin — no lookup performed
+        if (/@sha256:[a-f0-9]{64}$/.test(containerQuery)) {
+            logger.info(`using digest-pinned container identity: ${containerQuery}`);
+            return { container: containerQuery };
+        }
+
+        // 2. local engine lookup
+        try {
+            const output = await Studio.execDocker(['image', 'inspect', containerQuery]);
+            const [info] = JSON.parse(output);
+            const repoName = containerQuery.replace(/:.*$/, '');
+            const repoDigests = info.RepoDigests || [];
+            const matchingDigest =
+                repoDigests.find(digest => digest.startsWith(`${repoName}@`))
+                || repoDigests[0];
+
+            if (matchingDigest) {
+                logger.info(`resolved container identity from local image: ${matchingDigest}`);
+                return { container: matchingDigest };
+            }
+
+            // local-only image, never pushed (#417): use image ID, marked local
+            logger.info(`resolved local-only container identity: ${info.Id} (${containerQuery})`);
+            return { container: info.Id, resolved: 'local' };
+        } catch (err) {
+            // image not present locally, fall through to registry lookup
+        }
+
+        // 3. registry lookup
+        const { hash: imageHash } = await this.getImageHash(containerQuery);
+        return { container: `${containerQuery.replace(/:.*$/, '')}@${imageHash}` };
+    }
+
     async getImageHash (containerQuery) {
         // Get manifest digest from registry without pulling.
         // This is the only identifier that is consistent across all machines
@@ -147,17 +194,20 @@ class Lens extends Configurable {
     async buildSpecForContainer (inputTree, config) {
         const { container: containerQuery } = config;
 
-        // Get manifest digest from registry without pulling
-        const { hash: imageHash } = await this.getImageHash(containerQuery);
+        // resolve container identity via the resolution ladder
+        // (digest pin → local lookup → registry)
+        const identity = await this.resolveContainerIdentity(containerQuery);
 
         // build spec
         const data = {
             ...config,
-            container: `${containerQuery.replace(/:.*$/, '')}@${imageHash}`,
+            container: identity.container,
+            resolved: identity.resolved || null, // null values are omitted from spec TOML
             input: await inputTree.write(),
             output: null,
             before: null,
-            after: null
+            after: null,
+            timeout: null // execution deadline cannot change output, must stay out of spec hash
         };
 
         // write spec and return packet

--- a/lib/Studio.js
+++ b/lib/Studio.js
@@ -51,6 +51,78 @@ function execDocker(args, options = { }) {
 }
 
 /**
+ * Helper function to run a docker command with streamed binary stdio, for jobs
+ * whose stdout is a binary payload (e.g. a git bundle) that string
+ * accumulation would corrupt. Unlike execDocker, stdout is captured as a
+ * Buffer, an input Buffer can be piped to stdin, and an optional deadline
+ * force-removes the named container on expiry.
+ *
+ * @param {Array<string>} args - The arguments to pass to the docker command.
+ * @param {Object} options
+ * @param {?Buffer} options.input - Buffer to pipe to stdin.
+ * @param {number} options.timeoutMs - Deadline in milliseconds (0 = none).
+ * @param {?string} options.containerName - Container to force-remove on deadline expiry.
+ * @param {?Function} options.onStderrLine - Called with each stderr line.
+ * @returns {Promise<{code: ?number, stdout: Buffer, stderr: string, timedOut: boolean}>}
+ */
+function spawnDockerJob (args, { input = null, timeoutMs = 0, containerName = null, onStderrLine = null } = {}) {
+    logger.debug(`docker ${args.join(' ')}`);
+
+    return new Promise((resolve, reject) => {
+        const dockerProcess = spawn('docker', args, { stdio: 'pipe' });
+
+        const stdoutChunks = [];
+        let stderr = '';
+        let timedOut = false;
+        let timer = null;
+
+        if (timeoutMs > 0) {
+            timer = setTimeout(() => {
+                timedOut = true;
+
+                const kill = () => dockerProcess.kill('SIGKILL');
+
+                if (containerName) {
+                    // remove the container itself, not just the CLI client —
+                    // killing the attached client alone can leave the
+                    // container running
+                    execDocker(['rm', '--force', containerName])
+                        .catch(err => logger.warn(`failed to force-remove timed-out container ${containerName}: ${err.message}`))
+                        .then(kill);
+                } else {
+                    kill();
+                }
+            }, timeoutMs);
+        }
+
+        dockerProcess.stdout.on('data', chunk => stdoutChunks.push(chunk));
+
+        dockerProcess.stderr.on('data', chunk => {
+            const text = chunk.toString();
+            stderr = (stderr + text).slice(-16384);
+
+            if (onStderrLine) {
+                text.trimEnd().split(/\n/).forEach(line => onStderrLine(line));
+            }
+        });
+
+        dockerProcess.on('error', err => {
+            if (timer) clearTimeout(timer);
+            reject(err);
+        });
+
+        dockerProcess.on('close', code => {
+            if (timer) clearTimeout(timer);
+            resolve({ code, stdout: Buffer.concat(stdoutChunks), stderr, timedOut });
+        });
+
+        // ignore EPIPE if the container exits before consuming all input
+        dockerProcess.stdin.on('error', () => {});
+        dockerProcess.stdin.end(input || undefined);
+    });
+}
+
+/**
  * A studio session that can be used to run multiple commands, using chroot if available or docker container
  */
 class Studio {
@@ -100,6 +172,13 @@ class Studio {
      */
     static execDocker(args, options = {}) {
         return execDocker(args, options);
+    }
+
+    /**
+     * Run a docker command with streamed binary stdio (see spawnDockerJob).
+     */
+    static spawnDockerJob(args, options = {}) {
+        return spawnDockerJob(args, options);
     }
 
     static async get (gitDir) {

--- a/plans/lens-execution.md
+++ b/plans/lens-execution.md
@@ -3,6 +3,7 @@ status: planned
 depends: [projector-napi-cli]
 specs:
   - specs/behaviors/composition.md
+  - specs/behaviors/lensing.md
 issues: [435]
 ---
 
@@ -23,6 +24,7 @@ Port lens (hololens) execution to the Rust engine: build the glob-filtered input
 3. Implement execution behind a trait/API boundary so composition stays pure and the executor is swappable (also the seam for remote lensing, #79, later).
 4. Cache compatibility: Rust-written lens cache refs must be readable by the JS engine and vice versa during the hybrid period.
 5. Lens-image migration to the v2 job protocol (SDK entrypoint, dual-protocol transition window) is tracked downstream at hologit/lenses#32.
+6. Warm container pool and object-transfer tiers 2–4 (incremental warm-ref negotiation, lazy/promisor fetch, shared runtime-host object cache) per specs/behaviors/lensing.md — deferred here from [`lens-protocol-v2-js`](lens-protocol-v2-js.md), which shipped the interim JS engine as one-shot/tier-1 only (PR #484).
 
 ## Validation
 
@@ -30,6 +32,7 @@ Port lens (hololens) execution to the Rust engine: build the glob-filtered input
 - [ ] Lensed reference projections (cfp-live-cluster-style helm3/kustomize, wmata-style tree-patch) produce hashes identical to the JS engine
 - [ ] Lens cache hits work across engines (JS-written cache honored by Rust and vice versa)
 - [ ] A local, unpushed lens image runs (#417 resolved or explicitly deferred in the spec)
+- [ ] Warm container pool + transfer tiers 2–4 implemented behind the same job protocol (deferred from [`lens-protocol-v2-js`](lens-protocol-v2-js.md))
 
 ## Risks / unknowns
 

--- a/plans/lens-protocol-v2-js.md
+++ b/plans/lens-protocol-v2-js.md
@@ -1,9 +1,10 @@
 ---
-status: in-progress
+status: done
 depends: []
 specs:
   - specs/behaviors/lensing.md
 issues: [417, 19]
+pr: 484
 ---
 
 # Lens job protocol v2 — interim JS implementation
@@ -71,17 +72,17 @@ Node.js engine (`lib/Lens.js`), as an interim step ahead of the Rust lens execut
 
 ## Validation
 
-- [ ] `npm test` passes (new lens-v2 suite green locally with docker; suite skips
+- [x] `npm test` passes (new lens-v2 suite green locally with docker; suite skips
       cleanly without docker)
-- [ ] `node bin/cli.js project docs-site` and
+- [x] `node bin/cli.js project docs-site` and
       `node bin/cli.js project github-action-projector` still produce the expected
       hashes via the v1 fallback (published lens images carry no v2 label)
-- [ ] `cargo test` passes (untouched, repo invariant)
-- [ ] A local, never-pushed lens image builds a spec with `resolved = "local"` and
+- [x] `cargo test` passes (untouched, repo invariant)
+- [x] A local, never-pushed lens image builds a spec with `resolved = "local"` and
       executes successfully offline (#417)
-- [ ] Lens failure surfaces exit code + log from the `refs/jobs/<spec-hash>/error`
+- [x] Lens failure surfaces exit code + log from the `refs/jobs/<spec-hash>/error`
       commit; timeout kills the container without leaking it
-- [ ] `pr-test.yml` green on the PR (test-action is the final gate; known v1 flake
+- [x] `pr-test.yml` green on the PR (test-action is the final gate; known v1 flake
       signature = instant HTTP 500 / unexpected disconnect on port-9000 push — rerun
       before investigating)
 
@@ -102,6 +103,19 @@ Node.js engine (`lib/Lens.js`), as an interim step ahead of the Rust lens execut
 - The engine invokes a v2 image's **default entrypoint** with no arguments — the
   protocol label plus "entrypoint implements the job protocol" is the whole contract
   (no hidden image contracts; the SDK path inside the image is the image's business).
+  The spec doesn't state this explicitly — flagged for a spec amendment (see
+  Follow-ups) rather than silently resolved.
+- Two more spec ambiguities hit and flagged (not silently resolved): the **error
+  commit's parentage** is unspecified (the reference SDK emits it parentless, which
+  keeps the error bundle self-contained), and **multi-arch digest divergence** — a
+  local `RepoDigests` entry and a registry lookup can name different digests (platform
+  manifest vs index) for the same image, so the ladder rung that resolves can change
+  the spec hash. Observed benignly (containerd storage records the index digest);
+  needs a spec ruling if it bites.
+- Floating tags now resolve to a **stale local image over the registry** by design
+  (offline-first ladder). Hit during validation: a months-old local `mkdocs:latest`
+  produced a broken v1 lens run until `docker pull` refreshed it. Digest pins remain
+  the documented recommendation.
 - `timeout` is engine/config concern, deliberately stripped from spec data (it cannot
   change the output, so per the spec it must not enter the spec hash).
 - `HOLO_DEBUG_PERSIST_CONTAINER` remains honored on the v1 path only; v2 one-shot
@@ -109,7 +123,25 @@ Node.js engine (`lib/Lens.js`), as an interim step ahead of the Rust lens execut
 - Fast inner-loop recipes are documented in the PR body (single-case jest invocation,
   driving `Lens.executeSpec` from a scratch script, `docker run -i` against a
   hand-built bundle to exercise the SDK without the engine).
+- Engine-code gotcha: `Repo → Workspace → Lens → Repo` is a CommonJS require cycle;
+  loading `Lens.js` first leaves `Workspace` holding a partial export ("Lens is not a
+  constructor"). Tests must require `Repo.js` before `Lens.js`, matching production
+  load order.
+- The PR's first `test-action` run reproduced the motivating v1 flake exactly
+  (instant HTTP 500 / unexpected disconnect on the port-9000 push; green on rerun) —
+  live confirmation of the failure class the v2 transport eliminates.
 
 ## Follow-ups
 
-*(populated at closeout)*
+- Tracked as: spec amendments to `specs/behaviors/lensing.md` proposed from the Notes
+  ambiguities — v2 invocation contract (default entrypoint, no arguments), error
+  commit parentage, and ladder-rung digest divergence for multi-arch images.
+- Deferred to [`lens-execution`](lens-execution.md) — warm container pool and object
+  transfer tiers 2–4 (incremental, lazy/promisor, shared runtime-host cache) land
+  with the Rust executor; the JS engine stays one-shot/tier-1 only.
+- Issue [#19](https://github.com/JarvusInnovations/hologit/issues/19) — remainder:
+  supersession/cancellation of no-longer-wanted jobs (this plan shipped only the
+  simple deadline).
+- Tracked as: hologit/lenses#32 — migrate published lens images to v2 by vendoring
+  `lens-sdk/lens-job.sh`; the v1 transport (and its flake class) retires once the
+  fleet is migrated.

--- a/plans/lens-protocol-v2-js.md
+++ b/plans/lens-protocol-v2-js.md
@@ -1,0 +1,115 @@
+---
+status: in-progress
+depends: []
+specs:
+  - specs/behaviors/lensing.md
+issues: [417, 19]
+---
+
+# Lens job protocol v2 — interim JS implementation
+
+## Scope
+
+Implement the exec/stdio lens job protocol from `specs/behaviors/lensing.md` in the
+Node.js engine (`lib/Lens.js`), as an interim step ahead of the Rust lens executor
+([`lens-execution`](lens-execution.md), #435, dep-gated on projector-napi):
+
+- **In:** container identity-resolution ladder (digest pin → local lookup → registry;
+  local-only images per #417), one-shot v2 stdio transport (bundle in on stdin, bundle
+  out on stdout, per-job `refs/jobs/<spec-hash>/{input,output,error}` refs), job
+  deadline/timeout (partial #19), dual-protocol detection via the
+  `sh.holo.lens.protocol=2` OCI image label with the existing v1 port-9000 path kept
+  intact as fallback, a reference SDK entrypoint (`lens-sdk/lens-job.sh`) that lens
+  images will vendor (hologit/lenses#32), and docker-gated integration tests against a
+  locally-built fixture image.
+- **Out (follow-ups):** warm container pool, `ext::`-transport incremental push,
+  promisor/lazy fetch, shared runtime-host object cache, the Rust executor (#435),
+  migrating published lens images (hologit/lenses#32).
+- **Frozen:** spec-object format and cache-ref scheme (`SpecObject.write('lens', …)`,
+  `refs/holo/lens/...`, `cacheFrom`/`cacheTo`) — cache compatibility across engine
+  versions is a spec requirement. Protocol version is a property of the *image*
+  (label), never of the spec object. The `resolved = "local"` spec field is the one
+  sanctioned spec-content addition (local-only specs are honestly non-portable).
+
+## Implements
+
+- `specs/behaviors/lensing.md` — § Container identity resolution (full ladder,
+  including the #417 local-only branch), § Job protocol (one-shot mode + deadlines;
+  warm pool and supersession deferred), § Container lifecycle (one-shot only),
+  § Object transfer (tier 1 Full only), § Spec and content addressing (wrapper commit
+  with `.holospec/lens.toml` + `input/`), § Principles (no hidden image contracts —
+  everything the engine needs from a v2 image is the protocol label plus an
+  entrypoint implementing the job protocol).
+
+## Approach
+
+1. **Identity ladder first** — replace the unconditional registry query in
+   `buildSpecForContainer`: (a) config already pins `@sha256:` → use as-is;
+   (b) `docker image inspect` on the tag → use `RepoDigests` entry when present;
+   (c) local image with no repo digest (never pushed, #417) → image ID +
+   `resolved = "local"` in spec data; (d) fall back to `buildx imagetools inspect`.
+   The local-only branch is what makes the offline test loop possible (tests build a
+   local image, never touch a registry).
+2. **Reference SDK + test fixture** — `lens-sdk/lens-job.sh` (POSIX sh): read input
+   bundle from stdin into a scratch bare repo, materialize the wrapper tree, run the
+   spec's `command` against `input/`, commit the result as first-parent child of the
+   input commit, emit the output (or structured error) bundle on stdout; stdout stays
+   binary-clean, all logging on stderr. Fixture image: `alpine:3` + git + the SDK +
+   deterministic test lens commands, built locally by the test suite.
+3. **One-shot v2 transport** — `executeSpecForContainer` becomes a dispatcher:
+   ensure image present, read `Config.Labels`, log which protocol runs, dispatch to
+   the untouched v1 path or the new v2 executor. V2: wrapper commit → bundle →
+   `docker run -i --rm` with piped stdio (dedicated Buffer-safe spawn helper in
+   `Studio`, not string-accumulating `execDocker`) → fetch output/error ref from the
+   returned bundle → verify first parent == input commit → return tree hash.
+   Deadline: config `timeout` (stripped from spec data) with 600s engine default;
+   on expiry `docker rm -f` the named container and raise a structured error.
+4. **Tests** — jest integration suite `test/integration/lens-v2.test.js`, docker-gated
+   (skip cleanly when docker unavailable): success round-trip, structured error
+   propagation, timeout kill, protocol detection (unlabeled image → v1 path),
+   idempotent cache hit, identity-ladder unit cases.
+
+## Validation
+
+- [ ] `npm test` passes (new lens-v2 suite green locally with docker; suite skips
+      cleanly without docker)
+- [ ] `node bin/cli.js project docs-site` and
+      `node bin/cli.js project github-action-projector` still produce the expected
+      hashes via the v1 fallback (published lens images carry no v2 label)
+- [ ] `cargo test` passes (untouched, repo invariant)
+- [ ] A local, never-pushed lens image builds a spec with `resolved = "local"` and
+      executes successfully offline (#417)
+- [ ] Lens failure surfaces exit code + log from the `refs/jobs/<spec-hash>/error`
+      commit; timeout kills the container without leaking it
+- [ ] `pr-test.yml` green on the PR (test-action is the final gate; known v1 flake
+      signature = instant HTTP 500 / unexpected disconnect on port-9000 push — rerun
+      before investigating)
+
+## Risks / unknowns
+
+- **Multi-arch digest divergence** — local `RepoDigests` may hold a platform manifest
+  digest while `buildx imagetools inspect` returns the index digest, so the same image
+  can produce different spec hashes depending on which ladder rung resolves. Inherent
+  in the spec's offline-first ladder; flagged for a spec amendment if it bites.
+- **SDK TOML parsing** — the reference SDK extracts `command` from
+  `.holospec/lens.toml` with sed (POSIX sh, no TOML parser); complex quoted commands
+  need care. Real lens images can ship richer SDKs; the contract is unchanged.
+- **v1 path untouched** — every published `ghcr.io/hologit/lenses/*` image is v1
+  today; any regression there is a hard blocker for this PR.
+
+## Notes
+
+- The engine invokes a v2 image's **default entrypoint** with no arguments — the
+  protocol label plus "entrypoint implements the job protocol" is the whole contract
+  (no hidden image contracts; the SDK path inside the image is the image's business).
+- `timeout` is engine/config concern, deliberately stripped from spec data (it cannot
+  change the output, so per the spec it must not enter the spec hash).
+- `HOLO_DEBUG_PERSIST_CONTAINER` remains honored on the v1 path only; v2 one-shot
+  containers are `--rm` and need no persistent debug container.
+- Fast inner-loop recipes are documented in the PR body (single-case jest invocation,
+  driving `Lens.executeSpec` from a scratch script, `docker run -i` against a
+  hand-built bundle to exercise the SDK without the engine).
+
+## Follow-ups
+
+*(populated at closeout)*

--- a/test/fixtures/lens-v2-test/Dockerfile
+++ b/test/fixtures/lens-v2-test/Dockerfile
@@ -1,0 +1,26 @@
+# Throwaway v2 lens image for integration tests (test/integration/lens-v2.test.js).
+#
+# Built locally by the test suite and NEVER pushed — which is exactly the point:
+# it exercises the local-only branch of the container identity-resolution ladder
+# (specs/behaviors/lensing.md, #417).
+#
+# Build from the repo root so the reference SDK can be copied in:
+#
+#   docker build -t holo-lens-v2-test \
+#       --label sh.holo.lens.protocol=2 \
+#       -f test/fixtures/lens-v2-test/Dockerfile .
+#
+# The protocol label is applied at build time (--label) rather than here so the
+# same Dockerfile can also build an unlabeled image for v1-fallback detection
+# tests.
+
+FROM alpine:3
+
+RUN apk add --no-cache git
+
+COPY lens-sdk/lens-job.sh /usr/local/bin/lens-job.sh
+COPY test/fixtures/lens-v2-test/holo-lens-test /usr/local/bin/holo-lens-test
+COPY test/fixtures/lens-v2-test/holo-lens-fail /usr/local/bin/holo-lens-fail
+RUN chmod +x /usr/local/bin/lens-job.sh /usr/local/bin/holo-lens-test /usr/local/bin/holo-lens-fail
+
+ENTRYPOINT ["/usr/local/bin/lens-job.sh"]

--- a/test/fixtures/lens-v2-test/holo-lens-fail
+++ b/test/fixtures/lens-v2-test/holo-lens-fail
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Test lens that always fails, for structured-error-propagation tests.
+echo 'holo-lens-fail: something went boom' >&2
+exit 3

--- a/test/fixtures/lens-v2-test/holo-lens-test
+++ b/test/fixtures/lens-v2-test/holo-lens-test
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Trivial deterministic test lens: writes an LENSED marker file plus an
+# upper-cased copy of each input file. Deterministic output = assertable tree.
+set -eu
+
+cd "$HOLOLENS_INPUT"
+
+find . -type f | sort | while read -r file; do
+    file=${file#./}
+    dir=$(dirname "$file")
+    mkdir -p "$HOLOLENS_OUTPUT/$dir"
+    tr '[:lower:]' '[:upper:]' < "$file" > "$HOLOLENS_OUTPUT/$file"
+done
+
+echo 'lensed' > "$HOLOLENS_OUTPUT/LENSED"
+echo 'holo-lens-test: done'

--- a/test/integration/lens-v2.test.js
+++ b/test/integration/lens-v2.test.js
@@ -1,0 +1,223 @@
+/**
+ * Lens v2 Job Protocol Integration Tests
+ *
+ * Exercises the exec/stdio one-shot lens job protocol
+ * (specs/behaviors/lensing.md § Job protocol) against a throwaway v2 lens
+ * image built locally from test/fixtures/lens-v2-test. The image is never
+ * pushed, which also exercises the local-only branch of the container
+ * identity-resolution ladder (#417).
+ *
+ * The suite skips cleanly when docker is unavailable.
+ */
+
+const { execSync } = require('child_process');
+const path = require('path');
+const TOML = require('@iarna/toml');
+
+const GitSandbox = require('../helpers/git-sandbox.js');
+// Repo must load before Lens: Repo → Workspace → Lens is a require cycle, and
+// loading Lens first leaves Workspace holding a partial Lens export
+require('../../lib/Repo.js');
+const Lens = require('../../lib/Lens.js');
+const Studio = require('../../lib/Studio.js');
+const SpecObject = require('../../lib/SpecObject.js');
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const V2_IMAGE = 'holo-lens-v2-test';
+const V1_IMAGE = 'holo-lens-v1-test';
+
+let dockerAvailable = false;
+try {
+    execSync('docker info', { stdio: 'ignore' });
+    dockerAvailable = true;
+} catch (err) {
+    // docker not available — integration suite will be skipped
+}
+
+const describeWithDocker = dockerAvailable ? describe : describe.skip;
+
+
+describe('Lens container identity resolution ladder', () => {
+    let sandbox;
+
+    beforeEach(async () => {
+        sandbox = await GitSandbox.create();
+    });
+
+    afterEach(async () => {
+        jest.restoreAllMocks();
+        await sandbox.cleanup();
+    });
+
+    test('explicit digest pin is used as-is with no engine/registry lookup', async () => {
+        const pinned = `example.com/lenses/test@sha256:${'ab'.repeat(32)}`;
+
+        await sandbox.addFile('file.txt', 'content');
+        await sandbox.initHolo({ name: 'lens-test' });
+        await sandbox.addFile('.holo/lenses/pinned.toml', TOML.stringify({
+            hololens: { container: pinned, command: 'holo-lens-test' }
+        }));
+        await sandbox.commit('setup');
+
+        const execDockerSpy = jest.spyOn(Studio, 'execDocker');
+
+        const workspace = await sandbox.getWorkspace();
+        const lens = workspace.getLens('pinned');
+        const spec = await lens.buildSpec(await lens.buildInputTree());
+
+        expect(execDockerSpy).not.toHaveBeenCalled();
+        expect(spec.data.container).toBe(pinned);
+        expect(spec.data.resolved).toBeNull();
+
+        // resolved marker must not appear in the written spec object
+        const specToml = await sandbox.git.catFile({ p: true }, spec.hash);
+        expect(specToml).not.toMatch(/resolved/);
+    });
+});
+
+
+describeWithDocker('Lens v2 job protocol', () => {
+    let sandbox;
+    let repoGit;
+
+    beforeAll(() => {
+        // build the throwaway lens images locally (never pushed — exercises
+        // the local-only identity resolution branch). The v2 image gets the
+        // protocol label at build time; the v1 image is the same build
+        // without the label, for fallback-detection tests.
+        const dockerfile = 'test/fixtures/lens-v2-test/Dockerfile';
+        execSync(`docker build -t ${V2_IMAGE} --label sh.holo.lens.protocol=2 -f ${dockerfile} .`, { cwd: REPO_ROOT, stdio: 'pipe' });
+        execSync(`docker build -t ${V1_IMAGE} -f ${dockerfile} .`, { cwd: REPO_ROOT, stdio: 'pipe' });
+    }, 300000);
+
+    beforeEach(async () => {
+        sandbox = await GitSandbox.create();
+    });
+
+    afterEach(async () => {
+        jest.restoreAllMocks();
+
+        // shut down git-client's persistent batch subprocesses so jest
+        // workers can exit cleanly
+        if (repoGit) {
+            repoGit.cleanup();
+            repoGit = null;
+        }
+
+        await sandbox.cleanup();
+    });
+
+    async function setupLens (name, hololens) {
+        await sandbox.addFile('docs/readme.md', 'hello lens world\n');
+        await sandbox.initHolo({ name: 'lens-test' });
+        await sandbox.addFile(`.holo/lenses/${name}.toml`, TOML.stringify({ hololens }));
+        await sandbox.commit('setup');
+
+        const workspace = await sandbox.getWorkspace();
+        repoGit = await workspace.getRepo().getGit();
+        return workspace.getLens(name);
+    }
+
+    test('local-only image resolves by image ID with resolved = "local" (#417)', async () => {
+        const lens = await setupLens('test', { container: V2_IMAGE, command: 'holo-lens-test' });
+        const spec = await lens.buildSpec(await lens.buildInputTree());
+
+        expect(spec.data.container).toMatch(/^sha256:[a-f0-9]{64}$/);
+        expect(spec.data.resolved).toBe('local');
+
+        const specToml = await sandbox.git.catFile({ p: true }, spec.hash);
+        expect(specToml).toMatch(/resolved = "local"/);
+        // deadline is an engine concern and must never enter the spec
+        expect(specToml).not.toMatch(/timeout/);
+    });
+
+    test('success round-trip: deterministic output tree, verified job refs', async () => {
+        const lens = await setupLens('test', { container: V2_IMAGE, command: 'holo-lens-test' });
+        const spec = await lens.buildSpec(await lens.buildInputTree());
+
+        const treeHash = await lens.executeSpec(spec.hash, {});
+
+        // lens output: LENSED marker + upper-cased copy of each input file
+        const files = await sandbox.listTree(treeHash);
+        expect(files).toContain('LENSED');
+        expect(files).toContain('docs/readme.md');
+        expect(await sandbox.readFromTree(treeHash, 'LENSED')).toBe('lensed');
+        expect(await sandbox.readFromTree(treeHash, 'docs/readme.md')).toBe('HELLO LENS WORLD');
+
+        // output ref retained; its first parent is the input wrapper commit
+        // (.holospec/lens.toml + input/), whose ref has been cleaned up
+        const outputRef = `refs/jobs/${spec.hash}/output`;
+        const parentCommit = await sandbox.git.revParse(`${outputRef}^`);
+        const parentFiles = await sandbox.listTree(await sandbox.git.getTreeHash(parentCommit));
+        expect(parentFiles).toContain('.holospec/lens.toml');
+        expect(parentFiles).toContain('input/docs/readme.md');
+        await expect(sandbox.git.revParse(`refs/jobs/${spec.hash}/input`)).rejects.toThrow();
+
+        // result cached at the spec-keyed ref
+        const specRef = SpecObject.buildRef('lens', spec.hash);
+        expect(await sandbox.git.getTreeHash(specRef, { verify: false })).toBe(treeHash);
+    });
+
+    test('lens failure surfaces structured error with exit code and log', async () => {
+        const lens = await setupLens('fail', { container: V2_IMAGE, command: 'holo-lens-fail' });
+        const spec = await lens.buildSpec(await lens.buildInputTree());
+
+        expect.assertions(4);
+        try {
+            await lens.executeSpec(spec.hash, {});
+        } catch (err) {
+            expect(err.code).toBe('ELENSFAILED');
+            expect(err.exitCode).toBe(3);
+            expect(err.log).toMatch(/something went boom/);
+            expect(err.message).toMatch(/exit code 3/);
+        }
+    });
+
+    test('job deadline kills the container without leaking it', async () => {
+        const lens = await setupLens('slow', { container: V2_IMAGE, command: 'sleep 300', timeout: 3 });
+        const spec = await lens.buildSpec(await lens.buildInputTree());
+
+        const started = Date.now();
+        await expect(lens.executeSpec(spec.hash, {})).rejects.toMatchObject({
+            code: 'ELENSTIMEOUT'
+        });
+        expect(Date.now() - started).toBeLessThan(15000);
+
+        // the labeled job container must be gone
+        const leaked = execSync(`docker ps -a --filter label=sh.holo.lens.job=${spec.hash} --format '{{.Names}}'`)
+            .toString().trim();
+        expect(leaked).toBe('');
+    }, 30000);
+
+    test('unlabeled image falls back to the v1 transport', async () => {
+        const lens = await setupLens('legacy', { container: V1_IMAGE, command: 'holo-lens-test' });
+        const inputTree = await lens.buildInputTree();
+        const inputTreeHash = await inputTree.write();
+        const spec = await lens.buildSpec(inputTree);
+
+        const v1Spy = jest.spyOn(Lens, 'executeSpecForContainerV1').mockResolvedValue(inputTreeHash);
+        const v2Spy = jest.spyOn(Lens, 'executeSpecForContainerV2');
+
+        const treeHash = await lens.executeSpec(spec.hash, { save: false });
+
+        expect(v1Spy).toHaveBeenCalledTimes(1);
+        expect(v2Spy).not.toHaveBeenCalled();
+        expect(treeHash).toBe(inputTreeHash);
+    });
+
+    test('second execution is a cache hit and never touches docker', async () => {
+        const lens = await setupLens('test', { container: V2_IMAGE, command: 'holo-lens-test' });
+        const spec = await lens.buildSpec(await lens.buildInputTree());
+
+        const firstHash = await lens.executeSpec(spec.hash, {});
+
+        const containerSpy = jest.spyOn(Lens, 'executeSpecForContainer');
+        const dockerSpy = jest.spyOn(Studio, 'spawnDockerJob');
+
+        const secondHash = await lens.executeSpec(spec.hash, {});
+
+        expect(secondHash).toBe(firstHash);
+        expect(containerSpy).not.toHaveBeenCalled();
+        expect(dockerSpy).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Implements the **one-shot slice of the v2 lens job protocol** from [`specs/behaviors/lensing.md`](https://github.com/JarvusInnovations/hologit/blob/develop/specs/behaviors/lensing.md) (accepted via #482) in the Node.js engine, as an interim step ahead of the Rust lens executor (#435, dep-gated on #434). Plan: `plans/lens-protocol-v2-js.md`.

## Why now

- **Kill a CI flake.** `test-action` failed twice yesterday with an instant `HTTP 500` / `unexpected disconnect` pushing to the lens container's port-9000 git server, then passed on plain rerun: [run 28690220598](https://github.com/JarvusInnovations/hologit/actions/runs/28690220598) (PR #482, attempt 2) and [run 28709961032](https://github.com/JarvusInnovations/hologit/actions/runs/28709961032) (PR #483, attempt 2). The v2 transport has no network listener, no port publishing, and no readiness polling — the whole failure class goes away once lens images migrate.
- **Prove the protocol against real lens workloads** before the Rust port bakes it in.
- **Produce the reference SDK** (`lens-sdk/lens-job.sh`) that hologit/lenses#32 will vendor into lens images.

## What's implemented

- **Container identity-resolution ladder** (spec § Container identity resolution): explicit `@sha256:` pin in config → used as-is, no lookup; locally present image → its `RepoDigests` digest; local-only image never pushed → image ID with an explicit `resolved = "local"` spec marker (closes #417); registry manifest lookup only as last resort. Warm caches now work offline.
- **One-shot v2 transport** (spec § Job protocol): the engine bundles a parentless wrapper commit (`.holospec/lens.toml` + `input/`) under `refs/jobs/<spec-hash>/input`, pipes it via `docker run --rm -i` to the image's default entrypoint, and reads a bundle back from stdout containing `refs/jobs/<spec-hash>/output` (success — first parent must be the input commit, verified) or `refs/jobs/<spec-hash>/error` (failure — `exit-code` + `log` entries, surfaced as a structured `ELENSFAILED` error). Exit code mirrors. stdout is reserved for the bundle; all container logging relays via stderr.
- **Job deadline** (partial #19): config `timeout` with a 600s engine default; on expiry the labeled container is force-removed and a structured `ELENSTIMEOUT` error raised. `timeout` is deliberately stripped from spec data — it can't change the output, so it must not enter the spec hash.
- **Dual-protocol detection**: v2 runs iff the image carries the OCI label `sh.holo.lens.protocol=2`. Otherwise the existing v1 port-9000 path runs **unchanged** (including `HOLO_DEBUG_PERSIST_CONTAINER`; v2 one-shot doesn't need it) — every published `ghcr.io/hologit/lenses/*` image is v1 today. The protocol in use is always logged.
- **Reference SDK** `lens-sdk/lens-job.sh` (POSIX sh + git only): the container side of the contract, per the spec's "no hidden image contracts" principle — the engine↔image contract is exactly the label plus "the entrypoint implements the job protocol".
- **Frozen surfaces untouched**: spec-object format, `refs/holo/lens/...` cache refs, `cacheFrom`/`cacheTo` — cache compatibility across engine versions preserved. `resolved = "local"` is the one sanctioned spec-content addition (local-only specs are honestly non-portable, so their cache divergence is by design).

## Testing

New docker-gated suite `test/integration/lens-v2.test.js` (skips cleanly without docker) builds a throwaway local lens image from `test/fixtures/lens-v2-test/` — never pushed, which is what exercises the #417 ladder branch. Covers: success round-trip, structured error propagation, timeout kill without container leak, v1 fallback for unlabeled images, idempotent cache hit, and identity-ladder cases.

Local results: `npm test` 98/98 green; `cargo test` green; `node bin/cli.js project docs-site` / `project github-action-projector` from a clean clone run the v1 fallback and produce hashes identical to develop (`ab47a8a9…` / `d56c03f7…`).

### Fast inner loop (for future agents)

- One case: `npx jest test/integration/lens-v2.test.js -t '<case name>'`
- Rebuild fixture: `docker build -t holo-lens-v2-test --label sh.holo.lens.protocol=2 -f test/fixtures/lens-v2-test/Dockerfile .`
- Drive `Lens.executeSpec` directly from a scratch script against a `test/helpers/git-sandbox.js` repo when jest overhead gets in the way; `DEBUG=1` gives engine-side visibility.
- Debug the SDK without the engine: hand-build a wrapper commit + `git bundle create`, then `docker run -i holo-lens-v2-test < input.bundle > out.bundle`; stdin/stdout makes it unit-testable.
- Note for local runs: with a floating tag (e.g. `mkdocs:latest`), a **stale local image now wins over the registry** by design (offline-first ladder). If a v1 lens fails mysteriously on your machine, `docker pull` the tag to refresh it. Floating tags remain discouraged in favor of digest pins.

## Follow-ups (out of scope here)

- Warm container pool (watch mode) and job supersession (#19 remainder)
- `ext::`-transport incremental push, promisor/lazy fetch, shared runtime-host object cache (spec tiers 2–4)
- Rust executor (#435)
- Migrating published lens images to v2 (hologit/lenses#32 — adopts `lens-sdk/lens-job.sh`)

Closes #417. Partial #19. Implements the one-shot slice of `specs/behaviors/lensing.md`. Sibling work: hologit/lenses#32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5fwEknfSxpaGCVEME5D4h
