### PR TITLE
feat(lens): underscore-prefix convention for engine-bookkeeping spec keys

### DIFF
--- a/lens-sdk/lens-job.sh
+++ b/lens-sdk/lens-job.sh
@@ -30,6 +30,10 @@
 # with those paths. The command's stdout+stderr are captured as the job log
 # and relayed to stderr.
 #
+# Spec keys beginning with `_` (e.g. `_resolved`) are engine bookkeeping:
+# transforms must ignore them, and SDKs that convert spec keys into
+# environment variables must exclude them.
+#
 # Requires only git and a POSIX shell (busybox-compatible).
 
 set -eu

--- a/lib/Lens.js
+++ b/lib/Lens.js
@@ -130,7 +130,9 @@ class Lens extends Configurable {
      *   2. Local engine lookup — the RepoDigests digest of a locally present
      *      image matching the tag; if the image is local but has never been
      *      pushed (no repo digest — #417), its image ID is used with an
-     *      explicit `resolved = "local"` marker (honestly non-portable).
+     *      explicit `_resolved = "local"` marker (honestly non-portable).
+     *      Underscore-prefixed spec keys are engine bookkeeping: lens
+     *      transforms must ignore them and SDK env conversions exclude them.
      *   3. Registry lookup — manifest digest via the registry.
      *
      * @returns {Promise<{container: string, resolved?: string}>}
@@ -214,7 +216,7 @@ class Lens extends Configurable {
         const data = {
             ...config,
             container: identity.container,
-            resolved: identity.resolved || null, // null values are omitted from spec TOML
+            _resolved: identity.resolved || null, // engine bookkeeping (underscore prefix); null values are omitted from spec TOML
             input: await inputTree.write(),
             output: null,
             before: null,
@@ -399,7 +401,7 @@ class Lens extends Configurable {
         const containerRef = spec.container;
 
         // ensure image is available locally
-        if (spec.resolved == 'local') {
+        if (spec._resolved == 'local') {
             // locally-resolved image (#417): identified by image ID, cannot be pulled
             try {
                 await Studio.execDocker(['image', 'inspect', containerRef]);

--- a/test/integration/lens-v2.test.js
+++ b/test/integration/lens-v2.test.js
@@ -67,11 +67,11 @@ describe('Lens container identity resolution ladder', () => {
 
         expect(execDockerSpy).not.toHaveBeenCalled();
         expect(spec.data.container).toBe(pinned);
-        expect(spec.data.resolved).toBeNull();
+        expect(spec.data._resolved).toBeNull();
 
-        // resolved marker must not appear in the written spec object
+        // bookkeeping marker must not appear in the written spec object
         const specToml = await sandbox.git.catFile({ p: true }, spec.hash);
-        expect(specToml).not.toMatch(/resolved/);
+        expect(specToml).not.toMatch(/_resolved/);
     });
 });
 
@@ -118,15 +118,15 @@ describeWithDocker('Lens v2 job protocol', () => {
         return workspace.getLens(name);
     }
 
-    test('local-only image resolves by image ID with resolved = "local" (#417)', async () => {
+    test('local-only image resolves by image ID with _resolved = "local" (#417)', async () => {
         const lens = await setupLens('test', { container: V2_IMAGE, command: 'holo-lens-test' });
         const spec = await lens.buildSpec(await lens.buildInputTree());
 
         expect(spec.data.container).toMatch(/^sha256:[a-f0-9]{64}$/);
-        expect(spec.data.resolved).toBe('local');
+        expect(spec.data._resolved).toBe('local');
 
         const specToml = await sandbox.git.catFile({ p: true }, spec.hash);
-        expect(specToml).toMatch(/resolved = "local"/);
+        expect(specToml).toMatch(/_resolved = "local"/);
         // deadline is an engine concern and must never enter the spec
         expect(specToml).not.toMatch(/timeout/);
     });


### PR DESCRIPTION
Establishes the `_`-prefix convention for engine-added spec keys and renames `resolved` → `_resolved` while it's free (nothing published consumes it — no release since #484).

Why: the spec→env conversion in lens images exposes every spec key to transforms (`HOLOLENS_*`). Engine bookkeeping leaking into that surface invites lenses to couple to transport-level trivia (e.g. behaving differently when an image was locally resolved), which would violate spec purity. The prefix gives SDKs a mechanical rule: strip `_*` from env conversion; transforms only ever see config the lens author wrote.

Counterparts: spec amendment on #485; lenses-side env strip in hologit/lenses#33.

Tests: lens-v2 suite updated, 14/14 passing locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)