### PR TITLE
holo-tree FFI robustness: error codes, panic containment, consumer-owned cache

### DIFF
--- a/holo-projector/src/branch.rs
+++ b/holo-projector/src/branch.rs
@@ -7,21 +7,21 @@ use gix::ObjectId;
 use crate::config::{self, MappingConfig};
 use crate::error::{Error, Result};
 use crate::source;
-use holo_tree::{MergeMode, MergeOptions, MutableTree};
+use holo_tree::{Context, MergeMode, MergeOptions, MutableTree};
 
 /// Composite a single branch's mappings into the output tree.
 ///
 /// `project_fn` is passed through to source resolution for recursive
-/// projections. It takes `(repo, tree_id, branch_name)` → tree hash.
+/// projections. It takes `(ctx, tree_id, branch_name)` → tree hash.
 pub fn composite(
-    repo: &gix::Repository,
+    ctx: &Context,
     workspace_tree: &mut MutableTree,
     branch_name: &str,
     workspace_name: &str,
     output: &mut MutableTree,
-    project_fn: &mut dyn FnMut(&gix::Repository, ObjectId, &str) -> Result<ObjectId>,
+    project_fn: &mut dyn FnMut(&Context, ObjectId, &str) -> Result<ObjectId>,
 ) -> Result<()> {
-    let mappings = config::discover_mappings(repo, workspace_tree, branch_name)?;
+    let mappings = config::discover_mappings(ctx, workspace_tree, branch_name)?;
     if mappings.is_empty() {
         return Ok(());
     }
@@ -31,7 +31,7 @@ pub fn composite(
     for mapping in &sorted {
         // Resolve source → tree hash
         let source_tree_hash = source::resolve(
-            repo,
+            ctx,
             workspace_tree,
             &mapping.holosource,
             workspace_name,
@@ -39,14 +39,14 @@ pub fn composite(
         )?;
 
         // Navigate to root subtree within source
-        let mut source_tree = source::resolve_tree_at_path(repo, source_tree_hash, &mapping.root)?;
+        let mut source_tree = source::resolve_tree_at_path(ctx.repo, source_tree_hash, &mapping.root)?;
 
         // Navigate to (or create) output subtree
-        let target = output.get_or_create_subtree(repo, &mapping.output)?;
+        let target = output.get_or_create_subtree(ctx, &mapping.output)?;
 
         // Merge
         let opts = MergeOptions::new(Some(&mapping.files), MergeMode::Overlay)?;
-        target.merge(repo, &mut source_tree, &opts, ".")?;
+        target.merge(ctx, &mut source_tree, &opts, ".")?;
     }
 
     Ok(())
@@ -57,28 +57,28 @@ pub fn composite(
 /// Sources are resolved by name using the provided source configs,
 /// which are looked up via `source_config_fn`.
 pub fn composite_plan(
-    repo: &gix::Repository,
+    ctx: &Context,
     mappings: &[MappingConfig],
     workspace_name: &str,
     workspace_tree: &mut MutableTree,
     output: &mut MutableTree,
-    project_fn: &mut dyn FnMut(&gix::Repository, ObjectId, &str) -> Result<ObjectId>,
+    project_fn: &mut dyn FnMut(&Context, ObjectId, &str) -> Result<ObjectId>,
 ) -> Result<()> {
     let sorted = toposort(mappings)?;
 
     for mapping in &sorted {
         let source_tree_hash = source::resolve(
-            repo,
+            ctx,
             workspace_tree,
             &mapping.holosource,
             workspace_name,
             project_fn,
         )?;
 
-        let mut source_tree = source::resolve_tree_at_path(repo, source_tree_hash, &mapping.root)?;
-        let target = output.get_or_create_subtree(repo, &mapping.output)?;
+        let mut source_tree = source::resolve_tree_at_path(ctx.repo, source_tree_hash, &mapping.root)?;
+        let target = output.get_or_create_subtree(ctx, &mapping.output)?;
         let opts = MergeOptions::new(Some(&mapping.files), MergeMode::Overlay)?;
-        target.merge(repo, &mut source_tree, &opts, ".")?;
+        target.merge(ctx, &mut source_tree, &opts, ".")?;
     }
 
     Ok(())

--- a/holo-projector/src/config.rs
+++ b/holo-projector/src/config.rs
@@ -6,7 +6,7 @@
 use serde::Deserialize;
 
 use crate::error::{Error, Result};
-use holo_tree::MutableTree;
+use holo_tree::{Context, MutableTree};
 
 // ── Workspace (.holo/config.toml) ──────────────────────────────────────────
 
@@ -165,40 +165,40 @@ impl StringOrVec {
 /// Read and parse a TOML file from a blob inside a git tree.
 /// Delegates to `holo_tree::toml::read_toml` for the generic parsing.
 pub fn read_toml<T: serde::de::DeserializeOwned>(
-    repo: &gix::Repository,
+    ctx: &Context,
     tree: &mut MutableTree,
     path: &str,
 ) -> Result<Option<T>> {
-    Ok(holo_tree::toml::read_toml(repo, tree, path)?)
+    Ok(holo_tree::toml::read_toml(ctx, tree, path)?)
 }
 
 // ── Mapping discovery ──────────────────────────────────────────────────────
 
 /// Walk `.holo/branches/{branch_name}/` and collect all mapping configs.
 pub fn discover_mappings(
-    repo: &gix::Repository,
+    ctx: &Context,
     tree: &mut MutableTree,
     branch_name: &str,
 ) -> Result<Vec<MappingConfig>> {
     let path = format!(".holo/branches/{branch_name}");
-    let branch_tree = match tree.get_subtree(repo, &path)? {
+    let branch_tree = match tree.get_subtree(ctx, &path)? {
         Some(t) => t,
         None => return Ok(vec![]),
     };
 
     let mut out = Vec::new();
-    walk_mappings(repo, branch_tree, "", &mut out)?;
+    walk_mappings(ctx, branch_tree, "", &mut out)?;
     Ok(out)
 }
 
 /// Recursively walk a mapping tree directory.
 fn walk_mappings(
-    repo: &gix::Repository,
+    ctx: &Context,
     tree: &mut MutableTree,
     prefix: &str,
     out: &mut Vec<MappingConfig>,
 ) -> Result<()> {
-    tree.ensure_children(repo)?;
+    tree.ensure_children(ctx)?;
 
     // Snapshot names + types to avoid borrow conflicts during recursion
     let entries: Vec<(String, bool, Option<gix::ObjectId>)> = tree
@@ -223,8 +223,8 @@ fn walk_mappings(
             } else {
                 format!("{prefix}/{name}")
             };
-            let subtree = tree.get_subtree(repo, &name)?.unwrap();
-            walk_mappings(repo, subtree, &new_prefix, out)?;
+            let subtree = tree.get_subtree(ctx, &name)?.unwrap();
+            walk_mappings(ctx, subtree, &new_prefix, out)?;
             continue;
         }
 
@@ -234,7 +234,7 @@ fn walk_mappings(
         };
 
         let hash = blob_hash.unwrap();
-        let obj = repo.find_object(hash)?;
+        let obj = ctx.repo.find_object(hash)?;
         let text = std::str::from_utf8(&obj.data).map_err(|_| Error::Config {
             path: name.clone(),
             message: "non-UTF8".into(),
@@ -260,16 +260,16 @@ fn walk_mappings(
 
 /// Look for a gitlink (commit entry) at `.holo/sources/{name}` in the tree.
 pub fn resolve_gitlink(
-    repo: &gix::Repository,
+    ctx: &Context,
     tree: &mut MutableTree,
     source_name: &str,
 ) -> Result<Option<gix::ObjectId>> {
-    let sources = match tree.get_subtree(repo, ".holo/sources")? {
+    let sources = match tree.get_subtree(ctx, ".holo/sources")? {
         Some(t) => t,
         None => return Ok(None),
     };
 
-    sources.ensure_children(repo)?;
+    sources.ensure_children(ctx)?;
     let children = match &sources.children {
         Some(c) => c,
         None => return Ok(None),

--- a/holo-projector/src/projection.rs
+++ b/holo-projector/src/projection.rs
@@ -5,39 +5,55 @@ use gix::ObjectId;
 use crate::branch;
 use crate::config::{self, BranchConfig, BranchConfigFile, MappingConfig, WorkspaceConfigFile};
 use crate::error::Result;
-use holo_tree::{Child, MutableTree};
+use holo_tree::{Context, MutableTree, TreeCache};
 
 /// Project a holobranch by reading `.holo/` config from a git tree.
 ///
 /// Returns the hash of the composed output tree.
+///
+/// Creates a fresh [`TreeCache`] for the run; recursive sub-projections share
+/// it through the [`Context`]. Use [`project_branch_in`] to supply your own
+/// context (e.g. to keep the cache warm across several projections).
 pub fn project_branch(
     repo: &gix::Repository,
     root_tree_id: ObjectId,
     branch_name: &str,
 ) -> Result<ObjectId> {
+    let cache = TreeCache::new();
+    let ctx = Context::new(repo, &cache);
+    project_branch_in(&ctx, root_tree_id, branch_name)
+}
+
+/// [`project_branch`] against a caller-supplied [`Context`], so an embedding
+/// consumer owns the cache and can reuse it across projections.
+pub fn project_branch_in(
+    ctx: &Context,
+    root_tree_id: ObjectId,
+    branch_name: &str,
+) -> Result<ObjectId> {
     let mut ws_tree = MutableTree::new(root_tree_id);
 
-    let ws_name = read_workspace_name(repo, &mut ws_tree)?;
+    let ws_name = read_workspace_name(ctx, &mut ws_tree)?;
 
     let mut output = MutableTree::empty();
 
     // Resolve extends chain (base first)
-    let chain = resolve_extends_chain(repo, &mut ws_tree, branch_name)?;
+    let chain = resolve_extends_chain(ctx, &mut ws_tree, branch_name)?;
 
     for name in &chain {
         branch::composite(
-            repo,
+            ctx,
             &mut ws_tree,
             name,
             &ws_name,
             &mut output,
-            &mut |r, tree_id, bn| project_branch(r, tree_id, bn),
+            &mut |c, tree_id, bn| project_branch_in(c, tree_id, bn),
         )?;
     }
 
-    strip_metadata(repo, &mut output)?;
+    strip_metadata(ctx, &mut output)?;
 
-    Ok(output.write(repo)?)
+    Ok(output.write(ctx)?)
 }
 
 /// Compose git trees from structured source/mapping definitions.
@@ -49,28 +65,28 @@ pub fn project_plan(
     sources: &[crate::PlanSource],
     mappings: &[crate::PlanMapping],
 ) -> Result<ObjectId> {
+    let cache = TreeCache::new();
+    let ctx = Context::new(repo, &cache);
+    project_plan_in(&ctx, sources, mappings)
+}
+
+/// [`project_plan`] against a caller-supplied [`Context`].
+pub fn project_plan_in(
+    ctx: &Context,
+    sources: &[crate::PlanSource],
+    mappings: &[crate::PlanMapping],
+) -> Result<ObjectId> {
     // Build a minimal workspace tree with just a config blob
     // so that self-source and recursive projections work.
     let ws_name = "plan";
     let mut ws_tree = MutableTree::empty();
     // Write .holo/config.toml so recursive projections can read it
-    let config_blob = repo
+    let config_blob = ctx
+        .repo
         .write_blob(format!("[holospace]\nname = \"{ws_name}\"\n"))
         .map_err(|e| holo_tree::Error::Git(e.to_string()))?;
-    {
-        let holo = ws_tree.get_or_create_subtree(repo, ".holo")?;
-        holo.ensure_children(repo)?;
-        holo.children.as_mut().unwrap().insert(
-            "config.toml".to_string(),
-            Child::Blob {
-                mode: 0o100644,
-                hash: config_blob.detach(),
-            },
-        );
-        holo.dirty = true;
-    }
-    ws_tree.dirty = true;
-    ws_tree.write(repo)?;
+    ws_tree.write_child_hash(ctx, ".holo/config.toml", config_blob.detach(), 0o100644)?;
+    ws_tree.write(ctx)?;
 
     // Write source config blobs into the workspace tree so that
     // source::resolve can read them via read_source_config
@@ -86,22 +102,13 @@ pub fn project_plan(
             toml_content.push_str(&format!("\n[holosource.project]\nholobranch = \"{hb}\"\n"));
         }
 
-        let blob_id = repo
-            .write_blob(&toml_content)
-            .map_err(|e| holo_tree::Error::Git(e.to_string()))?;
-
-        let sources_tree = ws_tree.get_or_create_subtree(repo, ".holo/sources")?;
-        sources_tree.children.as_mut().unwrap().insert(
-            format!("{}.toml", src.name),
-            Child::Blob {
-                mode: 0o100644,
-                hash: blob_id.detach(),
-            },
-        );
-        sources_tree.dirty = true;
+        ws_tree.write_child(
+            ctx,
+            &format!(".holo/sources/{}.toml", src.name),
+            &toml_content,
+        )?;
     }
-    ws_tree.dirty = true;
-    ws_tree.write(repo)?;
+    ws_tree.write(ctx)?;
 
     // Convert PlanMappings to MappingConfigs
     let mapping_configs: Vec<MappingConfig> = mappings
@@ -121,36 +128,36 @@ pub fn project_plan(
     let mut output = MutableTree::empty();
 
     branch::composite_plan(
-        repo,
+        ctx,
         &mapping_configs,
         ws_name,
         &mut ws_tree,
         &mut output,
-        &mut |r, tree_id, bn| project_branch(r, tree_id, bn),
+        &mut |c, tree_id, bn| project_branch_in(c, tree_id, bn),
     )?;
 
-    strip_metadata(repo, &mut output)?;
+    strip_metadata(ctx, &mut output)?;
 
-    Ok(output.write(repo)?)
+    Ok(output.write(ctx)?)
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-fn read_workspace_name(repo: &gix::Repository, tree: &mut MutableTree) -> Result<String> {
+fn read_workspace_name(ctx: &Context, tree: &mut MutableTree) -> Result<String> {
     let ws_config: Option<WorkspaceConfigFile> =
-        config::read_toml(repo, tree, ".holo/config.toml")?;
+        config::read_toml(ctx, tree, ".holo/config.toml")?;
     Ok(ws_config
         .and_then(|c| c.holospace.name)
         .unwrap_or_default())
 }
 
 fn read_branch_config(
-    repo: &gix::Repository,
+    ctx: &Context,
     tree: &mut MutableTree,
     name: &str,
 ) -> Result<BranchConfig> {
     let path = format!(".holo/branches/{name}.toml");
-    match config::read_toml::<BranchConfigFile>(repo, tree, &path)? {
+    match config::read_toml::<BranchConfigFile>(ctx, tree, &path)? {
         Some(f) => Ok(f.holobranch),
         None => Ok(BranchConfig::default()),
     }
@@ -158,7 +165,7 @@ fn read_branch_config(
 
 /// Walk the `extend` chain and return branch names in base-first order.
 fn resolve_extends_chain(
-    repo: &gix::Repository,
+    ctx: &Context,
     tree: &mut MutableTree,
     start: &str,
 ) -> Result<Vec<String>> {
@@ -166,7 +173,7 @@ fn resolve_extends_chain(
     let mut current = start.to_string();
 
     loop {
-        let config = read_branch_config(repo, tree, &current)?;
+        let config = read_branch_config(ctx, tree, &current)?;
         match config.extend {
             Some(ref ext) => {
                 stack.push(ext.clone());
@@ -182,21 +189,22 @@ fn resolve_extends_chain(
 
 /// Strip `.holo/{branches,sources}` from output, then strip `.holo`
 /// entirely if only `config.toml` remains.
-fn strip_metadata(repo: &gix::Repository, output: &mut MutableTree) -> Result<()> {
-    if let Some(holo) = output.get_subtree(repo, ".holo")? {
-        holo.delete_child(repo, "branches")?;
-        holo.delete_child(repo, "sources")?;
+fn strip_metadata(ctx: &Context, output: &mut MutableTree) -> Result<()> {
+    if let Some(holo) = output.get_subtree(ctx, ".holo")? {
+        holo.delete_child(ctx, "branches")?;
+        holo.delete_child(ctx, "sources")?;
     }
 
     // Strip .holo if only config.toml remains
-    if let Some(holo) = output.get_subtree(repo, ".holo")? {
-        holo.ensure_children(repo)?;
-        let children = holo.children.as_ref().unwrap();
-        let empty = children
+    if let Some(holo) = output.get_subtree(ctx, ".holo")? {
+        holo.ensure_children(ctx)?;
+        let empty = holo
+            .children
             .iter()
+            .flatten()
             .all(|(name, _)| name == "config.toml");
         if empty {
-            output.delete_child(repo, ".holo")?;
+            output.delete_child(ctx, ".holo")?;
         }
     }
 

--- a/holo-projector/src/source.rs
+++ b/holo-projector/src/source.rs
@@ -10,20 +10,20 @@ use gix::ObjectId;
 
 use crate::config::{self, SourceConfig, SourceConfigFile};
 use crate::error::{Error, Result};
-use holo_tree::MutableTree;
+use holo_tree::{Context, MutableTree};
 
 /// Resolve a source to a tree hash.
 ///
 /// `project_fn` is called for recursive projections (source.project and
-/// =>holobranch). It takes `(repo, tree_id, branch_name)` and returns a
-/// tree hash — this is `project_branch` passed as a callback to break the
+/// =>holobranch). It takes `(ctx, tree_id, branch_name)` and returns a
+/// tree hash — this is `project_branch_in` passed as a callback to break the
 /// circular dependency between source and projection.
 pub fn resolve(
-    repo: &gix::Repository,
+    ctx: &Context,
     workspace_tree: &mut MutableTree,
     source_name: &str,
     workspace_name: &str,
-    project_fn: &mut dyn FnMut(&gix::Repository, ObjectId, &str) -> Result<ObjectId>,
+    project_fn: &mut dyn FnMut(&Context, ObjectId, &str) -> Result<ObjectId>,
 ) -> Result<ObjectId> {
     let (base_name, mapping_holobranch) = match source_name.split_once("=>") {
         Some((base, branch)) => (base, Some(branch)),
@@ -34,28 +34,28 @@ pub fn resolve(
     if base_name == workspace_name {
         let mut head = workspace_tree.hash;
         if let Some(hb) = mapping_holobranch {
-            head = project_fn(repo, head, hb)?;
+            head = project_fn(ctx, head, hb)?;
         }
         return Ok(head);
     }
 
     // Read source config
-    let source_config = read_source_config(repo, workspace_tree, base_name)?;
+    let source_config = read_source_config(ctx, workspace_tree, base_name)?;
 
     // Resolve commit via gitlink → spec-ref → local ref
-    let commit = resolve_commit(repo, workspace_tree, source_name, base_name, &source_config)?;
+    let commit = resolve_commit(ctx, workspace_tree, source_name, base_name, &source_config)?;
 
     // Peel to tree
-    let mut head = commit_to_tree(repo, commit)?;
+    let mut head = commit_to_tree(ctx.repo, commit)?;
 
     // Apply source.project.holobranch
     if let Some(ref project) = source_config.project {
-        head = project_fn(repo, head, &project.holobranch)?;
+        head = project_fn(ctx, head, &project.holobranch)?;
     }
 
     // Apply mapping holobranch (=>syntax)
     if let Some(hb) = mapping_holobranch {
-        head = project_fn(repo, head, hb)?;
+        head = project_fn(ctx, head, hb)?;
     }
 
     Ok(head)
@@ -64,18 +64,18 @@ pub fn resolve(
 // ── Commit resolution ──────────────────────────────────────────────────────
 
 fn resolve_commit(
-    repo: &gix::Repository,
+    ctx: &Context,
     workspace_tree: &mut MutableTree,
     source_name: &str,
     base_name: &str,
     config: &SourceConfig,
 ) -> Result<ObjectId> {
     // 1. Gitlink
-    if let Some(hash) = config::resolve_gitlink(repo, workspace_tree, source_name)? {
+    if let Some(hash) = config::resolve_gitlink(ctx, workspace_tree, source_name)? {
         return Ok(hash);
     }
     if base_name != source_name {
-        if let Some(hash) = config::resolve_gitlink(repo, workspace_tree, base_name)? {
+        if let Some(hash) = config::resolve_gitlink(ctx, workspace_tree, base_name)? {
             return Ok(hash);
         }
     }
@@ -92,16 +92,16 @@ fn resolve_commit(
                 suffix
             );
 
-            if let Ok(resolved) = repo.rev_parse_single(spec_ref.as_str()) {
-                return peel_to_commit(repo, resolved.detach());
+            if let Ok(resolved) = ctx.repo.rev_parse_single(spec_ref.as_str()) {
+                return peel_to_commit(ctx.repo, resolved.detach());
             }
         }
     }
 
     // 3. Local ref
     if let Some(ref git_ref) = config.git_ref {
-        if let Ok(resolved) = repo.rev_parse_single(git_ref.as_str()) {
-            return peel_to_commit(repo, resolved.detach());
+        if let Ok(resolved) = ctx.repo.rev_parse_single(git_ref.as_str()) {
+            return peel_to_commit(ctx.repo, resolved.detach());
         }
     }
 
@@ -112,12 +112,12 @@ fn resolve_commit(
 }
 
 fn read_source_config(
-    repo: &gix::Repository,
+    ctx: &Context,
     tree: &mut MutableTree,
     name: &str,
 ) -> Result<SourceConfig> {
     let path = format!(".holo/sources/{name}.toml");
-    match config::read_toml::<SourceConfigFile>(repo, tree, &path)? {
+    match config::read_toml::<SourceConfigFile>(ctx, tree, &path)? {
         Some(f) => Ok(f.holosource),
         None => Ok(SourceConfig::default()),
     }

--- a/holo-projector/tests/helpers/mod.rs
+++ b/holo-projector/tests/helpers/mod.rs
@@ -10,6 +10,7 @@ use gix::ObjectId;
 pub struct Sandbox {
     pub dir: tempfile::TempDir,
     pub repo: gix::Repository,
+    pub cache: holo_projector::holo_tree::TreeCache,
 }
 
 impl Sandbox {
@@ -17,7 +18,16 @@ impl Sandbox {
     pub fn new() -> Self {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let repo = gix::init_bare(dir.path()).expect("failed to init bare repo");
-        Sandbox { dir, repo }
+        Sandbox {
+            dir,
+            repo,
+            cache: holo_projector::holo_tree::TreeCache::new(),
+        }
+    }
+
+    /// A per-call context over this sandbox's repo and cache.
+    pub fn ctx(&self) -> holo_projector::holo_tree::Context<'_> {
+        holo_projector::holo_tree::Context::new(&self.repo, &self.cache)
     }
 
     /// Write a blob and return its OID.
@@ -34,10 +44,10 @@ impl Sandbox {
 
         for (path, content) in files {
             let blob_hash = self.write_blob(content);
-            insert_blob_at_path(&self.repo, &mut tree, path, blob_hash);
+            insert_blob_at_path(&self.ctx(), &mut tree, path, blob_hash);
         }
 
-        tree.write(&self.repo).unwrap()
+        tree.write(&self.ctx()).unwrap()
     }
 
     /// Build a tree from entries that can include blobs, trees, and gitlinks.
@@ -108,7 +118,7 @@ impl Sandbox {
             spec.name
         );
         let config_blob = self.write_blob(&config_toml);
-        insert_blob_at_path(&self.repo, &mut tree, ".holo/config.toml", config_blob);
+        insert_blob_at_path(&self.ctx(), &mut tree, ".holo/config.toml", config_blob);
 
         // .holo/sources/{name}.toml
         for (name, source) in &spec.sources {
@@ -124,7 +134,7 @@ impl Sandbox {
             }
             let blob = self.write_blob(&toml);
             insert_blob_at_path(
-                &self.repo,
+                &self.ctx(),
                 &mut tree,
                 &format!(".holo/sources/{name}.toml"),
                 blob,
@@ -143,7 +153,7 @@ impl Sandbox {
                 }
                 let blob = self.write_blob(&toml);
                 insert_blob_at_path(
-                    &self.repo,
+                    &self.ctx(),
                     &mut tree,
                     &format!(".holo/branches/{branch_name}.toml"),
                     blob,
@@ -186,7 +196,7 @@ impl Sandbox {
 
                 let blob = self.write_blob(&toml);
                 insert_blob_at_path(
-                    &self.repo,
+                    &self.ctx(),
                     &mut tree,
                     &format!(".holo/branches/{branch_name}/{key}.toml"),
                     blob,
@@ -197,7 +207,7 @@ impl Sandbox {
         // Gitlink entries for sources in .holo/sources/
         for (name, commit_hash) in &spec.gitlinks {
             let sources_tree = tree
-                .get_or_create_subtree(&self.repo, ".holo/sources")
+                .get_or_create_subtree(&self.ctx(), ".holo/sources")
                 .unwrap();
             sources_tree.children.as_mut().unwrap().insert(
                 name.clone(),
@@ -209,16 +219,16 @@ impl Sandbox {
         // Additional content files (outside .holo/)
         for (path, content) in &spec.files {
             let blob = self.write_blob(content);
-            insert_blob_at_path(&self.repo, &mut tree, path, blob);
+            insert_blob_at_path(&self.ctx(), &mut tree, path, blob);
         }
 
-        tree.write(&self.repo).unwrap()
+        tree.write(&self.ctx()).unwrap()
     }
 }
 
 /// Insert a blob at a slash-separated path in a MutableTree.
 fn insert_blob_at_path(
-    repo: &gix::Repository,
+    ctx: &holo_projector::holo_tree::Context,
     tree: &mut holo_projector::holo_tree::tree::MutableTree,
     path: &str,
     blob_hash: ObjectId,
@@ -227,7 +237,7 @@ fn insert_blob_at_path(
         Some((d, f)) => (d, f),
         None => (".", path),
     };
-    let parent = tree.get_or_create_subtree(repo, dir).unwrap();
+    let parent = tree.get_or_create_subtree(ctx, dir).unwrap();
     parent.children.as_mut().unwrap().insert(
         file.to_string(),
         holo_projector::holo_tree::tree::Child::Blob {

--- a/holo-projector/tests/projection.rs
+++ b/holo-projector/tests/projection.rs
@@ -5,20 +5,20 @@ mod helpers;
 use helpers::*;
 use holo_projector::holo_tree::tree::MutableTree;
 
-fn list_tree(repo: &gix::Repository, hash: gix::ObjectId) -> Vec<String> {
+fn list_tree(ctx: &holo_projector::holo_tree::Context, hash: gix::ObjectId) -> Vec<String> {
     let mut tree = MutableTree::new(hash);
-    collect_paths(repo, &mut tree, "")
+    collect_paths(ctx, &mut tree, "")
 }
 
-fn collect_paths(repo: &gix::Repository, tree: &mut MutableTree, prefix: &str) -> Vec<String> {
-    tree.ensure_children(repo).unwrap();
+fn collect_paths(ctx: &holo_projector::holo_tree::Context, tree: &mut MutableTree, prefix: &str) -> Vec<String> {
+    tree.ensure_children(ctx).unwrap();
     let mut paths = Vec::new();
     let keys: Vec<String> = tree.children.as_ref().unwrap().keys().cloned().collect();
     for name in keys {
         let path = if prefix.is_empty() { name.clone() } else { format!("{prefix}/{name}") };
         match tree.children.as_mut().unwrap().get_mut(&name) {
             Some(holo_projector::holo_tree::tree::Child::Tree(ref mut t)) => {
-                paths.extend(collect_paths(repo, t, &path));
+                paths.extend(collect_paths(ctx, t, &path));
             }
             Some(holo_projector::holo_tree::tree::Child::Blob { .. }) => paths.push(path),
             _ => {}
@@ -27,9 +27,9 @@ fn collect_paths(repo: &gix::Repository, tree: &mut MutableTree, prefix: &str) -
     paths
 }
 
-fn read_blob(repo: &gix::Repository, hash: gix::ObjectId, path: &str) -> String {
+fn read_blob(ctx: &holo_projector::holo_tree::Context, hash: gix::ObjectId, path: &str) -> String {
     let mut tree = MutableTree::new(hash);
-    let data = tree.read_blob(repo, path).unwrap().unwrap();
+    let data = tree.read_blob(ctx, path).unwrap().unwrap();
     String::from_utf8(data).unwrap()
 }
 
@@ -58,7 +58,7 @@ fn project_self_source_all_files() {
     holo_projector::reset();
     let result = holo_projector::project_branch(&sb.repo, root, "site").unwrap();
 
-    let paths = list_tree(&sb.repo, result);
+    let paths = list_tree(&sb.ctx(), result);
     assert!(paths.contains(&"index.html".to_string()));
     assert!(paths.contains(&"style.css".to_string()));
     // .holo should be stripped
@@ -89,7 +89,7 @@ fn project_self_source_with_glob_filter() {
     holo_projector::reset();
     let result = holo_projector::project_branch(&sb.repo, root, "site").unwrap();
 
-    let paths = list_tree(&sb.repo, result);
+    let paths = list_tree(&sb.ctx(), result);
     assert!(paths.contains(&"docs/guide.md".to_string()));
     assert!(paths.contains(&"mkdocs.yml".to_string()));
     assert!(!paths.contains(&"src/app.js".to_string()));
@@ -123,7 +123,7 @@ fn project_self_source_with_negation() {
     holo_projector::reset();
     let result = holo_projector::project_branch(&sb.repo, root, "site").unwrap();
 
-    let paths = list_tree(&sb.repo, result);
+    let paths = list_tree(&sb.ctx(), result);
     assert!(paths.contains(&"src/app.js".to_string()));
     assert!(!paths.iter().any(|p| p.starts_with(".github")));
     assert!(!paths.iter().any(|p| p.starts_with("node_modules")));
@@ -169,11 +169,11 @@ fn project_two_sources_via_gitlinks() {
     holo_projector::reset();
     let result = holo_projector::project_branch(&sb.repo, root, "site").unwrap();
 
-    let paths = list_tree(&sb.repo, result);
+    let paths = list_tree(&sb.ctx(), result);
     assert!(paths.contains(&"a.txt".to_string()));
     assert!(paths.contains(&"b.txt".to_string()));
-    assert_eq!(read_blob(&sb.repo, result, "a.txt"), "from A");
-    assert_eq!(read_blob(&sb.repo, result, "b.txt"), "from B");
+    assert_eq!(read_blob(&sb.ctx(), result, "a.txt"), "from A");
+    assert_eq!(read_blob(&sb.ctx(), result, "b.txt"), "from B");
 }
 
 // ── Mapping root and output paths ──────────────────────────────────────────
@@ -208,7 +208,7 @@ fn project_with_root_path() {
     holo_projector::reset();
     let result = holo_projector::project_branch(&sb.repo, root, "site").unwrap();
 
-    let paths = list_tree(&sb.repo, result);
+    let paths = list_tree(&sb.ctx(), result);
     // Files from src/lib/ should appear at /mylib/ (default output = mapping name)
     assert!(paths.contains(&"mylib/util.js".to_string()));
     assert!(paths.contains(&"mylib/core.js".to_string()));
@@ -252,7 +252,7 @@ fn project_branch_extends_chain() {
     holo_projector::reset();
     let result = holo_projector::project_branch(&sb.repo, root, "extended").unwrap();
 
-    let paths = list_tree(&sb.repo, result);
+    let paths = list_tree(&sb.ctx(), result);
     assert!(paths.contains(&"base.txt".to_string()));
     assert!(paths.contains(&"override.txt".to_string()));
 }
@@ -301,7 +301,7 @@ fn project_source_with_inner_projection() {
     holo_projector::reset();
     let result = holo_projector::project_branch(&sb.repo, outer_root, "site").unwrap();
 
-    let paths = list_tree(&sb.repo, result);
+    let paths = list_tree(&sb.ctx(), result);
     assert!(paths.contains(&"lib/core.js".to_string()));
     // Inner projection should have filtered these out
     assert!(!paths.contains(&"test/core.test.js".to_string()));
@@ -327,7 +327,7 @@ fn strips_holo_branches_and_sources() {
     holo_projector::reset();
     let result = holo_projector::project_branch(&sb.repo, root, "site").unwrap();
 
-    let paths = list_tree(&sb.repo, result);
+    let paths = list_tree(&sb.ctx(), result);
     assert!(!paths.iter().any(|p| p.starts_with(".holo/branches")));
     assert!(!paths.iter().any(|p| p.starts_with(".holo/sources")));
 }
@@ -349,7 +349,7 @@ fn strips_holo_entirely_when_only_config_remains() {
     holo_projector::reset();
     let result = holo_projector::project_branch(&sb.repo, root, "site").unwrap();
 
-    let paths = list_tree(&sb.repo, result);
+    let paths = list_tree(&sb.ctx(), result);
     assert!(!paths.iter().any(|p| p.starts_with(".holo")),
         ".holo should be stripped entirely when only config.toml remains. Got: {:?}",
         paths.iter().filter(|p| p.starts_with(".holo")).collect::<Vec<_>>());
@@ -380,7 +380,7 @@ fn project_plan_single_source() {
     )
     .unwrap();
 
-    let paths = list_tree(&sb.repo, result);
+    let paths = list_tree(&sb.ctx(), result);
     assert!(paths.contains(&"app.js".to_string()));
     assert!(paths.contains(&"style.css".to_string()));
 }
@@ -424,11 +424,11 @@ fn project_plan_two_layers_with_ordering() {
     )
     .unwrap();
 
-    let paths = list_tree(&sb.repo, result);
+    let paths = list_tree(&sb.ctx(), result);
     assert!(paths.contains(&"base-only.txt".to_string()));
     assert!(paths.contains(&"overlay-only.txt".to_string()));
     // Overlay wins on shared file
-    assert_eq!(read_blob(&sb.repo, result, "file.txt"), "overlay");
+    assert_eq!(read_blob(&sb.ctx(), result, "file.txt"), "overlay");
 }
 
 // ── Hash stability ─────────────────────────────────────────────────────────

--- a/holo-projector/tests/source.rs
+++ b/holo-projector/tests/source.rs
@@ -60,7 +60,7 @@ fn resolves_gitlink_source() {
     let result = holo_projector::project_branch(&sb.repo, root, "site").unwrap();
 
     let mut tree = holo_projector::holo_tree::tree::MutableTree::new(result);
-    let data = tree.read_blob(&sb.repo, "hello.txt").unwrap().unwrap();
+    let data = tree.read_blob(&sb.ctx(), "hello.txt").unwrap().unwrap();
     assert_eq!(std::str::from_utf8(&data).unwrap(), "world");
 }
 
@@ -110,7 +110,7 @@ fn resolves_source_through_annotated_tag() {
     let result = holo_projector::project_branch(&sb.repo, root, "site").unwrap();
 
     let mut tree = holo_projector::holo_tree::tree::MutableTree::new(result);
-    let data = tree.read_blob(&sb.repo, "tagged.txt").unwrap().unwrap();
+    let data = tree.read_blob(&sb.ctx(), "tagged.txt").unwrap().unwrap();
     assert_eq!(std::str::from_utf8(&data).unwrap(), "from tag");
 }
 
@@ -139,7 +139,7 @@ fn self_source_returns_workspace_tree() {
     let result = holo_projector::project_branch(&sb.repo, root, "site").unwrap();
 
     let mut tree = holo_projector::holo_tree::tree::MutableTree::new(result);
-    let data = tree.read_blob(&sb.repo, "content.txt").unwrap().unwrap();
+    let data = tree.read_blob(&sb.ctx(), "content.txt").unwrap().unwrap();
     assert_eq!(std::str::from_utf8(&data).unwrap(), "self-source content");
 }
 
@@ -187,22 +187,22 @@ fn mapping_holobranch_triggers_inner_projection() {
 
     let paths = {
         let mut tree = holo_projector::holo_tree::tree::MutableTree::new(result);
-        collect_paths(&sb.repo, &mut tree, "")
+        collect_paths(&sb.ctx(), &mut tree, "")
     };
 
     assert!(paths.contains(&"src/core.js".to_string()));
     assert!(!paths.contains(&"test/spec.js".to_string()));
 }
 
-fn collect_paths(repo: &gix::Repository, tree: &mut holo_projector::holo_tree::tree::MutableTree, prefix: &str) -> Vec<String> {
-    tree.ensure_children(repo).unwrap();
+fn collect_paths(ctx: &holo_projector::holo_tree::Context, tree: &mut holo_projector::holo_tree::tree::MutableTree, prefix: &str) -> Vec<String> {
+    tree.ensure_children(ctx).unwrap();
     let mut paths = Vec::new();
     let keys: Vec<String> = tree.children.as_ref().unwrap().keys().cloned().collect();
     for name in keys {
         let path = if prefix.is_empty() { name.clone() } else { format!("{prefix}/{name}") };
         match tree.children.as_mut().unwrap().get_mut(&name) {
             Some(holo_projector::holo_tree::tree::Child::Tree(ref mut t)) => {
-                paths.extend(collect_paths(repo, t, &path));
+                paths.extend(collect_paths(ctx, t, &path));
             }
             Some(holo_projector::holo_tree::tree::Child::Blob { .. }) => paths.push(path),
             _ => {}

--- a/holo-tree-napi/index.d.ts
+++ b/holo-tree-napi/index.d.ts
@@ -115,9 +115,10 @@ export declare class Repo {
  * Holds its own clone of the repo handle so JS callers don't thread a repo
  * argument through every call.
  *
- * Phase-C finding #5 (thread-local tree cache) is addressed upstream by the
- * consumer-owned cache/context redesign — see `specs/api/errors.md`
- * § Thread-safety expectations.
+ * Owns its `TreeCache` (Phase-C finding #5): the cache travels with the
+ * `Tree` object rather than living in thread-implicit state, so whichever
+ * thread the JS engine dispatches a call on sees the same cache — see
+ * `specs/api/errors.md` § Thread-safety expectations.
  */
 export declare class Tree {
   /**

--- a/holo-tree-napi/index.d.ts
+++ b/holo-tree-napi/index.d.ts
@@ -6,6 +6,13 @@
 /** Git's well-known empty-tree hash (`4b825dc6…`). */
 export declare function emptyTreeHash(): string
 /**
+ * Internal self-test hook: deliberately panics inside the binding so the
+ * test suite can prove that a panic surfaces as a catchable JS error with
+ * code `PANIC` rather than aborting the host process (specs/api/errors.md
+ * § Panic policy). Never call this outside tests.
+ */
+export declare function __triggerPanicForTest(): void
+/**
  * A commit identity (author or committer). `timeSeconds`/`offsetMinutes` are
  * optional; when omitted the current wall-clock time at UTC is used. Pass them
  * explicitly to reproduce a specific commit (e.g. match `git commit-tree`
@@ -84,8 +91,9 @@ export declare class Repo {
    * When `expectedOldHash` is provided this is a **compare-and-swap**: the
    * update only succeeds if the ref currently resolves to exactly that hash,
    * so a concurrent writer who moved the ref makes the swap fail rather than
-   * silently clobbering their commit. Omit it to force the ref (the prior
-   * unconditional behavior).
+   * silently clobbering their commit. A lost swap throws with code
+   * `REF_CONFLICT` — the matchable optimistic-concurrency signal. Omit
+   * `expectedOldHash` to force the ref (the prior unconditional behavior).
    */
   updateRef(refname: string, hash: string, expectedOldHash?: string | undefined | null): void
   /**
@@ -107,13 +115,9 @@ export declare class Repo {
  * Holds its own clone of the repo handle so JS callers don't thread a repo
  * argument through every call.
  *
- * Phase-C finding #1: holo-tree's `MutableTree` takes `&gix::Repository` on
- * nearly every method and keeps a *thread-local* tree cache. We smooth the
- * first half here (the handle lives on the `Tree`) but NOT the second: each
- * call does `to_thread_local()`, and whether holo-tree's thread-local cache
- * stays warm across libuv-dispatched calls is the open ergonomics question to
- * resolve upstream (e.g. a repo-bound tree handle, or an explicit session/
- * cache object the consumer owns).
+ * Phase-C finding #5 (thread-local tree cache) is addressed upstream by the
+ * consumer-owned cache/context redesign — see `specs/api/errors.md`
+ * § Thread-safety expectations.
  */
 export declare class Tree {
   /**

--- a/holo-tree-napi/index.js
+++ b/holo-tree-napi/index.js
@@ -310,8 +310,9 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { emptyTreeHash, Repo, Tree } = nativeBinding
+const { emptyTreeHash, __triggerPanicForTest, Repo, Tree } = nativeBinding
 
 module.exports.emptyTreeHash = emptyTreeHash
+module.exports.__triggerPanicForTest = __triggerPanicForTest
 module.exports.Repo = Repo
 module.exports.Tree = Tree

--- a/holo-tree-napi/package-lock.json
+++ b/holo-tree-napi/package-lock.json
@@ -16,7 +16,10 @@
       },
       "optionalDependencies": {
         "@hologit/holo-tree-darwin-arm64": "0.0.1",
+        "@hologit/holo-tree-darwin-x64": "0.0.1",
+        "@hologit/holo-tree-linux-arm64-gnu": "0.0.1",
         "@hologit/holo-tree-linux-x64-gnu": "0.0.1",
+        "@hologit/holo-tree-linux-x64-musl": "0.0.1",
         "@hologit/holo-tree-win32-x64-msvc": "0.0.1"
       }
     },
@@ -36,10 +39,58 @@
         "node": ">=20"
       }
     },
+    "node_modules/@hologit/holo-tree-darwin-x64": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-darwin-x64/-/holo-tree-darwin-x64-0.0.1.tgz",
+      "integrity": "sha512-GDzGSvtXBlhiMpWYnufkbLDSupjtFcpHfLjhOiQpw61vposN/FmVSAjOyaU2VLdYqRUaA2njocqr5gf3LqZ3NQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@hologit/holo-tree-linux-arm64-gnu": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-linux-arm64-gnu/-/holo-tree-linux-arm64-gnu-0.0.1.tgz",
+      "integrity": "sha512-PgDKAv/cM3Syf5j+jwb7zKcpciHqmf6SmUjII23lLoliMWI5gAQPBxT7cgAWpNQ9PSynvVuCAlVUcL+0vW9B5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@hologit/holo-tree-linux-x64-gnu": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@hologit/holo-tree-linux-x64-gnu/-/holo-tree-linux-x64-gnu-0.0.1.tgz",
       "integrity": "sha512-GHF02JK3XTKlR3joEw4iMhakFMXUrd/JBpC1YiyRhxM8K484lgGEDY7BLoZT3Fqxk7S/2JVDzOBu9ePrGyApfg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@hologit/holo-tree-linux-x64-musl": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-linux-x64-musl/-/holo-tree-linux-x64-musl-0.0.1.tgz",
+      "integrity": "sha512-n9Gof+9ToWP1djaES2cIYLNyDNj9zOcFNMa2oO6BboMve8dCkf2JY3pWqlPH85SWngo72ms57rRbamk3SIkVXQ==",
       "cpu": [
         "x64"
       ],

--- a/holo-tree-napi/src/lib.rs
+++ b/holo-tree-napi/src/lib.rs
@@ -37,7 +37,7 @@ use napi_derive::napi;
 
 use holo_tree::repo as ht_repo;
 use holo_tree::tree::empty_tree_id;
-use holo_tree::{MutableTree, ObjectId};
+use holo_tree::{Context, MutableTree, ObjectId, TreeCache};
 
 // ── error plumbing ──────────────────────────────────────────────────────────
 
@@ -195,6 +195,7 @@ impl Repo {
             let inner = ht_repo::create_tree_from_ref(&local, &git_ref).map_err(ht_err)?;
             Ok(Tree {
                 repo: self.inner.clone(),
+                cache: TreeCache::new(),
                 inner,
             })
         })
@@ -205,6 +206,7 @@ impl Repo {
     pub fn create_tree(&self) -> Tree {
         Tree {
             repo: self.inner.clone(),
+            cache: TreeCache::new(),
             inner: MutableTree::empty(),
         }
     }
@@ -348,12 +350,14 @@ fn classify(child: &holo_tree::Child) -> (&'static str, String, u32) {
 /// Holds its own clone of the repo handle so JS callers don't thread a repo
 /// argument through every call.
 ///
-/// Phase-C finding #5 (thread-local tree cache) is addressed upstream by the
-/// consumer-owned cache/context redesign — see `specs/api/errors.md`
-/// § Thread-safety expectations.
+/// Owns its `TreeCache` (Phase-C finding #5): the cache travels with the
+/// `Tree` object rather than living in thread-implicit state, so whichever
+/// thread the JS engine dispatches a call on sees the same cache — see
+/// `specs/api/errors.md` § Thread-safety expectations.
 #[napi]
 pub struct Tree {
     repo: gix::ThreadSafeRepository,
+    cache: TreeCache,
     inner: MutableTree,
 }
 
@@ -365,9 +369,10 @@ impl Tree {
     pub fn write_child(&mut self, path: String, content: String) -> Result<String, ErrorCode> {
         contained(|| {
             let local = self.repo.to_thread_local();
+            let ctx = Context::new(&local, &self.cache);
             let oid = self
                 .inner
-                .write_child(&local, &path, &content)
+                .write_child(&ctx, &path, &content)
                 .map_err(ht_err)?;
             Ok(oid_hex(oid))
         })
@@ -378,9 +383,10 @@ impl Tree {
     pub fn write_child_bytes(&mut self, path: String, content: Buffer) -> Result<String, ErrorCode> {
         contained(|| {
             let local = self.repo.to_thread_local();
+            let ctx = Context::new(&local, &self.cache);
             let oid = self
                 .inner
-                .write_child_bytes(&local, &path, content.as_ref())
+                .write_child_bytes(&ctx, &path, content.as_ref())
                 .map_err(ht_err)?;
             Ok(oid_hex(oid))
         })
@@ -401,11 +407,12 @@ impl Tree {
     ) -> Result<String, ErrorCode> {
         contained(|| {
             let local = self.repo.to_thread_local();
+            let ctx = Context::new(&local, &self.cache);
             let oid = parse_oid(&hash)?;
             let mode =
                 u16::try_from(mode).map_err(|_| invalid_arg(format!("invalid blob mode {mode:o}")))?;
             self.inner
-                .write_child_hash(&local, &path, oid, mode)
+                .write_child_hash(&ctx, &path, oid, mode)
                 .map_err(ht_err)?;
             Ok(oid_hex(oid))
         })
@@ -416,7 +423,8 @@ impl Tree {
     pub fn read_blob(&mut self, path: String) -> Result<Option<Buffer>, ErrorCode> {
         contained(|| {
             let local = self.repo.to_thread_local();
-            let bytes = self.inner.read_blob(&local, &path).map_err(ht_err)?;
+            let ctx = Context::new(&local, &self.cache);
+            let bytes = self.inner.read_blob(&ctx, &path).map_err(ht_err)?;
             Ok(bytes.map(Buffer::from))
         })
     }
@@ -427,9 +435,10 @@ impl Tree {
     pub fn get_child(&mut self, path: String) -> Result<Option<ChildInfo>, ErrorCode> {
         contained(|| {
             let local = self.repo.to_thread_local();
+            let ctx = Context::new(&local, &self.cache);
             let info = self
                 .inner
-                .get_child(&local, &path)
+                .get_child(&ctx, &path)
                 .map_err(ht_err)?
                 .map(|child| {
                     let (ty, hash, mode) = classify(child);
@@ -449,11 +458,12 @@ impl Tree {
     pub fn get_children(&mut self, path: String) -> Result<Vec<NamedChildInfo>, ErrorCode> {
         contained(|| {
             let local = self.repo.to_thread_local();
-            let subtree = match self.inner.get_subtree(&local, &path).map_err(ht_err)? {
+            let ctx = Context::new(&local, &self.cache);
+            let subtree = match self.inner.get_subtree(&ctx, &path).map_err(ht_err)? {
                 Some(t) => t,
                 None => return Ok(vec![]),
             };
-            subtree.ensure_children(&local).map_err(ht_err)?;
+            subtree.ensure_children(&ctx).map_err(ht_err)?;
             let mut out = Vec::new();
             for (name, child) in subtree.children.iter().flatten() {
                 let (ty, hash, mode) = classify(child);
@@ -475,9 +485,10 @@ impl Tree {
     pub fn get_blob_map(&mut self, path: Option<String>) -> Result<Vec<BlobEntry>, ErrorCode> {
         contained(|| {
             let local = self.repo.to_thread_local();
+            let ctx = Context::new(&local, &self.cache);
             let path = path.unwrap_or_else(|| ".".to_string());
-            let map = match self.inner.get_subtree(&local, &path).map_err(ht_err)? {
-                Some(subtree) => subtree.get_blob_map(&local).map_err(ht_err)?,
+            let map = match self.inner.get_subtree(&ctx, &path).map_err(ht_err)? {
+                Some(subtree) => subtree.get_blob_map(&ctx).map_err(ht_err)?,
                 None => return Ok(vec![]),
             };
             let out = map
@@ -497,7 +508,8 @@ impl Tree {
     pub fn delete_child_deep(&mut self, path: String) -> Result<bool, ErrorCode> {
         contained(|| {
             let local = self.repo.to_thread_local();
-            self.inner.delete_child_deep(&local, &path).map_err(ht_err)
+            let ctx = Context::new(&local, &self.cache);
+            self.inner.delete_child_deep(&ctx, &path).map_err(ht_err)
         })
     }
 
@@ -509,7 +521,8 @@ impl Tree {
     pub fn clear_children(&mut self, path: String) -> Result<(), ErrorCode> {
         contained(|| {
             let local = self.repo.to_thread_local();
-            self.inner.clear_children(&local, &path).map_err(ht_err)
+            let ctx = Context::new(&local, &self.cache);
+            self.inner.clear_children(&ctx, &path).map_err(ht_err)
         })
     }
 
@@ -520,6 +533,7 @@ impl Tree {
     pub fn merge(&mut self, other: &mut Tree, options: MergeOpts) -> Result<(), ErrorCode> {
         contained(|| {
             let local = self.repo.to_thread_local();
+            let ctx = Context::new(&local, &self.cache);
             let mode = match options.mode.as_str() {
                 "overlay" => holo_tree::MergeMode::Overlay,
                 "replace" => holo_tree::MergeMode::Replace,
@@ -533,7 +547,7 @@ impl Tree {
             let opts =
                 holo_tree::MergeOptions::new(options.files.as_deref(), mode).map_err(ht_err)?;
             self.inner
-                .merge(&local, &mut other.inner, &opts, ".")
+                .merge(&ctx, &mut other.inner, &opts, ".")
                 .map_err(ht_err)
         })
     }
@@ -543,7 +557,8 @@ impl Tree {
     pub fn write(&mut self) -> Result<String, ErrorCode> {
         contained(|| {
             let local = self.repo.to_thread_local();
-            let oid = self.inner.write(&local).map_err(ht_err)?;
+            let ctx = Context::new(&local, &self.cache);
+            let oid = self.inner.write(&ctx).map_err(ht_err)?;
             Ok(oid_hex(oid))
         })
     }

--- a/holo-tree-napi/src/lib.rs
+++ b/holo-tree-napi/src/lib.rs
@@ -17,11 +17,20 @@
 //!   hash handling — it stores/compares hashes as hex strings everywhere).
 //! - **Blob content** crosses as `Buffer` (binary-safe; records are TOML/text
 //!   but attachments are arbitrary bytes).
+//! - **Errors** cross as JS `Error`s whose `code` property carries the stable
+//!   code from `specs/api/errors.md` (`holo_tree::Error::code()`, plus the
+//!   binding-level `INVALID_ARGUMENT`/`GIT`/`PANIC`). Consumers match on
+//!   `err.code`, never on message prose.
+//! - **Panics never cross.** Every export is wrapped in [`contained`] (and
+//!   `#[napi(catch_unwind)]` as a backstop for marshalling code), so a Rust
+//!   panic surfaces as a catchable JS error with code `PANIC` instead of
+//!   unwinding through the `extern "C"` trampoline — which aborts the whole
+//!   host process (`fatal runtime error: failed to initiate panic`, gitsheets
+//!   finding #6).
 //!
 //! This binding is a deliberately thin pass-through. Per the spike's governing
 //! principle (see `plans/holo-tree-napi-spike.md` in gitsheets), rough edges in
-//! holo-tree's API are recorded as `Phase-C finding` notes and fixed upstream —
-//! not papered over with cleverness here.
+//! holo-tree's API are fixed upstream — not papered over with cleverness here.
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -30,21 +39,68 @@ use holo_tree::repo as ht_repo;
 use holo_tree::tree::empty_tree_id;
 use holo_tree::{MutableTree, ObjectId};
 
-// ── helpers ─────────────────────────────────────────────────────────────────
+// ── error plumbing ──────────────────────────────────────────────────────────
 
-/// Map a holo-tree error into a JS exception.
+/// Stable error code carried to JS as the thrown error's `code` property.
 ///
-/// Phase-C finding: `holo_tree::Error` collapses to a flat string here. gitsheets
-/// needs to translate substrate failures into its typed error classes, which a
-/// stringified `Display` makes lossy — candidate upstream improvement is a stable
-/// error code / structured variant that survives FFI.
-fn ht_err(e: holo_tree::Error) -> napi::Error {
-    napi::Error::from_reason(e.to_string())
+/// napi sets a thrown error's `code` from its status string; using the
+/// holo-tree code as the status is what lets consumers branch on cause
+/// (`err.code === 'REF_CONFLICT'`) instead of parsing prose — the fix for
+/// gitsheets finding #4. Codes are specced in `specs/api/errors.md`.
+#[derive(Debug, Clone, Copy)]
+pub struct ErrorCode(pub &'static str);
+
+impl AsRef<str> for ErrorCode {
+    fn as_ref(&self) -> &str {
+        self.0
+    }
 }
 
-fn parse_oid(hex: &str) -> napi::Result<ObjectId> {
-    ObjectId::from_hex(hex.as_bytes())
-        .map_err(|e| napi::Error::from_reason(format!("invalid object id '{hex}': {e}")))
+/// A `Result` whose error carries a stable holo-tree error code.
+type CodedResult<T> = std::result::Result<T, napi::Error<ErrorCode>>;
+
+/// Map a holo-tree error into a JS exception carrying its stable code.
+fn ht_err(e: holo_tree::Error) -> napi::Error<ErrorCode> {
+    napi::Error::new(ErrorCode(e.code()), e.to_string())
+}
+
+/// A binding-level caller error (bad hex id, unknown merge mode, …).
+fn invalid_arg(message: impl ToString) -> napi::Error<ErrorCode> {
+    napi::Error::new(ErrorCode("INVALID_ARGUMENT"), message.to_string())
+}
+
+/// A binding-level git failure that holo-tree doesn't classify further.
+fn git_err(message: impl ToString) -> napi::Error<ErrorCode> {
+    napi::Error::new(ErrorCode("GIT"), message.to_string())
+}
+
+/// Run `f`, converting any Rust panic into a catchable JS error with code
+/// `PANIC` instead of letting it unwind across the FFI boundary.
+///
+/// Per `specs/api/errors.md` § Panic policy: a panic that escapes the binding
+/// aborts the host process (Rust cannot unwind through the generated
+/// `extern "C"` trampoline), which is exactly how gitsheets finding #6 took
+/// down a whole Node process. `AssertUnwindSafe` is sound here because after a
+/// `PANIC` error the involved objects are contractually in an unspecified
+/// (memory-safe) state and must be discarded by the consumer.
+fn contained<T>(f: impl FnOnce() -> CodedResult<T>) -> CodedResult<T> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).unwrap_or_else(|payload| {
+        let message = if let Some(s) = payload.downcast_ref::<String>() {
+            s.clone()
+        } else if let Some(s) = payload.downcast_ref::<&str>() {
+            (*s).to_string()
+        } else {
+            "unknown panic payload".to_string()
+        };
+        Err(napi::Error::new(
+            ErrorCode("PANIC"),
+            format!("panic in holo-tree binding (this is a bug — please report): {message}"),
+        ))
+    })
+}
+
+fn parse_oid(hex: &str) -> CodedResult<ObjectId> {
+    ObjectId::from_hex(hex.as_bytes()).map_err(|e| invalid_arg(format!("invalid object id '{hex}': {e}")))
 }
 
 fn oid_hex(oid: ObjectId) -> String {
@@ -52,9 +108,18 @@ fn oid_hex(oid: ObjectId) -> String {
 }
 
 /// Git's well-known empty-tree hash (`4b825dc6…`).
-#[napi]
+#[napi(catch_unwind)]
 pub fn empty_tree_hash() -> String {
     oid_hex(empty_tree_id())
+}
+
+/// Internal self-test hook: deliberately panics inside the binding so the
+/// test suite can prove that a panic surfaces as a catchable JS error with
+/// code `PANIC` rather than aborting the host process (specs/api/errors.md
+/// § Panic policy). Never call this outside tests.
+#[napi(js_name = "__triggerPanicForTest", catch_unwind)]
+pub fn trigger_panic_for_test() -> Result<(), ErrorCode> {
+    contained(|| panic!("deliberate panic-containment self-test"))
 }
 
 /// A commit identity (author or committer). `timeSeconds`/`offsetMinutes` are
@@ -83,7 +148,7 @@ fn format_git_time(seconds: i64, offset_minutes: i32) -> String {
     format!("{seconds} {sign}{:02}{:02}", abs / 60, abs % 60)
 }
 
-fn to_gix_signature(sig: Signature) -> napi::Result<gix::actor::Signature> {
+fn to_gix_signature(sig: Signature) -> CodedResult<gix::actor::Signature> {
     let seconds = sig.time_seconds.unwrap_or_else(now_secs);
     let time = format_git_time(seconds, sig.offset_minutes.unwrap_or(0));
     gix::actor::SignatureRef {
@@ -92,7 +157,7 @@ fn to_gix_signature(sig: Signature) -> napi::Result<gix::actor::Signature> {
         time: &time,
     }
     .to_owned()
-    .map_err(|e| napi::Error::from_reason(format!("invalid signature time: {e}")))
+    .map_err(|e| invalid_arg(format!("invalid signature time: {e}")))
 }
 
 // ── Repo ────────────────────────────────────────────────────────────────────
@@ -111,30 +176,32 @@ pub struct Repo {
 impl Repo {
     /// Open a repository at `gitDir` (a `.git` directory, or any path gix can
     /// discover a repo from).
-    #[napi(factory)]
-    pub fn open(git_dir: String) -> napi::Result<Repo> {
-        let inner = gix::open(&git_dir)
-            .map_err(|e| {
-                napi::Error::from_reason(format!("failed to open repo at '{git_dir}': {e}"))
-            })?
-            .into_sync();
-        Ok(Repo { inner })
+    #[napi(factory, catch_unwind)]
+    pub fn open(git_dir: String) -> Result<Repo, ErrorCode> {
+        contained(|| {
+            let inner = gix::open(&git_dir)
+                .map_err(|e| git_err(format!("failed to open repo at '{git_dir}': {e}")))?
+                .into_sync();
+            Ok(Repo { inner })
+        })
     }
 
     /// Resolve a ref (branch, tag, or commit hash) to its tree and return a
     /// mutable, in-memory view of it.
-    #[napi]
-    pub fn create_tree_from_ref(&self, git_ref: String) -> napi::Result<Tree> {
-        let local = self.inner.to_thread_local();
-        let inner = ht_repo::create_tree_from_ref(&local, &git_ref).map_err(ht_err)?;
-        Ok(Tree {
-            repo: self.inner.clone(),
-            inner,
+    #[napi(catch_unwind)]
+    pub fn create_tree_from_ref(&self, git_ref: String) -> Result<Tree, ErrorCode> {
+        contained(|| {
+            let local = self.inner.to_thread_local();
+            let inner = ht_repo::create_tree_from_ref(&local, &git_ref).map_err(ht_err)?;
+            Ok(Tree {
+                repo: self.inner.clone(),
+                inner,
+            })
         })
     }
 
     /// Create a fresh empty, mutable in-memory tree rooted at this repo.
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn create_tree(&self) -> Tree {
         Tree {
             repo: self.inner.clone(),
@@ -145,7 +212,7 @@ impl Repo {
     /// Write a commit object pointing at `treeHash` with `parents`. `author`
     /// and `committer` are optional; each falls back to the repo's configured
     /// identity, then a "holo-tree" default. Returns the new commit hash.
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn commit_tree(
         &self,
         tree_hash: String,
@@ -153,18 +220,21 @@ impl Repo {
         message: String,
         author: Option<Signature>,
         committer: Option<Signature>,
-    ) -> napi::Result<String> {
-        let local = self.inner.to_thread_local();
-        let tree = parse_oid(&tree_hash)?;
-        let parent_oids = parents
-            .iter()
-            .map(|p| parse_oid(p))
-            .collect::<napi::Result<Vec<_>>>()?;
-        let author = author.map(to_gix_signature).transpose()?;
-        let committer = committer.map(to_gix_signature).transpose()?;
-        let commit = ht_repo::commit_tree(&local, tree, &parent_oids, &message, author, committer)
-            .map_err(ht_err)?;
-        Ok(oid_hex(commit))
+    ) -> Result<String, ErrorCode> {
+        contained(|| {
+            let local = self.inner.to_thread_local();
+            let tree = parse_oid(&tree_hash)?;
+            let parent_oids = parents
+                .iter()
+                .map(|p| parse_oid(p))
+                .collect::<CodedResult<Vec<_>>>()?;
+            let author = author.map(to_gix_signature).transpose()?;
+            let committer = committer.map(to_gix_signature).transpose()?;
+            let commit =
+                ht_repo::commit_tree(&local, tree, &parent_oids, &message, author, committer)
+                    .map_err(ht_err)?;
+            Ok(oid_hex(commit))
+        })
     }
 
     /// Point a ref at an object hash.
@@ -172,42 +242,49 @@ impl Repo {
     /// When `expectedOldHash` is provided this is a **compare-and-swap**: the
     /// update only succeeds if the ref currently resolves to exactly that hash,
     /// so a concurrent writer who moved the ref makes the swap fail rather than
-    /// silently clobbering their commit. Omit it to force the ref (the prior
-    /// unconditional behavior).
-    #[napi]
+    /// silently clobbering their commit. A lost swap throws with code
+    /// `REF_CONFLICT` — the matchable optimistic-concurrency signal. Omit
+    /// `expectedOldHash` to force the ref (the prior unconditional behavior).
+    #[napi(catch_unwind)]
     pub fn update_ref(
         &self,
         refname: String,
         hash: String,
         expected_old_hash: Option<String>,
-    ) -> napi::Result<()> {
-        let local = self.inner.to_thread_local();
-        let oid = parse_oid(&hash)?;
-        let expected = expected_old_hash.as_deref().map(parse_oid).transpose()?;
-        ht_repo::update_ref(&local, &refname, oid, expected).map_err(ht_err)
+    ) -> Result<(), ErrorCode> {
+        contained(|| {
+            let local = self.inner.to_thread_local();
+            let oid = parse_oid(&hash)?;
+            let expected = expected_old_hash.as_deref().map(parse_oid).transpose()?;
+            ht_repo::update_ref(&local, &refname, oid, expected).map_err(ht_err)
+        })
     }
 
     /// Resolve a ref / rev-spec (branch, tag, `HEAD`, hash, …) to its commit
     /// hash, peeling annotated tags. Returns `null` when the ref does not
     /// resolve — the natural "does this ref exist?" probe before a CAS
     /// `updateRef`.
-    #[napi]
-    pub fn resolve_ref(&self, git_ref: String) -> napi::Result<Option<String>> {
-        let local = self.inner.to_thread_local();
-        let oid = ht_repo::resolve_ref(&local, &git_ref).map_err(ht_err)?;
-        Ok(oid.map(oid_hex))
+    #[napi(catch_unwind)]
+    pub fn resolve_ref(&self, git_ref: String) -> Result<Option<String>, ErrorCode> {
+        contained(|| {
+            let local = self.inner.to_thread_local();
+            let oid = ht_repo::resolve_ref(&local, &git_ref).map_err(ht_err)?;
+            Ok(oid.map(oid_hex))
+        })
     }
 
     /// Hash raw bytes as a loose blob in the ODB and return its hash, without
     /// inserting it into any tree. Binary-safe.
-    #[napi]
-    pub fn write_blob(&self, content: Buffer) -> napi::Result<String> {
-        let local = self.inner.to_thread_local();
-        let oid = local
-            .write_blob(content.as_ref())
-            .map_err(|e| napi::Error::from_reason(e.to_string()))?
-            .detach();
-        Ok(oid_hex(oid))
+    #[napi(catch_unwind)]
+    pub fn write_blob(&self, content: Buffer) -> Result<String, ErrorCode> {
+        contained(|| {
+            let local = self.inner.to_thread_local();
+            let oid = local
+                .write_blob(content.as_ref())
+                .map_err(git_err)?
+                .detach();
+            Ok(oid_hex(oid))
+        })
     }
 }
 
@@ -271,13 +348,9 @@ fn classify(child: &holo_tree::Child) -> (&'static str, String, u32) {
 /// Holds its own clone of the repo handle so JS callers don't thread a repo
 /// argument through every call.
 ///
-/// Phase-C finding #1: holo-tree's `MutableTree` takes `&gix::Repository` on
-/// nearly every method and keeps a *thread-local* tree cache. We smooth the
-/// first half here (the handle lives on the `Tree`) but NOT the second: each
-/// call does `to_thread_local()`, and whether holo-tree's thread-local cache
-/// stays warm across libuv-dispatched calls is the open ergonomics question to
-/// resolve upstream (e.g. a repo-bound tree handle, or an explicit session/
-/// cache object the consumer owns).
+/// Phase-C finding #5 (thread-local tree cache) is addressed upstream by the
+/// consumer-owned cache/context redesign — see `specs/api/errors.md`
+/// § Thread-safety expectations.
 #[napi]
 pub struct Tree {
     repo: gix::ThreadSafeRepository,
@@ -288,25 +361,29 @@ pub struct Tree {
 impl Tree {
     /// Hash `content` (UTF-8 text) as a blob and insert it at `path`, creating
     /// intermediate trees as needed. Returns the blob hash.
-    #[napi]
-    pub fn write_child(&mut self, path: String, content: String) -> napi::Result<String> {
-        let local = self.repo.to_thread_local();
-        let oid = self
-            .inner
-            .write_child(&local, &path, &content)
-            .map_err(ht_err)?;
-        Ok(oid_hex(oid))
+    #[napi(catch_unwind)]
+    pub fn write_child(&mut self, path: String, content: String) -> Result<String, ErrorCode> {
+        contained(|| {
+            let local = self.repo.to_thread_local();
+            let oid = self
+                .inner
+                .write_child(&local, &path, &content)
+                .map_err(ht_err)?;
+            Ok(oid_hex(oid))
+        })
     }
 
     /// Hash raw bytes as a blob and insert at `path`. Binary-safe.
-    #[napi]
-    pub fn write_child_bytes(&mut self, path: String, content: Buffer) -> napi::Result<String> {
-        let local = self.repo.to_thread_local();
-        let oid = self
-            .inner
-            .write_child_bytes(&local, &path, content.as_ref())
-            .map_err(ht_err)?;
-        Ok(oid_hex(oid))
+    #[napi(catch_unwind)]
+    pub fn write_child_bytes(&mut self, path: String, content: Buffer) -> Result<String, ErrorCode> {
+        contained(|| {
+            let local = self.repo.to_thread_local();
+            let oid = self
+                .inner
+                .write_child_bytes(&local, &path, content.as_ref())
+                .map_err(ht_err)?;
+            Ok(oid_hex(oid))
+        })
     }
 
     /// Place an already-written blob at `path` by its `hash`, without reading its
@@ -315,142 +392,159 @@ impl Tree {
     /// lookup, so a large attachment isn't read back and re-hashed. `mode` is the
     /// git filemode: `0o100644` regular, `0o100755` executable, `0o120000`
     /// symlink. Returns the placed hash.
-    #[napi]
+    #[napi(catch_unwind)]
     pub fn write_child_hash(
         &mut self,
         path: String,
         hash: String,
         mode: u32,
-    ) -> napi::Result<String> {
-        let local = self.repo.to_thread_local();
-        let oid = parse_oid(&hash)?;
-        let mode = u16::try_from(mode)
-            .map_err(|_| napi::Error::from_reason(format!("invalid blob mode {mode:o}")))?;
-        self.inner
-            .write_child_hash(&local, &path, oid, mode)
-            .map_err(ht_err)?;
-        Ok(oid_hex(oid))
+    ) -> Result<String, ErrorCode> {
+        contained(|| {
+            let local = self.repo.to_thread_local();
+            let oid = parse_oid(&hash)?;
+            let mode =
+                u16::try_from(mode).map_err(|_| invalid_arg(format!("invalid blob mode {mode:o}")))?;
+            self.inner
+                .write_child_hash(&local, &path, oid, mode)
+                .map_err(ht_err)?;
+            Ok(oid_hex(oid))
+        })
     }
 
     /// Read a blob's bytes at `path`, or `null` if no blob exists there.
-    #[napi]
-    pub fn read_blob(&mut self, path: String) -> napi::Result<Option<Buffer>> {
-        let local = self.repo.to_thread_local();
-        let bytes = self.inner.read_blob(&local, &path).map_err(ht_err)?;
-        Ok(bytes.map(Buffer::from))
+    #[napi(catch_unwind)]
+    pub fn read_blob(&mut self, path: String) -> Result<Option<Buffer>, ErrorCode> {
+        contained(|| {
+            let local = self.repo.to_thread_local();
+            let bytes = self.inner.read_blob(&local, &path).map_err(ht_err)?;
+            Ok(bytes.map(Buffer::from))
+        })
     }
 
     /// Read-only: look up the child at a deep `path` and report its type,
     /// hash, and mode, or `null` if nothing exists there.
-    #[napi]
-    pub fn get_child(&mut self, path: String) -> napi::Result<Option<ChildInfo>> {
-        let local = self.repo.to_thread_local();
-        let info = self
-            .inner
-            .get_child(&local, &path)
-            .map_err(ht_err)?
-            .map(|child| {
-                let (ty, hash, mode) = classify(child);
-                ChildInfo {
-                    r#type: ty.to_string(),
-                    hash,
-                    mode,
-                }
-            });
-        Ok(info)
+    #[napi(catch_unwind)]
+    pub fn get_child(&mut self, path: String) -> Result<Option<ChildInfo>, ErrorCode> {
+        contained(|| {
+            let local = self.repo.to_thread_local();
+            let info = self
+                .inner
+                .get_child(&local, &path)
+                .map_err(ht_err)?
+                .map(|child| {
+                    let (ty, hash, mode) = classify(child);
+                    ChildInfo {
+                        r#type: ty.to_string(),
+                        hash,
+                        mode,
+                    }
+                });
+            Ok(info)
+        })
     }
 
     /// Read-only: list the direct children of the subtree at `path` (use `"."`
     /// for the root). Returns an empty array if `path` is missing or not a tree.
-    #[napi]
-    pub fn get_children(&mut self, path: String) -> napi::Result<Vec<NamedChildInfo>> {
-        let local = self.repo.to_thread_local();
-        let subtree = match self.inner.get_subtree(&local, &path).map_err(ht_err)? {
-            Some(t) => t,
-            None => return Ok(vec![]),
-        };
-        subtree.ensure_children(&local).map_err(ht_err)?;
-        let mut out = Vec::new();
-        for (name, child) in subtree.children.as_ref().unwrap().iter() {
-            let (ty, hash, mode) = classify(child);
-            out.push(NamedChildInfo {
-                name: name.clone(),
-                r#type: ty.to_string(),
-                hash,
-                mode,
-            });
-        }
-        Ok(out)
+    #[napi(catch_unwind)]
+    pub fn get_children(&mut self, path: String) -> Result<Vec<NamedChildInfo>, ErrorCode> {
+        contained(|| {
+            let local = self.repo.to_thread_local();
+            let subtree = match self.inner.get_subtree(&local, &path).map_err(ht_err)? {
+                Some(t) => t,
+                None => return Ok(vec![]),
+            };
+            subtree.ensure_children(&local).map_err(ht_err)?;
+            let mut out = Vec::new();
+            for (name, child) in subtree.children.iter().flatten() {
+                let (ty, hash, mode) = classify(child);
+                out.push(NamedChildInfo {
+                    name: name.clone(),
+                    r#type: ty.to_string(),
+                    hash,
+                    mode,
+                });
+            }
+            Ok(out)
+        })
     }
 
     /// Read-only: recursively collect every blob under the subtree at `path`
     /// (defaults to the whole tree) into a flat list. Each `path` is relative
     /// to the navigated subtree. Returns an empty array if `path` is missing.
-    #[napi]
-    pub fn get_blob_map(&mut self, path: Option<String>) -> napi::Result<Vec<BlobEntry>> {
-        let local = self.repo.to_thread_local();
-        let path = path.unwrap_or_else(|| ".".to_string());
-        let map = match self.inner.get_subtree(&local, &path).map_err(ht_err)? {
-            Some(subtree) => subtree.get_blob_map(&local).map_err(ht_err)?,
-            None => return Ok(vec![]),
-        };
-        let out = map
-            .into_iter()
-            .map(|(p, info)| BlobEntry {
-                path: p,
-                hash: oid_hex(info.hash),
-                mode: u32::from(info.mode),
-            })
-            .collect();
-        Ok(out)
+    #[napi(catch_unwind)]
+    pub fn get_blob_map(&mut self, path: Option<String>) -> Result<Vec<BlobEntry>, ErrorCode> {
+        contained(|| {
+            let local = self.repo.to_thread_local();
+            let path = path.unwrap_or_else(|| ".".to_string());
+            let map = match self.inner.get_subtree(&local, &path).map_err(ht_err)? {
+                Some(subtree) => subtree.get_blob_map(&local).map_err(ht_err)?,
+                None => return Ok(vec![]),
+            };
+            let out = map
+                .into_iter()
+                .map(|(p, info)| BlobEntry {
+                    path: p,
+                    hash: oid_hex(info.hash),
+                    mode: u32::from(info.mode),
+                })
+                .collect();
+            Ok(out)
+        })
     }
 
     /// Delete a child at a deep `path`. Returns whether it existed.
-    #[napi]
-    pub fn delete_child_deep(&mut self, path: String) -> napi::Result<bool> {
-        let local = self.repo.to_thread_local();
-        self.inner
-            .delete_child_deep(&local, &path)
-            .map_err(ht_err)
+    #[napi(catch_unwind)]
+    pub fn delete_child_deep(&mut self, path: String) -> Result<bool, ErrorCode> {
+        contained(|| {
+            let local = self.repo.to_thread_local();
+            self.inner.delete_child_deep(&local, &path).map_err(ht_err)
+        })
     }
 
     /// Clear all children under a deep `path` in O(1) — replace the subtree
     /// there with the empty tree (and dirty its ancestors) without loading the
     /// cleared subtree's contents. `path == "."` clears the whole tree. Used to
     /// wipe a directory before a full rewrite.
-    #[napi]
-    pub fn clear_children(&mut self, path: String) -> napi::Result<()> {
-        let local = self.repo.to_thread_local();
-        self.inner.clear_children(&local, &path).map_err(ht_err)
+    #[napi(catch_unwind)]
+    pub fn clear_children(&mut self, path: String) -> Result<(), ErrorCode> {
+        contained(|| {
+            let local = self.repo.to_thread_local();
+            self.inner.clear_children(&local, &path).map_err(ht_err)
+        })
     }
 
     /// Merge another tree into this one in place, per `options.mode`
     /// (`overlay`/`replace`/`underlay`) and optional `options.files` globs.
     /// `other` must be a *different* `Tree` instance.
-    #[napi]
-    pub fn merge(&mut self, other: &mut Tree, options: MergeOpts) -> napi::Result<()> {
-        let local = self.repo.to_thread_local();
-        let mode = match options.mode.as_str() {
-            "overlay" => holo_tree::MergeMode::Overlay,
-            "replace" => holo_tree::MergeMode::Replace,
-            "underlay" => holo_tree::MergeMode::Underlay,
-            other => {
-                return Err(napi::Error::from_reason(format!(
-                    "invalid merge mode '{other}', expected 'overlay', 'replace', or 'underlay'"
-                )))
-            }
-        };
-        let opts = holo_tree::MergeOptions::new(options.files.as_deref(), mode).map_err(ht_err)?;
-        self.inner
-            .merge(&local, &mut other.inner, &opts, ".")
-            .map_err(ht_err)
+    #[napi(catch_unwind)]
+    pub fn merge(&mut self, other: &mut Tree, options: MergeOpts) -> Result<(), ErrorCode> {
+        contained(|| {
+            let local = self.repo.to_thread_local();
+            let mode = match options.mode.as_str() {
+                "overlay" => holo_tree::MergeMode::Overlay,
+                "replace" => holo_tree::MergeMode::Replace,
+                "underlay" => holo_tree::MergeMode::Underlay,
+                other_mode => {
+                    return Err(invalid_arg(format!(
+                        "invalid merge mode '{other_mode}', expected 'overlay', 'replace', or 'underlay'"
+                    )))
+                }
+            };
+            let opts =
+                holo_tree::MergeOptions::new(options.files.as_deref(), mode).map_err(ht_err)?;
+            self.inner
+                .merge(&local, &mut other.inner, &opts, ".")
+                .map_err(ht_err)
+        })
     }
 
     /// Flush dirty subtrees to the ODB and return the resulting tree hash.
-    #[napi]
-    pub fn write(&mut self) -> napi::Result<String> {
-        let local = self.repo.to_thread_local();
-        let oid = self.inner.write(&local).map_err(ht_err)?;
-        Ok(oid_hex(oid))
+    #[napi(catch_unwind)]
+    pub fn write(&mut self) -> Result<String, ErrorCode> {
+        contained(|| {
+            let local = self.repo.to_thread_local();
+            let oid = self.inner.write(&local).map_err(ht_err)?;
+            Ok(oid_hex(oid))
+        })
     }
 }

--- a/holo-tree-napi/test/errors.mjs
+++ b/holo-tree-napi/test/errors.mjs
@@ -1,0 +1,145 @@
+// Error-contract tests for the holo-tree-napi binding (specs/api/errors.md).
+//
+// Every failure must surface as a catchable JS Error whose `code` property
+// carries a stable code from the contract — tests assert on codes, never on
+// message prose. The panic-containment test proves that a Rust panic becomes
+// a catchable `PANIC` error instead of aborting the host process (the
+// `fatal runtime error: failed to initiate panic` failure mode of gitsheets
+// finding #6).
+//
+// Requires the addon to be built first: `npm run build:debug` (or `build`).
+// Run with: `npm test` (node --test).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { Repo, __triggerPanicForTest } = require('../index.js');
+
+function git(cwd, ...args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function scratchRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'holo-tree-napi-errors-'));
+  git(dir, 'init', '-q');
+  git(dir, 'config', 'user.name', 'Test');
+  git(dir, 'config', 'user.email', 'test@example.com');
+  git(dir, 'commit', '--allow-empty', '-q', '-m', 'init');
+  git(dir, 'commit', '--allow-empty', '-q', '-m', 'second');
+  return dir;
+}
+
+/** Assert `fn` throws a real Error carrying exactly `code`. */
+function assertThrowsCode(fn, code) {
+  let caught;
+  try {
+    fn();
+  } catch (err) {
+    caught = err;
+  }
+  assert.ok(caught instanceof Error, `expected a thrown Error for ${code}`);
+  assert.equal(caught.code, code, `expected code ${code}, got ${caught.code}: ${caught.message}`);
+  return caught;
+}
+
+test('a Rust panic surfaces as a catchable PANIC error, not a process abort', () => {
+  const err = assertThrowsCode(() => __triggerPanicForTest(), 'PANIC');
+  assert.match(err.message, /panic/i);
+
+  // The whole point: the process survives and the binding keeps working.
+  const dir = scratchRepo();
+  try {
+    const repo = Repo.open(join(dir, '.git'));
+    const tree = repo.createTreeFromRef('HEAD');
+    tree.writeChild('post-panic.txt', 'still alive\n');
+    assert.match(tree.write(), /^[0-9a-f]{40}$/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('compare-and-swap updateRef loss surfaces as REF_CONFLICT', () => {
+  const dir = scratchRepo();
+  try {
+    const repo = Repo.open(join(dir, '.git'));
+    const head = repo.resolveRef('HEAD');
+    const parent = repo.resolveRef('HEAD~1');
+
+    // Ref is at `head`, but we claim it should still be at `parent`.
+    git(dir, 'update-ref', 'refs/heads/work', head);
+    assertThrowsCode(
+      () => repo.updateRef('refs/heads/work', parent, parent),
+      'REF_CONFLICT',
+    );
+    // CAS against a ref that doesn't exist at all is also a conflict.
+    assertThrowsCode(
+      () => repo.updateRef('refs/heads/ghost', head, parent),
+      'REF_CONFLICT',
+    );
+    // The ref was not clobbered by the failed swaps.
+    assert.equal(repo.resolveRef('refs/heads/work'), head);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('malformed caller input surfaces as INVALID_ARGUMENT', () => {
+  const dir = scratchRepo();
+  try {
+    const repo = Repo.open(join(dir, '.git'));
+
+    // Non-hex object id (binding-level marshalling).
+    assertThrowsCode(() => repo.updateRef('refs/heads/x', 'not-a-hash'), 'INVALID_ARGUMENT');
+
+    // Unknown merge mode (binding-level marshalling).
+    const a = repo.createTree();
+    const b = repo.createTree();
+    assertThrowsCode(() => a.merge(b, { mode: 'sideways' }), 'INVALID_ARGUMENT');
+
+    // Valid hash pointing at a non-blob object (crate-level classification).
+    const tree = repo.createTreeFromRef('HEAD');
+    tree.writeChild('dir/file.txt', 'x\n');
+    const treeHash = tree.write();
+    const reread = repo.createTreeFromRef(repo.commitTree(treeHash, [], 'tmp'));
+    const dirHash = reread.getChild('dir').hash;
+    assertThrowsCode(() => reread.writeChildHash('y', dirHash, 0o100644), 'INVALID_ARGUMENT');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a hash absent from the ODB surfaces as OBJECT_NOT_FOUND', () => {
+  const dir = scratchRepo();
+  try {
+    const repo = Repo.open(join(dir, '.git'));
+    const tree = repo.createTree();
+    assertThrowsCode(
+      () => tree.writeChildHash('x', '0123456789abcdef0123456789abcdef01234567', 0o100644),
+      'OBJECT_NOT_FOUND',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('writing through a blob path component surfaces as NOT_A_TREE', () => {
+  const dir = scratchRepo();
+  try {
+    const repo = Repo.open(join(dir, '.git'));
+    const tree = repo.createTree();
+    tree.writeChild('a/b', 'blob here\n');
+    assertThrowsCode(() => tree.writeChild('a/b/c', 'nope\n'), 'NOT_A_TREE');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('unopenable repository surfaces as GIT', () => {
+  assertThrowsCode(() => Repo.open('/nonexistent/definitely/not/a/repo'), 'GIT');
+});

--- a/holo-tree/src/error.rs
+++ b/holo-tree/src/error.rs
@@ -1,38 +1,89 @@
 //! Error types for holo-tree operations.
+//!
+//! The consumer-facing contract — the stable code table, its stability rules,
+//! the panic policy, and thread-safety expectations — is specced in
+//! `specs/api/errors.md`. Codes are the API; message text is not.
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    /// An underlying git operation failed in a way holo-tree does not
+    /// classify further. The residual class — failures may migrate from here
+    /// to more specific variants in minor releases.
     #[error("git: {0}")]
     Git(String),
 
+    /// An object id that was expected to exist in the ODB does not.
+    #[error("object not found: {id}")]
+    ObjectNotFound { id: String },
+
+    /// An object or path component expected to be a tree is some other kind.
     #[error("not a tree: {0}")]
     NotATree(String),
 
+    /// A fixed path could not be fully navigated where existence is required.
+    /// Operations specced to return "absent" signal it with `None`, not this.
     #[error("path component '{component}' not found in tree")]
     PathNotFound { component: String },
 
+    /// A glob pattern failed to compile.
     #[error("glob pattern error: {0}")]
     Glob(#[from] globset::Error),
 
+    /// A TOML blob is non-UTF-8 or failed to parse.
     #[error("TOML parse error in {path}: {message}")]
     Toml { path: String, message: String },
+
+    /// A caller-supplied value is malformed regardless of repository state:
+    /// a non-hex object id, an invalid blob filemode, an unknown merge mode,
+    /// an object of the wrong kind passed by hash, an unparseable signature.
+    #[error("invalid argument: {0}")]
+    InvalidArgument(String),
+
+    /// A compare-and-swap `update_ref` failed because the ref's current value
+    /// is not the expected one — it moved, disappeared, or unexpectedly
+    /// exists. The optimistic-concurrency signal.
+    #[error("ref conflict on {refname}: {message}")]
+    RefConflict { refname: String, message: String },
+
+    /// A holo-tree internal invariant was violated. Always a holo-tree bug —
+    /// exists so a violated invariant degrades to a catchable error instead
+    /// of a panic that would abort an embedding host process.
+    #[error("holo-tree internal invariant violated: {0}")]
+    Internal(String),
 }
 
 impl Error {
     /// A stable, machine-matchable code for this error variant.
     ///
     /// Unlike the human-readable `Display` string (which embeds variable
-    /// context), these codes are part of the API contract: downstream
-    /// consumers — notably the napi binding and gitsheets — match on them to
-    /// map substrate failures onto their own typed errors. Keep them stable.
+    /// context), these codes are part of the API contract (see
+    /// `specs/api/errors.md`): downstream consumers — notably the napi
+    /// binding and gitsheets — match on them to map substrate failures onto
+    /// their own typed errors. Codes are append-only; never rename or reuse.
     pub fn code(&self) -> &'static str {
         match self {
             Error::Git(_) => "GIT",
+            Error::ObjectNotFound { .. } => "OBJECT_NOT_FOUND",
             Error::NotATree(_) => "NOT_A_TREE",
             Error::PathNotFound { .. } => "PATH_NOT_FOUND",
             Error::Glob(_) => "GLOB",
             Error::Toml { .. } => "TOML",
+            Error::InvalidArgument(_) => "INVALID_ARGUMENT",
+            Error::RefConflict { .. } => "REF_CONFLICT",
+            Error::Internal(_) => "INTERNAL",
         }
+    }
+
+    /// Build an [`Error::Internal`] for a violated invariant.
+    ///
+    /// Loud in development (`debug_assert!`), a catchable `INTERNAL` error in
+    /// release — per the panic policy in `specs/api/errors.md`, a violated
+    /// invariant must degrade gracefully rather than panic across FFI.
+    #[track_caller]
+    pub(crate) fn internal(message: impl Into<String>) -> Self {
+        let message = message.into();
+        debug_assert!(false, "holo-tree internal invariant violated: {message}");
+        Error::Internal(message)
     }
 }
 
@@ -42,7 +93,12 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 impl From<gix::object::find::existing::Error> for Error {
     fn from(e: gix::object::find::existing::Error) -> Self {
-        Error::Git(e.to_string())
+        match e {
+            gix::object::find::existing::Error::NotFound { oid } => Error::ObjectNotFound {
+                id: oid.to_string(),
+            },
+            other => Error::Git(other.to_string()),
+        }
     }
 }
 
@@ -71,6 +127,10 @@ mod tests {
     #[test]
     fn codes_are_stable_per_variant() {
         assert_eq!(Error::Git("x".into()).code(), "GIT");
+        assert_eq!(
+            Error::ObjectNotFound { id: "x".into() }.code(),
+            "OBJECT_NOT_FOUND"
+        );
         assert_eq!(Error::NotATree("x".into()).code(), "NOT_A_TREE");
         assert_eq!(
             Error::PathNotFound {
@@ -87,5 +147,25 @@ mod tests {
             .code(),
             "TOML"
         );
+        assert_eq!(
+            Error::InvalidArgument("x".into()).code(),
+            "INVALID_ARGUMENT"
+        );
+        assert_eq!(
+            Error::RefConflict {
+                refname: "refs/heads/main".into(),
+                message: "moved".into()
+            }
+            .code(),
+            "REF_CONFLICT"
+        );
+        assert_eq!(Error::Internal("x".into()).code(), "INTERNAL");
+    }
+
+    #[test]
+    fn not_found_conversion_yields_object_not_found() {
+        let oid = gix::ObjectId::empty_tree(gix::hash::Kind::Sha1);
+        let e: Error = gix::object::find::existing::Error::NotFound { oid }.into();
+        assert_eq!(e.code(), "OBJECT_NOT_FOUND");
     }
 }

--- a/holo-tree/src/glob.rs
+++ b/holo-tree/src/glob.rs
@@ -27,7 +27,7 @@ impl GlobMatcher {
     /// absent, or the single pattern `**`.
     pub fn new(files: Option<&[String]>) -> Result<Self> {
         let patterns = match files {
-            Some(pats) if !(pats.len() == 1 && pats[0] == "**") => {
+            Some(pats) if !(pats.len() == 1 && pats.first().is_some_and(|p| p == "**")) => {
                 let mut entries = Vec::with_capacity(pats.len());
                 let mut has_neg = false;
 

--- a/holo-tree/src/lib.rs
+++ b/holo-tree/src/lib.rs
@@ -19,6 +19,20 @@
 //! - [`toml`] — Generic TOML-from-git-blob reader
 //! - [`repo`] — Ref resolution, commit creation, ref updates
 
+// Panic policy (specs/api/errors.md): no panicking constructs reachable from
+// public entry points — violated invariants degrade to Error::Internal.
+// Unit-test modules are exempt (tests may unwrap).
+#![cfg_attr(
+    not(test),
+    warn(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::panic,
+        clippy::unreachable
+    )
+)]
+
 pub mod error;
 pub mod glob;
 pub mod repo;

--- a/holo-tree/src/lib.rs
+++ b/holo-tree/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! # Modules
 //!
-//! - [`tree`] — MutableTree, Child, merge, write, cache
+//! - [`tree`] — MutableTree, Child, merge, write, TreeCache/Context
 //! - [`glob`] — Minimatch-compatible glob matching
 //! - [`toml`] — Generic TOML-from-git-blob reader
 //! - [`repo`] — Ref resolution, commit creation, ref updates
@@ -28,9 +28,10 @@ pub mod tree;
 // Re-export the most-used types at crate root
 pub use error::{Error, Result};
 pub use gix::ObjectId;
-pub use tree::{BlobInfo, Child, MergeMode, MergeOptions, MutableTree};
+pub use tree::{BlobInfo, Child, Context, MergeMode, MergeOptions, MutableTree, TreeCache};
 
-/// Reset all module-level caches and stats counters.
+/// Reset all stats counters. Tree caches are consumer-owned ([`TreeCache`]) —
+/// drop or clear them directly.
 pub fn reset() {
     tree::reset();
 }

--- a/holo-tree/src/repo.rs
+++ b/holo-tree/src/repo.rs
@@ -178,8 +178,11 @@ pub fn resolve_ref(repo: &gix::Repository, git_ref: &str) -> Result<Option<Objec
 /// only succeeds if the ref currently resolves to exactly that object
 /// (`PreviousValue::MustExistAndMatch`), so a concurrent writer that moved the
 /// ref out from under the caller makes the swap fail loudly rather than clobber
-/// their commit. When `None`, the ref is set unconditionally
-/// (`PreviousValue::Any`), matching the original force behavior.
+/// their commit. A lost swap surfaces as [`Error::RefConflict`] (code
+/// `REF_CONFLICT`) — the matchable optimistic-concurrency signal — whether the
+/// ref moved, disappeared, or unexpectedly exists. When `expected_old` is
+/// `None`, the ref is set unconditionally (`PreviousValue::Any`), matching the
+/// original force behavior.
 ///
 /// The reflog identity is derived from the **committer of the commit the ref now
 /// points at**, falling back to a stable `holo-tree` default for non-commit
@@ -241,8 +244,28 @@ pub fn update_ref(
     };
 
     repo.edit_references_as(Some(edit), Some(committer))
-        .map_err(|e| Error::Git(e.to_string()))?;
+        .map_err(|e| classify_ref_edit_error(&qualified, e))?;
     Ok(())
+}
+
+/// Map a gix ref-edit failure onto the error contract: expected-old-value
+/// mismatches become `REF_CONFLICT` (the optimistic-concurrency signal a CAS
+/// caller retries on); everything else stays in the residual `GIT` class.
+fn classify_ref_edit_error(refname: &str, e: gix::reference::edit::Error) -> Error {
+    use gix::refs::file::transaction::prepare::Error as PrepareError;
+
+    match &e {
+        gix::reference::edit::Error::FileTransactionPrepare(
+            prepare @ (PrepareError::ReferenceOutOfDate { .. }
+            | PrepareError::MustExist { .. }
+            | PrepareError::MustNotExist { .. }
+            | PrepareError::DeleteReferenceMustExist { .. }),
+        ) => Error::RefConflict {
+            refname: refname.to_string(),
+            message: prepare.to_string(),
+        },
+        _ => Error::Git(e.to_string()),
+    }
 }
 
 /// Map a bare branch name to a fully-qualified ref, matching `git update-ref`'s
@@ -260,20 +283,21 @@ fn qualify_ref(refname: &str) -> std::borrow::Cow<'_, str> {
 }
 
 /// Fallback signature when git config has no author/committer.
+///
+/// Built directly from parts — no parsing, nothing to `.expect()` — per the
+/// panic policy's "provably-infallible exceptions are eliminated, not excused"
+/// (`specs/api/errors.md`). A clock before the UNIX epoch degrades to 0 rather
+/// than panicking.
 fn default_signature() -> gix::actor::Signature {
-    gix::actor::SignatureRef {
+    let seconds = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    gix::actor::Signature {
         name: "holo-tree".into(),
         email: "holo-tree@localhost".into(),
-        time: &format!(
-            "{} +0000",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs()
-        ),
+        time: gix::date::Time { seconds, offset: 0 },
     }
-    .to_owned()
-    .expect("valid fallback signature")
 }
 
 #[cfg(test)]

--- a/holo-tree/src/toml.rs
+++ b/holo-tree/src/toml.rs
@@ -1,16 +1,16 @@
 //! Generic TOML-from-git-blob reader.
 
 use crate::error::{Error, Result};
-use crate::tree::MutableTree;
+use crate::tree::{Context, MutableTree};
 
 /// Read and parse a TOML file from a blob inside a git tree.
 /// Returns `None` if the blob doesn't exist at the given path.
 pub fn read_toml<T: serde::de::DeserializeOwned>(
-    repo: &gix::Repository,
+    ctx: &Context,
     tree: &mut MutableTree,
     path: &str,
 ) -> Result<Option<T>> {
-    let blob = tree.read_blob(repo, path)?;
+    let blob = tree.read_blob(ctx, path)?;
     match blob {
         None => Ok(None),
         Some(data) => {

--- a/holo-tree/src/tree.rs
+++ b/holo-tree/src/tree.rs
@@ -7,9 +7,11 @@
 //!
 //! Key design decisions:
 //! - `BTreeMap` for deterministic iteration matching git's canonical sort
-//! - Thread-local cache eliminates redundant ODB reads across recursive projections
+//! - Module-level cache eliminates redundant ODB reads across recursive projections
 //! - "Clone clean input" optimization skips loading trees that pass through unchanged
 //! - Dirty propagation in `get_or_create_subtree` marks all ancestors
+//! - No panicking constructs on public paths: violated invariants degrade to
+//!   `Error::Internal` per the panic policy in `specs/api/errors.md`
 
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
@@ -106,11 +108,9 @@ fn cache_write(hash: ObjectId, entries: Vec<CachedEntry>) {
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
-const EMPTY_TREE_HEX: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
-
-/// Git's well-known empty tree hash.
+/// Git's well-known empty tree hash (`4b825dc642cb6eb9a060e54bf8d69288fbee4904`).
 pub fn empty_tree_id() -> ObjectId {
-    ObjectId::from_hex(EMPTY_TREE_HEX.as_bytes()).unwrap()
+    ObjectId::empty_tree(gix::hash::Kind::Sha1)
 }
 
 // ── Entry classification ───────────────────────────────────────────────────
@@ -171,11 +171,11 @@ pub enum Child {
     Commit { hash: ObjectId },
 }
 
-fn child_hash(child: &Child) -> Option<ObjectId> {
+fn child_hash(child: &Child) -> ObjectId {
     match child {
-        Child::Tree(t) => Some(t.hash),
-        Child::Blob { hash, .. } => Some(*hash),
-        Child::Commit { hash } => Some(*hash),
+        Child::Tree(t) => t.hash,
+        Child::Blob { hash, .. } => *hash,
+        Child::Commit { hash } => *hash,
     }
 }
 
@@ -232,6 +232,26 @@ impl MutableTree {
         }
     }
 
+    // ── Loaded-children accessors ────────────────────────────────────────
+    //
+    // Every mutation/read below runs `ensure_children` before touching
+    // `self.children`, so `None` here is a violated internal invariant.
+    // Per the panic policy (specs/api/errors.md) that must degrade to a
+    // catchable `INTERNAL` error, not a panic that aborts an embedding
+    // host across FFI — the exact failure mode of gitsheets finding #1/#6.
+
+    fn children_ref(&self) -> Result<&BTreeMap<String, Child>> {
+        self.children
+            .as_ref()
+            .ok_or_else(|| Error::internal("tree children accessed before being loaded"))
+    }
+
+    fn children_mut(&mut self) -> Result<&mut BTreeMap<String, Child>> {
+        self.children
+            .as_mut()
+            .ok_or_else(|| Error::internal("tree children accessed before being loaded"))
+    }
+
     // ── Child loading ────────────────────────────────────────────────────
 
     /// Load children from the git ODB if not yet loaded.
@@ -252,7 +272,7 @@ impl MutableTree {
                 let obj = repo.find_object(self.hash)?;
                 let tree = obj
                     .try_into_tree()
-                    .map_err(|_| Error::Git(format!("{} is not a tree", self.hash)))?;
+                    .map_err(|_| Error::NotATree(self.hash.to_string()))?;
 
                 TREES_READ.fetch_add(1, Ordering::Relaxed);
 
@@ -314,7 +334,7 @@ impl MutableTree {
 
         for part in parts {
             cur.ensure_children(repo)?;
-            match cur.children.as_mut().unwrap().get_mut(part) {
+            match cur.children_mut()?.get_mut(part) {
                 Some(Child::Tree(ref mut t)) => cur = t,
                 _ => return Ok(None),
             }
@@ -341,8 +361,8 @@ impl MutableTree {
             // Destination is the root itself. Mark dirty and load its children
             // so a mutating caller (e.g. write_child_bytes for a repo-root file
             // like "a.toml", whose dir is ".") can insert alongside existing
-            // entries — rather than panic on `children.as_mut().unwrap()` when
-            // the root was lazily loaded from a ref. Same postcondition as the
+            // entries — rather than fail on unloaded children when the root
+            // was lazily loaded from a ref. Same postcondition as the
             // deep-path return below.
             self.dirty = true;
             self.ensure_children(repo)?;
@@ -354,9 +374,7 @@ impl MutableTree {
         for part in path.split('/') {
             cur.ensure_children(repo)?;
             let child = cur
-                .children
-                .as_mut()
-                .unwrap()
+                .children_mut()?
                 .entry(part.to_string())
                 .or_insert_with(|| {
                     let mut t = MutableTree::empty();
@@ -409,7 +427,7 @@ impl MutableTree {
         };
 
         tree.ensure_children(repo)?;
-        match tree.children.as_ref().unwrap().get(file) {
+        match tree.children_ref()?.get(file) {
             Some(Child::Blob { hash, .. }) => {
                 BLOBS_READ.fetch_add(1, Ordering::Relaxed);
                 let obj = repo.find_object(*hash)?;
@@ -426,7 +444,7 @@ impl MutableTree {
         name: &str,
     ) -> Result<bool> {
         self.ensure_children(repo)?;
-        if self.children.as_mut().unwrap().remove(name).is_some() {
+        if self.children_mut()?.remove(name).is_some() {
             self.dirty = true;
             Ok(true)
         } else {
@@ -458,7 +476,7 @@ impl MutableTree {
         };
 
         tree.ensure_children(repo)?;
-        Ok(tree.children.as_ref().unwrap().get(name))
+        Ok(tree.children_ref()?.get(name))
     }
 
     /// Write string content as a blob at a deep path, creating intermediate
@@ -496,7 +514,7 @@ impl MutableTree {
         };
 
         let tree = self.get_or_create_subtree(repo, dir)?;
-        tree.children.as_mut().unwrap().insert(
+        tree.children_mut()?.insert(
             name.to_string(),
             Child::Blob {
                 mode: 0o100644,
@@ -525,9 +543,10 @@ impl MutableTree {
     ///
     /// # Errors
     ///
-    /// Returns an error if `hash` does not exist in the ODB or is not a blob, if
-    /// `mode` is not a valid blob mode, or if an intermediate path component
-    /// exists but is not a tree (same footgun guard as
+    /// Returns `OBJECT_NOT_FOUND` if `hash` does not exist in the ODB,
+    /// `INVALID_ARGUMENT` if it is not a blob or `mode` is not a valid blob
+    /// mode, and `NOT_A_TREE` if an intermediate path component exists but is
+    /// not a tree (same footgun guard as
     /// [`write_child_bytes`](Self::write_child_bytes)).
     pub fn write_child_hash(
         &mut self,
@@ -537,7 +556,7 @@ impl MutableTree {
         mode: u16,
     ) -> Result<()> {
         if !matches!(mode, 0o100644 | 0o100755 | 0o120000) {
-            return Err(Error::Git(format!(
+            return Err(Error::InvalidArgument(format!(
                 "invalid blob mode {mode:o} for {path}: expected 100644, 100755, or 120000"
             )));
         }
@@ -545,11 +564,9 @@ impl MutableTree {
         // Validate existence + kind from the object header, without decoding the
         // blob — that byte-read is exactly what a place-by-hash caller wants to
         // skip.
-        let header = repo
-            .find_header(hash)
-            .map_err(|e| Error::Git(e.to_string()))?;
+        let header = repo.find_header(hash)?;
         if header.kind() != gix::object::Kind::Blob {
-            return Err(Error::Git(format!(
+            return Err(Error::InvalidArgument(format!(
                 "object {hash} is not a blob (found {:?})",
                 header.kind()
             )));
@@ -561,9 +578,7 @@ impl MutableTree {
         };
 
         let tree = self.get_or_create_subtree(repo, dir)?;
-        tree.children
-            .as_mut()
-            .unwrap()
+        tree.children_mut()?
             .insert(name.to_string(), Child::Blob { mode, hash });
         tree.dirty = true;
         Ok(())
@@ -594,7 +609,7 @@ impl MutableTree {
                 continue;
             }
             cur.ensure_children(repo)?;
-            match cur.children.as_mut().unwrap().get_mut(part) {
+            match cur.children_mut()?.get_mut(part) {
                 Some(Child::Tree(t)) => {
                     t.dirty = true;
                     cur = t;
@@ -635,9 +650,7 @@ impl MutableTree {
         let mut empty = MutableTree::empty();
         empty.dirty = true;
         parent
-            .children
-            .as_mut()
-            .unwrap()
+            .children_mut()?
             .insert(name.to_string(), Child::Tree(empty));
         parent.dirty = true;
         Ok(())
@@ -661,7 +674,7 @@ impl MutableTree {
     ) -> Result<()> {
         self.ensure_children(repo)?;
 
-        let keys: Vec<String> = self.children.as_ref().unwrap().keys().cloned().collect();
+        let keys: Vec<String> = self.children_ref()?.keys().cloned().collect();
         for name in keys {
             let path = if prefix.is_empty() {
                 name.clone()
@@ -669,7 +682,7 @@ impl MutableTree {
                 format!("{prefix}/{name}")
             };
 
-            match self.children.as_mut().unwrap().get_mut(&name) {
+            match self.children_mut()?.get_mut(&name) {
                 Some(Child::Tree(ref mut t)) => t.collect_blobs(repo, &path, out)?,
                 Some(Child::Blob { hash, mode }) => {
                     out.insert(path, BlobInfo { hash: *hash, mode: *mode });
@@ -697,22 +710,16 @@ impl MutableTree {
         self.ensure_children(repo)?;
         input.ensure_children(repo)?;
 
-        let input_names: Vec<String> = input
-            .children
-            .as_ref()
-            .unwrap()
-            .keys()
-            .cloned()
-            .collect();
+        let input_names: Vec<String> = input.children_ref()?.keys().cloned().collect();
 
         for child_name in &input_names {
-            let input_child = match input.children.as_ref().unwrap().get(child_name) {
+            let input_child = match input.children_ref()?.get(child_name) {
                 Some(c) => c,
                 None => continue,
             };
 
             // Skip identical clean subtrees
-            if let Some(base_child) = self.children.as_ref().unwrap().get(child_name) {
+            if let Some(base_child) = self.children_ref()?.get(child_name) {
                 if child_hash(base_child) == child_hash(input_child)
                     && !child_is_dirty(base_child)
                     && !child_is_dirty(input_child)
@@ -755,16 +762,12 @@ impl MutableTree {
             // ── Blob / commit ────────────────────────────────────────────
             if !is_tree {
                 let should_write = match opts.mode {
-                    MergeMode::Underlay => {
-                        !self.children.as_ref().unwrap().contains_key(child_name)
-                    }
+                    MergeMode::Underlay => !self.children_ref()?.contains_key(child_name),
                     MergeMode::Overlay | MergeMode::Replace => true,
                 };
                 if should_write {
-                    self.children
-                        .as_mut()
-                        .unwrap()
-                        .insert(child_name.clone(), clone_child(input_child));
+                    let cloned = clone_child(input_child);
+                    self.children_mut()?.insert(child_name.clone(), cloned);
                     self.dirty = true;
                 }
                 continue;
@@ -772,7 +775,7 @@ impl MutableTree {
 
             // ── Tree ─────────────────────────────────────────────────────
             let has_base_tree = matches!(
-                self.children.as_ref().unwrap().get(child_name),
+                self.children_ref()?.get(child_name),
                 Some(Child::Tree(_))
             );
 
@@ -782,64 +785,79 @@ impl MutableTree {
                 if pending_child_match {
                     // (a) Glob undecided: merge into temp, keep only if dirty
                     let mut temp = MutableTree::empty();
-                    let it = match input.children.as_mut().unwrap().get_mut(child_name)
-                    {
+                    let it = match input.children_mut()?.get_mut(child_name) {
                         Some(Child::Tree(t)) => t,
-                        _ => unreachable!(),
+                        _ => {
+                            return Err(Error::internal(
+                                "merge: input tree child vanished or changed kind",
+                            ))
+                        }
                     };
                     temp.merge(repo, it, opts, &child_path)?;
                     if temp.dirty {
-                        self.children
-                            .as_mut()
-                            .unwrap()
+                        self.children_mut()?
                             .insert(child_name.clone(), Child::Tree(temp));
                         self.dirty = true;
                     }
                     continue;
                 }
 
-                let input_ref =
-                    input.children.as_ref().unwrap().get(child_name).unwrap();
+                let input_ref = input.children_ref()?.get(child_name).ok_or_else(|| {
+                    Error::internal("merge: input tree child vanished during merge")
+                })?;
                 if !child_is_dirty(input_ref) {
                     // (b) Input child is clean — clone by hash, skip merge
-                    let h = child_hash(input_ref).unwrap();
-                    self.children
-                        .as_mut()
-                        .unwrap()
+                    let h = child_hash(input_ref);
+                    self.children_mut()?
                         .insert(child_name.clone(), Child::Tree(MutableTree::new(h)));
                     self.dirty = true;
                     continue;
                 }
 
                 // (c) Input child is dirty — merge into new empty tree
-                let it = match input.children.as_mut().unwrap().get_mut(child_name) {
+                let it = match input.children_mut()?.get_mut(child_name) {
                     Some(Child::Tree(t)) => t,
-                    _ => unreachable!(),
+                    _ => {
+                        return Err(Error::internal(
+                            "merge: input tree child vanished or changed kind",
+                        ))
+                    }
                 };
                 let mut new_base = MutableTree::empty();
                 new_base.merge(repo, it, opts, &child_path)?;
                 if new_base.dirty {
                     self.dirty = true;
                 }
-                self.children
-                    .as_mut()
-                    .unwrap()
+                self.children_mut()?
                     .insert(child_name.clone(), Child::Tree(new_base));
                 continue;
             }
 
             // Both sides are trees — recursive merge
-            let mut input_tree =
-                match input.children.as_mut().unwrap().remove(child_name) {
-                    Some(Child::Tree(t)) => t,
-                    _ => unreachable!(),
-                };
+            let mut input_tree = match input.children_mut()?.remove(child_name) {
+                Some(Child::Tree(t)) => t,
+                Some(other) => {
+                    // Put it back before erroring; kind can't change mid-merge.
+                    input.children_mut()?.insert(child_name.clone(), other);
+                    return Err(Error::internal(
+                        "merge: input tree child changed kind during merge",
+                    ));
+                }
+                None => {
+                    return Err(Error::internal(
+                        "merge: input tree child vanished during merge",
+                    ))
+                }
+            };
 
-            let base_tree =
-                match self.children.as_mut().unwrap().get_mut(child_name) {
-                    Some(Child::Tree(ref mut t)) => t,
-                    _ => unreachable!(),
-                };
+            let base_tree = match self.children_mut()?.get_mut(child_name) {
+                Some(Child::Tree(ref mut t)) => t,
+                _ => {
+                    return Err(Error::internal(
+                        "merge: base tree child vanished or changed kind during merge",
+                    ))
+                }
+            };
 
             base_tree.merge(repo, &mut input_tree, opts, &child_path)?;
             if base_tree.dirty {
@@ -848,23 +866,25 @@ impl MutableTree {
 
             // Restore input tree (we borrowed it temporarily)
             input
-                .children
-                .as_mut()
-                .unwrap()
+                .children_mut()?
                 .insert(child_name.clone(), Child::Tree(input_tree));
         }
 
         // Replace mode: remove target children absent from input
         if opts.mode == MergeMode::Replace {
-            let input_children = input.children.as_ref().unwrap();
-            let self_children = self.children.as_mut().unwrap();
-            let to_remove: Vec<String> = self_children
-                .keys()
-                .filter(|k| !input_children.contains_key(*k))
-                .cloned()
-                .collect();
-            for key in to_remove {
-                self_children.remove(&key);
+            let to_remove: Vec<String> = {
+                let input_children = input.children_ref()?;
+                self.children_ref()?
+                    .keys()
+                    .filter(|k| !input_children.contains_key(*k))
+                    .cloned()
+                    .collect()
+            };
+            if !to_remove.is_empty() {
+                let self_children = self.children_mut()?;
+                for key in &to_remove {
+                    self_children.remove(key);
+                }
                 self.dirty = true;
             }
         }
@@ -886,7 +906,7 @@ impl MutableTree {
             self.ensure_children(repo)?;
         }
 
-        let children = self.children.as_mut().unwrap();
+        let children = self.children_mut()?;
 
         // Recurse into dirty child trees
         let names: Vec<String> = children.keys().cloned().collect();
@@ -904,17 +924,22 @@ impl MutableTree {
             match child {
                 Child::Tree(t) if t.hash == empty_tree_id() => continue,
                 Child::Tree(t) => entries.push(GixEntry {
-                    mode: EntryMode::try_from(0o040000u32).unwrap(),
+                    mode: EntryKind::Tree.into(),
                     filename: name.as_str().into(),
                     oid: t.hash,
                 }),
                 Child::Blob { mode, hash } => entries.push(GixEntry {
-                    mode: EntryMode::try_from(*mode as u32).unwrap(),
+                    // Modes here were either loaded from a valid tree object or
+                    // validated on the way in (write_child_hash); a bad one is
+                    // an internal invariant violation, not a caller error.
+                    mode: EntryMode::try_from(u32::from(*mode)).map_err(|_| {
+                        Error::internal(format!("invalid blob mode {mode:o} for '{name}'"))
+                    })?,
                     filename: name.as_str().into(),
                     oid: *hash,
                 }),
                 Child::Commit { hash } => entries.push(GixEntry {
-                    mode: EntryMode::try_from(0o160000u32).unwrap(),
+                    mode: EntryKind::Commit.into(),
                     filename: name.as_str().into(),
                     oid: *hash,
                 }),

--- a/holo-tree/src/tree.rs
+++ b/holo-tree/src/tree.rs
@@ -7,7 +7,9 @@
 //!
 //! Key design decisions:
 //! - `BTreeMap` for deterministic iteration matching git's canonical sort
-//! - Module-level cache eliminates redundant ODB reads across recursive projections
+//! - A consumer-owned [`TreeCache`] (lent to operations via [`Context`])
+//!   eliminates redundant ODB reads across recursive projections without any
+//!   thread-implicit state (specs/api/errors.md § Thread-safety expectations)
 //! - "Clone clean input" optimization skips loading trees that pass through unchanged
 //! - Dirty propagation in `get_or_create_subtree` marks all ancestors
 //! - No panicking constructs on public paths: violated invariants degrade to
@@ -57,7 +59,10 @@ pub fn stats() -> Stats {
     }
 }
 
-/// Reset all stats counters and the tree cache.
+/// Reset all stats counters.
+///
+/// The tree cache is consumer-owned ([`TreeCache`]) — drop or
+/// [`TreeCache::clear`] it instead.
 pub fn reset() {
     TREES_READ.store(0, Ordering::Relaxed);
     TREES_WRITTEN.store(0, Ordering::Relaxed);
@@ -65,7 +70,6 @@ pub fn reset() {
     CACHE_HITS.store(0, Ordering::Relaxed);
     CACHE_MISSES.store(0, Ordering::Relaxed);
     BLOBS_READ.store(0, Ordering::Relaxed);
-    TREE_CACHE.with(|c| c.borrow_mut().clear());
 }
 
 // ── Tree cache ─────────────────────────────────────────────────────────────
@@ -79,31 +83,91 @@ struct CachedEntry {
     hash: ObjectId,
 }
 
-thread_local! {
-    static TREE_CACHE: RefCell<HashMap<ObjectId, Vec<CachedEntry>>> =
-        RefCell::new(HashMap::new());
+/// Consumer-owned cache of parsed tree entries, keyed by tree `ObjectId`.
+///
+/// Replaces the former `thread_local!` cache so that no correctness (or
+/// warmth) depends on which thread a call lands on — the failure mode of
+/// gitsheets finding #5. Because entries are keyed by content-addressed
+/// object id, one cache is safe to reuse across trees, operations, and even
+/// repositories (see specs/api/errors.md § Thread-safety expectations).
+///
+/// `Send` but not `Sync`: move it between threads whole; one logical
+/// operation uses it at a time.
+#[derive(Default)]
+pub struct TreeCache {
+    entries: RefCell<HashMap<ObjectId, Vec<CachedEntry>>>,
 }
 
-fn cache_read(hash: &ObjectId) -> Option<Vec<CachedEntry>> {
-    TREE_CACHE.with(|c| {
-        let cache = c.borrow();
-        match cache.get(hash) {
+impl TreeCache {
+    /// Create an empty cache.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of cached trees.
+    pub fn len(&self) -> usize {
+        self.entries.try_borrow().map(|m| m.len()).unwrap_or(0)
+    }
+
+    /// Whether the cache holds no trees.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Drop all cached entries.
+    pub fn clear(&self) {
+        if let Ok(mut m) = self.entries.try_borrow_mut() {
+            m.clear();
+        }
+    }
+
+    // `try_borrow` throughout: a (theoretically) re-entrant borrow degrades
+    // to a cache miss / skipped insert instead of a RefCell panic, per the
+    // panic policy in specs/api/errors.md.
+
+    fn read(&self, hash: &ObjectId) -> Option<Vec<CachedEntry>> {
+        let hit = self
+            .entries
+            .try_borrow()
+            .ok()
+            .and_then(|m| m.get(hash).cloned());
+        match hit {
             Some(entries) => {
                 CACHE_HITS.fetch_add(1, Ordering::Relaxed);
-                Some(entries.clone())
+                Some(entries)
             }
             None => {
                 CACHE_MISSES.fetch_add(1, Ordering::Relaxed);
                 None
             }
         }
-    })
+    }
+
+    fn write(&self, hash: ObjectId, entries: Vec<CachedEntry>) {
+        if let Ok(mut m) = self.entries.try_borrow_mut() {
+            m.insert(hash, entries);
+        }
+    }
 }
 
-fn cache_write(hash: ObjectId, entries: Vec<CachedEntry>) {
-    TREE_CACHE.with(|c| {
-        c.borrow_mut().insert(hash, entries);
-    });
+/// A per-operation view binding a repository handle to a consumer-owned
+/// [`TreeCache`]. All `MutableTree` operations take a `&Context` — the repo
+/// and the cache travel together explicitly instead of one being threaded
+/// through every call and the other living in thread-implicit state.
+///
+/// Cheap to construct; hosts that re-derive a per-thread `gix::Repository`
+/// (e.g. via `ThreadSafeRepository::to_thread_local`) build a fresh `Context`
+/// around the long-lived cache per call.
+pub struct Context<'a> {
+    pub repo: &'a gix::Repository,
+    cache: &'a TreeCache,
+}
+
+impl<'a> Context<'a> {
+    /// Bind `repo` and `cache` for a run of tree operations.
+    pub fn new(repo: &'a gix::Repository, cache: &'a TreeCache) -> Self {
+        Context { repo, cache }
+    }
 }
 
 // ── Constants ──────────────────────────────────────────────────────────────
@@ -256,7 +320,7 @@ impl MutableTree {
 
     /// Load children from the git ODB if not yet loaded.
     /// Checks the module-level cache first.
-    pub fn ensure_children(&mut self, repo: &gix::Repository) -> Result<()> {
+    pub fn ensure_children(&mut self, ctx: &Context) -> Result<()> {
         if self.children.is_some() {
             return Ok(());
         }
@@ -266,10 +330,10 @@ impl MutableTree {
             return Ok(());
         }
 
-        let entries = match cache_read(&self.hash) {
+        let entries = match ctx.cache.read(&self.hash) {
             Some(cached) => cached,
             None => {
-                let obj = repo.find_object(self.hash)?;
+                let obj = ctx.repo.find_object(self.hash)?;
                 let tree = obj
                     .try_into_tree()
                     .map_err(|_| Error::NotATree(self.hash.to_string()))?;
@@ -295,7 +359,7 @@ impl MutableTree {
                     })
                     .collect::<Result<_>>()?;
 
-                cache_write(self.hash, entries.clone());
+                ctx.cache.write(self.hash, entries.clone());
                 entries
             }
         };
@@ -322,7 +386,7 @@ impl MutableTree {
     /// any component is missing or not a tree.
     pub fn get_subtree(
         &mut self,
-        repo: &gix::Repository,
+        ctx: &Context,
         path: &str,
     ) -> Result<Option<&mut MutableTree>> {
         if path == "." || path.is_empty() {
@@ -333,7 +397,7 @@ impl MutableTree {
         let mut cur = self;
 
         for part in parts {
-            cur.ensure_children(repo)?;
+            cur.ensure_children(ctx)?;
             match cur.children_mut()?.get_mut(part) {
                 Some(Child::Tree(ref mut t)) => cur = t,
                 _ => return Ok(None),
@@ -354,7 +418,7 @@ impl MutableTree {
     /// in `write()`.)
     pub fn get_or_create_subtree(
         &mut self,
-        repo: &gix::Repository,
+        ctx: &Context,
         path: &str,
     ) -> Result<&mut MutableTree> {
         if path == "." || path.is_empty() {
@@ -365,14 +429,14 @@ impl MutableTree {
             // was lazily loaded from a ref. Same postcondition as the
             // deep-path return below.
             self.dirty = true;
-            self.ensure_children(repo)?;
+            self.ensure_children(ctx)?;
             return Ok(self);
         }
 
         self.dirty = true;
         let mut cur = self;
         for part in path.split('/') {
-            cur.ensure_children(repo)?;
+            cur.ensure_children(ctx)?;
             let child = cur
                 .children_mut()?
                 .entry(part.to_string())
@@ -402,14 +466,14 @@ impl MutableTree {
         // `write_child_bytes`) rely on `children` being `Some` — and loading
         // here is also what preserves existing siblings when writing into an
         // existing directory.
-        cur.ensure_children(repo)?;
+        cur.ensure_children(ctx)?;
         Ok(cur)
     }
 
     /// Read a blob's raw bytes by navigating a slash-separated path.
     pub fn read_blob(
         &mut self,
-        repo: &gix::Repository,
+        ctx: &Context,
         path: &str,
     ) -> Result<Option<Vec<u8>>> {
         let (dir, file) = match path.rsplit_once('/') {
@@ -420,17 +484,17 @@ impl MutableTree {
         let tree = if dir == "." {
             self
         } else {
-            match self.get_subtree(repo, dir)? {
+            match self.get_subtree(ctx, dir)? {
                 Some(t) => t,
                 None => return Ok(None),
             }
         };
 
-        tree.ensure_children(repo)?;
+        tree.ensure_children(ctx)?;
         match tree.children_ref()?.get(file) {
             Some(Child::Blob { hash, .. }) => {
                 BLOBS_READ.fetch_add(1, Ordering::Relaxed);
-                let obj = repo.find_object(*hash)?;
+                let obj = ctx.repo.find_object(*hash)?;
                 Ok(Some(obj.data.to_vec()))
             }
             _ => Ok(None),
@@ -440,10 +504,10 @@ impl MutableTree {
     /// Remove a direct child by name. Returns whether it existed.
     pub fn delete_child(
         &mut self,
-        repo: &gix::Repository,
+        ctx: &Context,
         name: &str,
     ) -> Result<bool> {
-        self.ensure_children(repo)?;
+        self.ensure_children(ctx)?;
         if self.children_mut()?.remove(name).is_some() {
             self.dirty = true;
             Ok(true)
@@ -458,7 +522,7 @@ impl MutableTree {
     /// Returns `None` if any path component doesn't exist.
     pub fn get_child(
         &mut self,
-        repo: &gix::Repository,
+        ctx: &Context,
         path: &str,
     ) -> Result<Option<&Child>> {
         let (dir, name) = match path.rsplit_once('/') {
@@ -469,13 +533,13 @@ impl MutableTree {
         let tree = if dir == "." {
             self
         } else {
-            match self.get_subtree(repo, dir)? {
+            match self.get_subtree(ctx, dir)? {
                 Some(t) => t,
                 None => return Ok(None),
             }
         };
 
-        tree.ensure_children(repo)?;
+        tree.ensure_children(ctx)?;
         Ok(tree.children_ref()?.get(name))
     }
 
@@ -489,21 +553,22 @@ impl MutableTree {
     /// intentional — silently replacing a blob with a tree would be a footgun.
     pub fn write_child(
         &mut self,
-        repo: &gix::Repository,
+        ctx: &Context,
         path: &str,
         content: &str,
     ) -> Result<ObjectId> {
-        self.write_child_bytes(repo, path, content.as_bytes())
+        self.write_child_bytes(ctx, path, content.as_bytes())
     }
 
     /// Write raw bytes as a blob at a deep path.
     pub fn write_child_bytes(
         &mut self,
-        repo: &gix::Repository,
+        ctx: &Context,
         path: &str,
         content: &[u8],
     ) -> Result<ObjectId> {
-        let blob_id = repo
+        let blob_id = ctx
+            .repo
             .write_blob(content)
             .map_err(|e| Error::Git(e.to_string()))?
             .detach();
@@ -513,7 +578,7 @@ impl MutableTree {
             None => (".", path),
         };
 
-        let tree = self.get_or_create_subtree(repo, dir)?;
+        let tree = self.get_or_create_subtree(ctx, dir)?;
         tree.children_mut()?.insert(
             name.to_string(),
             Child::Blob {
@@ -550,7 +615,7 @@ impl MutableTree {
     /// [`write_child_bytes`](Self::write_child_bytes)).
     pub fn write_child_hash(
         &mut self,
-        repo: &gix::Repository,
+        ctx: &Context,
         path: &str,
         hash: ObjectId,
         mode: u16,
@@ -564,7 +629,7 @@ impl MutableTree {
         // Validate existence + kind from the object header, without decoding the
         // blob — that byte-read is exactly what a place-by-hash caller wants to
         // skip.
-        let header = repo.find_header(hash)?;
+        let header = ctx.repo.find_header(hash)?;
         if header.kind() != gix::object::Kind::Blob {
             return Err(Error::InvalidArgument(format!(
                 "object {hash} is not a blob (found {:?})",
@@ -577,7 +642,7 @@ impl MutableTree {
             None => (".", path),
         };
 
-        let tree = self.get_or_create_subtree(repo, dir)?;
+        let tree = self.get_or_create_subtree(ctx, dir)?;
         tree.children_mut()?
             .insert(name.to_string(), Child::Blob { mode, hash });
         tree.dirty = true;
@@ -587,12 +652,12 @@ impl MutableTree {
     /// Delete a child at a deep slash-separated path (not just a direct child).
     pub fn delete_child_deep(
         &mut self,
-        repo: &gix::Repository,
+        ctx: &Context,
         path: &str,
     ) -> Result<bool> {
         let (dir, name) = match path.rsplit_once('/') {
             Some((d, f)) => (d, f),
-            None => return self.delete_child(repo, path),
+            None => return self.delete_child(ctx, path),
         };
 
         // Mark the path to `dir` dirty as we descend: removing a descendant
@@ -608,7 +673,7 @@ impl MutableTree {
             if part.is_empty() || part == "." {
                 continue;
             }
-            cur.ensure_children(repo)?;
+            cur.ensure_children(ctx)?;
             match cur.children_mut()?.get_mut(part) {
                 Some(Child::Tree(t)) => {
                     t.dirty = true;
@@ -617,7 +682,7 @@ impl MutableTree {
                 _ => return Ok(false),
             }
         }
-        cur.delete_child(repo, name)
+        cur.delete_child(ctx, name)
     }
 
     /// Clear all children under a deep `path`, replacing the subtree there
@@ -630,7 +695,7 @@ impl MutableTree {
     /// exist is a no-op in the written result.
     ///
     /// `path == "."` (or empty) clears the root tree itself.
-    pub fn clear_children(&mut self, repo: &gix::Repository, path: &str) -> Result<()> {
+    pub fn clear_children(&mut self, ctx: &Context, path: &str) -> Result<()> {
         if path == "." || path.is_empty() {
             self.children = Some(BTreeMap::new());
             self.hash = empty_tree_id();
@@ -646,7 +711,7 @@ impl MutableTree {
         // get_or_create_subtree marks the whole navigated path (root included)
         // dirty, which is exactly what we need: every ancestor's serialized
         // form changes once the cleared subtree is pruned on write().
-        let parent = self.get_or_create_subtree(repo, dir)?;
+        let parent = self.get_or_create_subtree(ctx, dir)?;
         let mut empty = MutableTree::empty();
         empty.dirty = true;
         parent
@@ -659,20 +724,20 @@ impl MutableTree {
     /// Recursively collect all blobs into a flat map.
     pub fn get_blob_map(
         &mut self,
-        repo: &gix::Repository,
+        ctx: &Context,
     ) -> Result<BTreeMap<String, BlobInfo>> {
         let mut out = BTreeMap::new();
-        self.collect_blobs(repo, "", &mut out)?;
+        self.collect_blobs(ctx, "", &mut out)?;
         Ok(out)
     }
 
     fn collect_blobs(
         &mut self,
-        repo: &gix::Repository,
+        ctx: &Context,
         prefix: &str,
         out: &mut BTreeMap<String, BlobInfo>,
     ) -> Result<()> {
-        self.ensure_children(repo)?;
+        self.ensure_children(ctx)?;
 
         let keys: Vec<String> = self.children_ref()?.keys().cloned().collect();
         for name in keys {
@@ -683,7 +748,7 @@ impl MutableTree {
             };
 
             match self.children_mut()?.get_mut(&name) {
-                Some(Child::Tree(ref mut t)) => t.collect_blobs(repo, &path, out)?,
+                Some(Child::Tree(ref mut t)) => t.collect_blobs(ctx, &path, out)?,
                 Some(Child::Blob { hash, mode }) => {
                     out.insert(path, BlobInfo { hash: *hash, mode: *mode });
                 }
@@ -702,13 +767,13 @@ impl MutableTree {
     /// pseudocode and invariants.
     pub fn merge(
         &mut self,
-        repo: &gix::Repository,
+        ctx: &Context,
         input: &mut MutableTree,
         opts: &MergeOptions,
         base_path: &str,
     ) -> Result<()> {
-        self.ensure_children(repo)?;
-        input.ensure_children(repo)?;
+        self.ensure_children(ctx)?;
+        input.ensure_children(ctx)?;
 
         let input_names: Vec<String> = input.children_ref()?.keys().cloned().collect();
 
@@ -793,7 +858,7 @@ impl MutableTree {
                             ))
                         }
                     };
-                    temp.merge(repo, it, opts, &child_path)?;
+                    temp.merge(ctx, it, opts, &child_path)?;
                     if temp.dirty {
                         self.children_mut()?
                             .insert(child_name.clone(), Child::Tree(temp));
@@ -824,7 +889,7 @@ impl MutableTree {
                     }
                 };
                 let mut new_base = MutableTree::empty();
-                new_base.merge(repo, it, opts, &child_path)?;
+                new_base.merge(ctx, it, opts, &child_path)?;
                 if new_base.dirty {
                     self.dirty = true;
                 }
@@ -859,7 +924,7 @@ impl MutableTree {
                 }
             };
 
-            base_tree.merge(repo, &mut input_tree, opts, &child_path)?;
+            base_tree.merge(ctx, &mut input_tree, opts, &child_path)?;
             if base_tree.dirty {
                 self.dirty = true;
             }
@@ -896,14 +961,14 @@ impl MutableTree {
 
     /// Recursively write dirty trees to the git ODB.
     /// Returns the hash of this tree.
-    pub fn write(&mut self, repo: &gix::Repository) -> Result<ObjectId> {
+    pub fn write(&mut self, ctx: &Context) -> Result<ObjectId> {
         if !self.dirty {
             TREES_SKIPPED_CLEAN.fetch_add(1, Ordering::Relaxed);
             return Ok(self.hash);
         }
 
         if self.children.is_none() {
-            self.ensure_children(repo)?;
+            self.ensure_children(ctx)?;
         }
 
         let children = self.children_mut()?;
@@ -913,7 +978,7 @@ impl MutableTree {
         for name in &names {
             if let Some(Child::Tree(ref mut ct)) = children.get_mut(name) {
                 if ct.dirty {
-                    ct.write(repo)?;
+                    ct.write(ctx)?;
                 }
             }
         }
@@ -951,7 +1016,7 @@ impl MutableTree {
         } else {
             entries.sort();
             let tree = GixTree { entries };
-            let id = repo.write_object(&tree)?;
+            let id = ctx.repo.write_object(&tree)?;
             self.hash = id.detach();
             TREES_WRITTEN.fetch_add(1, Ordering::Relaxed);
         }

--- a/holo-tree/tests/clear_children.rs
+++ b/holo-tree/tests/clear_children.rs
@@ -6,10 +6,10 @@ mod helpers;
 use helpers::Sandbox;
 use holo_tree::MutableTree;
 
-fn list_tree(repo: &gix::Repository, hash: gix::ObjectId) -> Vec<String> {
+fn list_tree(ctx: &holo_tree::Context, hash: gix::ObjectId) -> Vec<String> {
     let mut tree = MutableTree::new(hash);
     let mut out = Vec::new();
-    for (path, _) in tree.get_blob_map(repo).unwrap() {
+    for (path, _) in tree.get_blob_map(ctx).unwrap() {
         out.push(path);
     }
     out.sort();
@@ -27,12 +27,12 @@ fn clears_a_deep_subtree_but_preserves_siblings() {
     ]);
 
     let mut tree = MutableTree::new(base);
-    tree.clear_children(&sb.repo, "data/widgets").unwrap();
-    let hash = tree.write(&sb.repo).unwrap();
+    tree.clear_children(&sb.ctx(), "data/widgets").unwrap();
+    let hash = tree.write(&sb.ctx()).unwrap();
 
     assert_ne!(hash, base, "clearing a populated subtree must change the hash");
     assert_eq!(
-        list_tree(&sb.repo, hash),
+        list_tree(&sb.ctx(), hash),
         vec![
             "README.md".to_string(),
             "data/gadgets/9.toml".to_string(),
@@ -50,13 +50,13 @@ fn cleared_subtree_can_be_repopulated_in_the_same_pass() {
     ]);
 
     let mut tree = MutableTree::new(base);
-    tree.clear_children(&sb.repo, "data/widgets").unwrap();
-    tree.write_child(&sb.repo, "data/widgets/new.toml", "id = 3\n")
+    tree.clear_children(&sb.ctx(), "data/widgets").unwrap();
+    tree.write_child(&sb.ctx(), "data/widgets/new.toml", "id = 3\n")
         .unwrap();
-    let hash = tree.write(&sb.repo).unwrap();
+    let hash = tree.write(&sb.ctx()).unwrap();
 
     assert_eq!(
-        list_tree(&sb.repo, hash),
+        list_tree(&sb.ctx(), hash),
         vec!["data/widgets/new.toml".to_string()],
         "old entries cleared, new entry present",
     );
@@ -68,8 +68,8 @@ fn clearing_the_root_yields_the_empty_tree() {
     let base = sb.write_tree(&[("a.toml", "1\n"), ("b/c.toml", "2\n")]);
 
     let mut tree = MutableTree::new(base);
-    tree.clear_children(&sb.repo, ".").unwrap();
-    let hash = tree.write(&sb.repo).unwrap();
+    tree.clear_children(&sb.ctx(), ".").unwrap();
+    let hash = tree.write(&sb.ctx()).unwrap();
 
     assert_eq!(
         hash,
@@ -85,8 +85,8 @@ fn clearing_a_missing_path_is_a_noop_on_write() {
 
     let mut tree = MutableTree::new(base);
     // Path doesn't exist yet; an empty subtree is pruned on write().
-    tree.clear_children(&sb.repo, "data/never").unwrap();
-    let hash = tree.write(&sb.repo).unwrap();
+    tree.clear_children(&sb.ctx(), "data/never").unwrap();
+    let hash = tree.write(&sb.ctx()).unwrap();
 
     assert_eq!(
         hash, base,

--- a/holo-tree/tests/helpers/mod.rs
+++ b/holo-tree/tests/helpers/mod.rs
@@ -10,6 +10,7 @@ use gix::ObjectId;
 pub struct Sandbox {
     pub dir: tempfile::TempDir,
     pub repo: gix::Repository,
+    pub cache: holo_tree::TreeCache,
 }
 
 impl Sandbox {
@@ -17,7 +18,16 @@ impl Sandbox {
     pub fn new() -> Self {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let repo = gix::init_bare(dir.path()).expect("failed to init bare repo");
-        Sandbox { dir, repo }
+        Sandbox {
+            dir,
+            repo,
+            cache: holo_tree::TreeCache::new(),
+        }
+    }
+
+    /// A per-call [`holo_tree::Context`] over this sandbox's repo and cache.
+    pub fn ctx(&self) -> holo_tree::Context<'_> {
+        holo_tree::Context::new(&self.repo, &self.cache)
     }
 
     /// Write a blob and return its OID.
@@ -34,10 +44,10 @@ impl Sandbox {
 
         for (path, content) in files {
             let blob_hash = self.write_blob(content);
-            insert_blob_at_path(&self.repo, &mut tree, path, blob_hash);
+            insert_blob_at_path(&self.ctx(), &mut tree, path, blob_hash);
         }
 
-        tree.write(&self.repo).unwrap()
+        tree.write(&self.ctx()).unwrap()
     }
 
     /// Build a tree from entries that can include blobs, trees, and gitlinks.
@@ -133,7 +143,7 @@ impl Sandbox {
             spec.name
         );
         let config_blob = self.write_blob(&config_toml);
-        insert_blob_at_path(&self.repo, &mut tree, ".holo/config.toml", config_blob);
+        insert_blob_at_path(&self.ctx(), &mut tree, ".holo/config.toml", config_blob);
 
         // .holo/sources/{name}.toml
         for (name, source) in &spec.sources {
@@ -149,7 +159,7 @@ impl Sandbox {
             }
             let blob = self.write_blob(&toml);
             insert_blob_at_path(
-                &self.repo,
+                &self.ctx(),
                 &mut tree,
                 &format!(".holo/sources/{name}.toml"),
                 blob,
@@ -168,7 +178,7 @@ impl Sandbox {
                 }
                 let blob = self.write_blob(&toml);
                 insert_blob_at_path(
-                    &self.repo,
+                    &self.ctx(),
                     &mut tree,
                     &format!(".holo/branches/{branch_name}.toml"),
                     blob,
@@ -211,7 +221,7 @@ impl Sandbox {
 
                 let blob = self.write_blob(&toml);
                 insert_blob_at_path(
-                    &self.repo,
+                    &self.ctx(),
                     &mut tree,
                     &format!(".holo/branches/{branch_name}/{key}.toml"),
                     blob,
@@ -222,7 +232,7 @@ impl Sandbox {
         // Gitlink entries for sources in .holo/sources/
         for (name, commit_hash) in &spec.gitlinks {
             let sources_tree = tree
-                .get_or_create_subtree(&self.repo, ".holo/sources")
+                .get_or_create_subtree(&self.ctx(), ".holo/sources")
                 .unwrap();
             sources_tree.children.as_mut().unwrap().insert(
                 name.clone(),
@@ -234,16 +244,16 @@ impl Sandbox {
         // Additional content files (outside .holo/)
         for (path, content) in &spec.files {
             let blob = self.write_blob(content);
-            insert_blob_at_path(&self.repo, &mut tree, path, blob);
+            insert_blob_at_path(&self.ctx(), &mut tree, path, blob);
         }
 
-        tree.write(&self.repo).unwrap()
+        tree.write(&self.ctx()).unwrap()
     }
 }
 
 /// Insert a blob at a slash-separated path in a MutableTree.
 fn insert_blob_at_path(
-    repo: &gix::Repository,
+    ctx: &holo_tree::Context,
     tree: &mut holo_tree::tree::MutableTree,
     path: &str,
     blob_hash: ObjectId,
@@ -252,7 +262,7 @@ fn insert_blob_at_path(
         Some((d, f)) => (d, f),
         None => (".", path),
     };
-    let parent = tree.get_or_create_subtree(repo, dir).unwrap();
+    let parent = tree.get_or_create_subtree(ctx, dir).unwrap();
     parent.children.as_mut().unwrap().insert(
         file.to_string(),
         holo_tree::tree::Child::Blob {

--- a/holo-tree/tests/repo_ops.rs
+++ b/holo-tree/tests/repo_ops.rs
@@ -54,12 +54,27 @@ fn update_ref_cas_fails_when_expected_does_not_match() {
 
     // ...but we claim it should be at A — the swap must be rejected.
     let err = update_ref(&sb.repo, "refs/heads/work", a, Some(a)).unwrap_err();
-    assert!(
-        matches!(err, holo_tree::Error::Git(_)),
-        "CAS mismatch should surface as a git error, got {err:?}",
+    // Per specs/api/errors.md: assert the stable code, never message text.
+    assert_eq!(
+        err.code(),
+        "REF_CONFLICT",
+        "CAS mismatch must surface as REF_CONFLICT, got {err:?}",
     );
     // Ref is unchanged.
     assert_eq!(resolve_ref(&sb.repo, "refs/heads/work").unwrap(), Some(b));
+}
+
+#[test]
+fn update_ref_cas_fails_when_ref_is_missing() {
+    let sb = Sandbox::new();
+    let (a, b) = two_commits(&sb);
+    // No ref exists, but the caller claims it should be at A.
+    let err = update_ref(&sb.repo, "refs/heads/ghost", b, Some(a)).unwrap_err();
+    assert_eq!(
+        err.code(),
+        "REF_CONFLICT",
+        "CAS against a missing ref must surface as REF_CONFLICT, got {err:?}",
+    );
 }
 
 #[test]

--- a/holo-tree/tests/thread_dispatch.rs
+++ b/holo-tree/tests/thread_dispatch.rs
@@ -1,0 +1,85 @@
+//! Thread-safety contract tests (specs/api/errors.md § Thread-safety
+//! expectations): correctness must not depend on which thread a call lands
+//! on. The consumer-owned `TreeCache` travels with the operation — unlike the
+//! former `thread_local!` cache, whose warmth (or worse) silently depended on
+//! thread identity (gitsheets finding #5).
+
+mod helpers;
+
+use helpers::Sandbox;
+use holo_tree::{Context, MutableTree, TreeCache};
+
+/// One logical operation dispatched across threads: a tree loaded (and its
+/// cache populated) on thread A is mutated and written on thread B, with the
+/// moved cache staying authoritative.
+#[test]
+fn tree_and_cache_move_across_threads() {
+    let sb = Sandbox::new();
+    let base = sb.write_tree(&[
+        ("data/widgets/1.toml", "id = 1\n"),
+        ("README.md", "hi\n"),
+    ]);
+
+    // Thread A (here): populate the consumer-owned cache.
+    let cache = TreeCache::new();
+    let mut tree = MutableTree::new(base);
+    {
+        let ctx = Context::new(&sb.repo, &cache);
+        tree.ensure_children(&ctx).unwrap();
+    }
+    assert!(!cache.is_empty(), "loading a tree should populate the cache");
+
+    // Thread B: the tree + cache move (Send); the repo handle is re-derived
+    // per thread, as an embedding host (e.g. the napi binding) would.
+    let repo_sync = sb.repo.clone().into_sync();
+    let written = std::thread::spawn(move || {
+        let repo = repo_sync.to_thread_local();
+        let ctx = Context::new(&repo, &cache);
+        tree.write_child(&ctx, "data/widgets/2.toml", "id = 2\n")
+            .unwrap();
+        tree.write(&ctx).unwrap()
+    })
+    .join()
+    .expect("cross-thread dispatch must not panic");
+
+    // The result is exactly what a single-threaded run produces.
+    let expected = sb.write_tree(&[
+        ("data/widgets/1.toml", "id = 1\n"),
+        ("data/widgets/2.toml", "id = 2\n"),
+        ("README.md", "hi\n"),
+    ]);
+    assert_eq!(written, expected);
+}
+
+/// The cache is keyed by content-addressed object id, so a cache populated
+/// against one repository serves the same tree everywhere — proven by reading
+/// a tree through a `Context` over an *empty* repository, where the only
+/// possible source of the children is the travelled cache.
+#[test]
+fn cache_is_content_addressed_and_repo_independent() {
+    let sb = Sandbox::new();
+    let base = sb.write_tree(&[("a.txt", "a\n"), ("dir/b.txt", "b\n")]);
+
+    let cache = TreeCache::new();
+    {
+        let ctx = Context::new(&sb.repo, &cache);
+        let mut tree = MutableTree::new(base);
+        tree.ensure_children(&ctx).unwrap();
+        // Load the subtree too so its entries are cached.
+        tree.get_subtree(&ctx, "dir")
+            .unwrap()
+            .unwrap()
+            .ensure_children(&ctx)
+            .unwrap();
+    }
+
+    // A different, empty repository: the tree object does not exist here.
+    let other = Sandbox::new();
+    let ctx = Context::new(&other.repo, &cache);
+    let mut tree = MutableTree::new(base);
+    tree.ensure_children(&ctx)
+        .expect("children must come from the travelled cache");
+    let children = tree.children.as_ref().unwrap();
+    assert!(children.contains_key("a.txt"));
+    assert!(children.contains_key("dir"));
+}

--- a/holo-tree/tests/tree_merge.rs
+++ b/holo-tree/tests/tree_merge.rs
@@ -5,13 +5,13 @@ mod helpers;
 use helpers::Sandbox;
 use holo_tree::tree::{MergeMode, MergeOptions, MutableTree};
 
-fn list_tree(repo: &gix::Repository, hash: gix::ObjectId) -> Vec<String> {
+fn list_tree(ctx: &holo_tree::Context, hash: gix::ObjectId) -> Vec<String> {
     let mut tree = MutableTree::new(hash);
-    collect_paths(repo, &mut tree, "")
+    collect_paths(ctx, &mut tree, "")
 }
 
-fn collect_paths(repo: &gix::Repository, tree: &mut MutableTree, prefix: &str) -> Vec<String> {
-    tree.ensure_children(repo).unwrap();
+fn collect_paths(ctx: &holo_tree::Context, tree: &mut MutableTree, prefix: &str) -> Vec<String> {
+    tree.ensure_children(ctx).unwrap();
     let mut paths = Vec::new();
     // snapshot keys to avoid borrow issues
     let keys: Vec<String> = tree.children.as_ref().unwrap().keys().cloned().collect();
@@ -23,7 +23,7 @@ fn collect_paths(repo: &gix::Repository, tree: &mut MutableTree, prefix: &str) -
         };
         match tree.children.as_mut().unwrap().get_mut(&name) {
             Some(holo_tree::tree::Child::Tree(ref mut t)) => {
-                paths.extend(collect_paths(repo, t, &path));
+                paths.extend(collect_paths(ctx, t, &path));
             }
             Some(holo_tree::tree::Child::Blob { .. }) => paths.push(path),
             Some(holo_tree::tree::Child::Commit { .. }) => paths.push(format!("{path} [gitlink]")),
@@ -33,9 +33,9 @@ fn collect_paths(repo: &gix::Repository, tree: &mut MutableTree, prefix: &str) -
     paths
 }
 
-fn read_blob(repo: &gix::Repository, hash: gix::ObjectId, path: &str) -> String {
+fn read_blob(ctx: &holo_tree::Context, hash: gix::ObjectId, path: &str) -> String {
     let mut tree = MutableTree::new(hash);
-    let data = tree.read_blob(repo, path).unwrap().unwrap();
+    let data = tree.read_blob(ctx, path).unwrap().unwrap();
     String::from_utf8(data).unwrap()
 }
 
@@ -50,10 +50,10 @@ fn overlay_overwrites_existing_files() {
     let mut target = MutableTree::new(target_hash);
     let mut source = MutableTree::new(source_hash);
     let opts = MergeOptions::new(None, MergeMode::Overlay).unwrap();
-    target.merge(&sb.repo, &mut source, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut source, &opts, ".").unwrap();
 
-    let result = target.write(&sb.repo).unwrap();
-    assert_eq!(read_blob(&sb.repo, result, "file.txt"), "updated");
+    let result = target.write(&sb.ctx()).unwrap();
+    assert_eq!(read_blob(&sb.ctx(), result, "file.txt"), "updated");
 }
 
 #[test]
@@ -65,14 +65,14 @@ fn overlay_preserves_non_overlapping_files() {
     let mut target = MutableTree::new(target_hash);
     let mut source = MutableTree::new(source_hash);
     let opts = MergeOptions::new(None, MergeMode::Overlay).unwrap();
-    target.merge(&sb.repo, &mut source, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut source, &opts, ".").unwrap();
 
-    let result = target.write(&sb.repo).unwrap();
-    let files = list_tree(&sb.repo, result);
+    let result = target.write(&sb.ctx()).unwrap();
+    let files = list_tree(&sb.ctx(), result);
     assert!(files.contains(&"keep.txt".to_string()));
     assert!(files.contains(&"shared.txt".to_string()));
-    assert_eq!(read_blob(&sb.repo, result, "keep.txt"), "kept");
-    assert_eq!(read_blob(&sb.repo, result, "shared.txt"), "v2");
+    assert_eq!(read_blob(&sb.ctx(), result, "keep.txt"), "kept");
+    assert_eq!(read_blob(&sb.ctx(), result, "shared.txt"), "v2");
 }
 
 #[test]
@@ -84,10 +84,10 @@ fn overlay_adds_new_files() {
     let mut target = MutableTree::new(target_hash);
     let mut source = MutableTree::new(source_hash);
     let opts = MergeOptions::new(None, MergeMode::Overlay).unwrap();
-    target.merge(&sb.repo, &mut source, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut source, &opts, ".").unwrap();
 
-    let result = target.write(&sb.repo).unwrap();
-    let files = list_tree(&sb.repo, result);
+    let result = target.write(&sb.ctx()).unwrap();
+    let files = list_tree(&sb.ctx(), result);
     assert!(files.contains(&"a.txt".to_string()));
     assert!(files.contains(&"b.txt".to_string()));
 }
@@ -101,10 +101,10 @@ fn overlay_merges_nested_directories() {
     let mut target = MutableTree::new(target_hash);
     let mut source = MutableTree::new(source_hash);
     let opts = MergeOptions::new(None, MergeMode::Overlay).unwrap();
-    target.merge(&sb.repo, &mut source, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut source, &opts, ".").unwrap();
 
-    let result = target.write(&sb.repo).unwrap();
-    let files = list_tree(&sb.repo, result);
+    let result = target.write(&sb.ctx()).unwrap();
+    let files = list_tree(&sb.ctx(), result);
     assert!(files.contains(&"a/b/file1.txt".to_string()));
     assert!(files.contains(&"a/b/file2.txt".to_string()));
     assert!(files.contains(&"a/c/file3.txt".to_string()));
@@ -121,10 +121,10 @@ fn replace_removes_unmatched_target_children() {
     let mut target = MutableTree::new(target_hash);
     let mut source = MutableTree::new(source_hash);
     let opts = MergeOptions::new(None, MergeMode::Replace).unwrap();
-    target.merge(&sb.repo, &mut source, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut source, &opts, ".").unwrap();
 
-    let result = target.write(&sb.repo).unwrap();
-    let files = list_tree(&sb.repo, result);
+    let result = target.write(&sb.ctx()).unwrap();
+    let files = list_tree(&sb.ctx(), result);
     assert!(!files.contains(&"remove.txt".to_string()));
     assert!(files.contains(&"shared.txt".to_string()));
 }
@@ -140,10 +140,10 @@ fn underlay_does_not_overwrite_existing() {
     let mut target = MutableTree::new(target_hash);
     let mut source = MutableTree::new(source_hash);
     let opts = MergeOptions::new(None, MergeMode::Underlay).unwrap();
-    target.merge(&sb.repo, &mut source, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut source, &opts, ".").unwrap();
 
-    let result = target.write(&sb.repo).unwrap();
-    assert_eq!(read_blob(&sb.repo, result, "file.txt"), "original");
+    let result = target.write(&sb.ctx()).unwrap();
+    assert_eq!(read_blob(&sb.ctx(), result, "file.txt"), "original");
 }
 
 #[test]
@@ -155,10 +155,10 @@ fn underlay_fills_gaps() {
     let mut target = MutableTree::new(target_hash);
     let mut source = MutableTree::new(source_hash);
     let opts = MergeOptions::new(None, MergeMode::Underlay).unwrap();
-    target.merge(&sb.repo, &mut source, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut source, &opts, ".").unwrap();
 
-    let result = target.write(&sb.repo).unwrap();
-    let files = list_tree(&sb.repo, result);
+    let result = target.write(&sb.ctx()).unwrap();
+    let files = list_tree(&sb.ctx(), result);
     assert!(files.contains(&"existing.txt".to_string()));
     assert!(files.contains(&"new.txt".to_string()));
 }
@@ -178,10 +178,10 @@ fn glob_includes_only_matching_files() {
     let mut source = MutableTree::new(source_hash);
     let files = vec!["**/*.js".to_string()];
     let opts = MergeOptions::new(Some(&files), MergeMode::Overlay).unwrap();
-    target.merge(&sb.repo, &mut source, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut source, &opts, ".").unwrap();
 
-    let result = target.write(&sb.repo).unwrap();
-    let paths = list_tree(&sb.repo, result);
+    let result = target.write(&sb.ctx()).unwrap();
+    let paths = list_tree(&sb.ctx(), result);
     assert!(paths.contains(&"src/app.js".to_string()));
     assert!(!paths.contains(&"src/style.css".to_string()));
     assert!(!paths.contains(&"src/index.html".to_string()));
@@ -201,10 +201,10 @@ fn glob_double_star_matches_root_level() {
     let mut source = MutableTree::new(source_hash);
     let files = vec!["**/*.php".to_string()];
     let opts = MergeOptions::new(Some(&files), MergeMode::Overlay).unwrap();
-    target.merge(&sb.repo, &mut source, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut source, &opts, ".").unwrap();
 
-    let result = target.write(&sb.repo).unwrap();
-    let paths = list_tree(&sb.repo, result);
+    let result = target.write(&sb.ctx()).unwrap();
+    let paths = list_tree(&sb.ctx(), result);
     assert!(paths.contains(&"Admin.php".to_string()), "** must match zero segments");
     assert!(paths.contains(&"sub/Nested.php".to_string()));
     assert!(!paths.contains(&"README.md".to_string()));
@@ -222,10 +222,10 @@ fn glob_negation_excludes_directory() {
     let mut source = MutableTree::new(source_hash);
     let files = vec!["*/**".to_string(), "!.github/".to_string()];
     let opts = MergeOptions::new(Some(&files), MergeMode::Overlay).unwrap();
-    target.merge(&sb.repo, &mut source, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut source, &opts, ".").unwrap();
 
-    let result = target.write(&sb.repo).unwrap();
-    let paths = list_tree(&sb.repo, result);
+    let result = target.write(&sb.ctx()).unwrap();
+    let paths = list_tree(&sb.ctx(), result);
     assert!(paths.contains(&"src/app.js".to_string()));
     assert!(!paths.iter().any(|p| p.starts_with(".github")));
 }
@@ -249,10 +249,10 @@ fn glob_multiple_negations() {
         "!docs/".to_string(),
     ];
     let opts = MergeOptions::new(Some(&files), MergeMode::Overlay).unwrap();
-    target.merge(&sb.repo, &mut source, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut source, &opts, ".").unwrap();
 
-    let result = target.write(&sb.repo).unwrap();
-    let paths = list_tree(&sb.repo, result);
+    let result = target.write(&sb.ctx()).unwrap();
+    let paths = list_tree(&sb.ctx(), result);
     assert!(paths.contains(&"src/app.js".to_string()));
     assert!(!paths.iter().any(|p| p.starts_with(".github")));
     assert!(!paths.iter().any(|p| p.starts_with(".vscode")));
@@ -269,7 +269,7 @@ fn identical_merge_stays_clean() {
     let mut target = MutableTree::new(hash);
     let mut source = MutableTree::new(hash);
     let opts = MergeOptions::new(None, MergeMode::Overlay).unwrap();
-    target.merge(&sb.repo, &mut source, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut source, &opts, ".").unwrap();
 
     assert!(!target.dirty, "merging identical trees should not set dirty");
 }
@@ -282,10 +282,10 @@ fn write_resets_dirty() {
     let mut target = MutableTree::empty();
     let mut source = MutableTree::new(source_hash);
     let opts = MergeOptions::new(None, MergeMode::Overlay).unwrap();
-    target.merge(&sb.repo, &mut source, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut source, &opts, ".").unwrap();
     assert!(target.dirty);
 
-    target.write(&sb.repo).unwrap();
+    target.write(&sb.ctx()).unwrap();
     assert!(!target.dirty);
 }
 
@@ -295,7 +295,7 @@ fn get_or_create_subtree_marks_ancestors_dirty() {
     // subtrees created via get_or_create_subtree were silently lost.
     let sb = Sandbox::new();
     let mut tree = MutableTree::empty();
-    let sub = tree.get_or_create_subtree(&sb.repo, "a/b/c").unwrap();
+    let sub = tree.get_or_create_subtree(&sb.ctx(), "a/b/c").unwrap();
     // Insert a blob into the deepest subtree
     sub.children.as_mut().unwrap().insert(
         "file.txt".to_string(),
@@ -308,8 +308,8 @@ fn get_or_create_subtree_marks_ancestors_dirty() {
 
     assert!(tree.dirty, "root must be dirty after creating subtree path");
 
-    let result = tree.write(&sb.repo).unwrap();
-    let paths = list_tree(&sb.repo, result);
+    let result = tree.write(&sb.ctx()).unwrap();
+    let paths = list_tree(&sb.ctx(), result);
     assert!(
         paths.contains(&"a/b/c/file.txt".to_string()),
         "file in created subtree must survive write(). Got: {:?}",
@@ -329,13 +329,13 @@ fn sequential_merges_accumulate() {
     let opts = MergeOptions::new(None, MergeMode::Overlay).unwrap();
 
     let mut src_a = MutableTree::new(source_a);
-    target.merge(&sb.repo, &mut src_a, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut src_a, &opts, ".").unwrap();
 
     let mut src_b = MutableTree::new(source_b);
-    target.merge(&sb.repo, &mut src_b, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut src_b, &opts, ".").unwrap();
 
-    let result = target.write(&sb.repo).unwrap();
-    let paths = list_tree(&sb.repo, result);
+    let result = target.write(&sb.ctx()).unwrap();
+    let paths = list_tree(&sb.ctx(), result);
     assert!(paths.contains(&"a.txt".to_string()));
     assert!(paths.contains(&"b.txt".to_string()));
 }
@@ -348,7 +348,7 @@ fn empty_into_empty_is_noop() {
     let mut target = MutableTree::empty();
     let mut source = MutableTree::empty();
     let opts = MergeOptions::new(None, MergeMode::Overlay).unwrap();
-    target.merge(&sb.repo, &mut source, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut source, &opts, ".").unwrap();
     assert!(!target.dirty);
 }
 
@@ -367,11 +367,11 @@ fn preserves_executable_mode() {
     let mut target = MutableTree::empty();
     let mut source = MutableTree::new(source_hash);
     let opts = MergeOptions::new(None, MergeMode::Overlay).unwrap();
-    target.merge(&sb.repo, &mut source, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut source, &opts, ".").unwrap();
 
-    let result = target.write(&sb.repo).unwrap();
+    let result = target.write(&sb.ctx()).unwrap();
     let mut check = MutableTree::new(result);
-    check.ensure_children(&sb.repo).unwrap();
+    check.ensure_children(&sb.ctx()).unwrap();
     match check.children.as_ref().unwrap().get("run.sh") {
         Some(Child::Blob { mode, .. }) => assert_eq!(*mode, 0o100755),
         other => panic!("expected executable blob, got {:?}", other.is_some()),
@@ -392,11 +392,11 @@ fn preserves_gitlink_entries() {
     let mut target = MutableTree::empty();
     let mut source = MutableTree::new(source_hash);
     let opts = MergeOptions::new(None, MergeMode::Overlay).unwrap();
-    target.merge(&sb.repo, &mut source, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut source, &opts, ".").unwrap();
 
-    let result = target.write(&sb.repo).unwrap();
+    let result = target.write(&sb.ctx()).unwrap();
     let mut check = MutableTree::new(result);
-    check.ensure_children(&sb.repo).unwrap();
+    check.ensure_children(&sb.ctx()).unwrap();
     match check.children.as_ref().unwrap().get("submodule") {
         Some(holo_tree::tree::Child::Commit { hash }) => assert_eq!(*hash, fake_commit),
         _ => panic!("expected gitlink"),
@@ -417,9 +417,9 @@ fn deep_nesting_20_levels() {
     let mut target = MutableTree::empty();
     let mut source = MutableTree::new(source_hash);
     let opts = MergeOptions::new(None, MergeMode::Overlay).unwrap();
-    target.merge(&sb.repo, &mut source, &opts, ".").unwrap();
+    target.merge(&sb.ctx(), &mut source, &opts, ".").unwrap();
 
-    let result = target.write(&sb.repo).unwrap();
-    let paths = list_tree(&sb.repo, result);
+    let result = target.write(&sb.ctx()).unwrap();
+    let paths = list_tree(&sb.ctx(), result);
     assert!(paths.contains(&deep_path));
 }

--- a/holo-tree/tests/write_child.rs
+++ b/holo-tree/tests/write_child.rs
@@ -236,7 +236,8 @@ fn write_child_hash_rejects_missing_object() {
     let err = tree
         .write_child_hash(&sb.repo, "x", absent, 0o100644)
         .unwrap_err();
-    assert!(matches!(err, holo_tree::Error::Git(_)), "got {err:?}");
+    // Per specs/api/errors.md: assert the stable code, never message text.
+    assert_eq!(err.code(), "OBJECT_NOT_FOUND", "got {err:?}");
 }
 
 /// A hash pointing at a non-blob object (here a tree) is rejected rather than
@@ -250,13 +251,8 @@ fn write_child_hash_rejects_non_blob() {
     let err = tree
         .write_child_hash(&sb.repo, "x", tree_oid, 0o100644)
         .unwrap_err();
-    match err {
-        holo_tree::Error::Git(msg) => assert!(
-            msg.contains("not a blob"),
-            "expected a not-a-blob error, got: {msg}",
-        ),
-        other => panic!("expected Git error, got {other:?}"),
-    }
+    // Wrong object kind is a caller error: INVALID_ARGUMENT (not message prose).
+    assert_eq!(err.code(), "INVALID_ARGUMENT", "got {err:?}");
 }
 
 /// An invalid (non-blob) mode is rejected up front, before any tree mutation —
@@ -271,7 +267,7 @@ fn write_child_hash_rejects_invalid_mode() {
     let err = tree
         .write_child_hash(&sb.repo, "x", blob, 0o040000)
         .unwrap_err();
-    assert!(matches!(err, holo_tree::Error::Git(_)), "got {err:?}");
+    assert_eq!(err.code(), "INVALID_ARGUMENT", "got {err:?}");
     // The tree must be untouched by a rejected call.
     assert_eq!(
         tree.write(&sb.repo).unwrap(),

--- a/holo-tree/tests/write_child.rs
+++ b/holo-tree/tests/write_child.rs
@@ -22,19 +22,19 @@ fn write_child_into_existing_subtree_preserves_siblings() {
 
     // Load it lazily and write a sibling into the existing data/ directory.
     let mut tree = MutableTree::new(base);
-    tree.write_child(&sb.repo, "data/b.toml", "id = 2\n").unwrap();
-    let new_hash = tree.write(&sb.repo).unwrap();
+    tree.write_child(&sb.ctx(), "data/b.toml", "id = 2\n").unwrap();
+    let new_hash = tree.write(&sb.ctx()).unwrap();
     assert_ne!(new_hash, base, "writing a child must change the tree hash");
 
     // Round-trip through the ODB: both records are present.
     let mut reloaded = MutableTree::new(new_hash);
     assert_eq!(
-        reloaded.read_blob(&sb.repo, "data/a.toml").unwrap().as_deref(),
+        reloaded.read_blob(&sb.ctx(), "data/a.toml").unwrap().as_deref(),
         Some(&b"id = 1\n"[..]),
         "existing sibling must be preserved",
     );
     assert_eq!(
-        reloaded.read_blob(&sb.repo, "data/b.toml").unwrap().as_deref(),
+        reloaded.read_blob(&sb.ctx(), "data/b.toml").unwrap().as_deref(),
         Some(&b"id = 2\n"[..]),
         "newly written child must be present",
     );
@@ -46,12 +46,12 @@ fn write_child_into_fresh_subtree_still_works() {
 
     // Empty starting point — the subtree is created fresh.
     let mut tree = MutableTree::empty();
-    tree.write_child(&sb.repo, "data/only.toml", "id = 1\n").unwrap();
-    let hash = tree.write(&sb.repo).unwrap();
+    tree.write_child(&sb.ctx(), "data/only.toml", "id = 1\n").unwrap();
+    let hash = tree.write(&sb.ctx()).unwrap();
 
     let mut reloaded = MutableTree::new(hash);
     assert_eq!(
-        reloaded.read_blob(&sb.repo, "data/only.toml").unwrap().as_deref(),
+        reloaded.read_blob(&sb.ctx(), "data/only.toml").unwrap().as_deref(),
         Some(&b"id = 1\n"[..]),
     );
 }
@@ -69,18 +69,18 @@ fn write_child_at_repo_root_preserves_siblings() {
     let base = sb.write_tree(&[("existing.toml", "id = 0\n")]);
     let mut tree = MutableTree::new(base);
 
-    tree.write_child(&sb.repo, "new.toml", "id = 1\n").unwrap();
-    let hash = tree.write(&sb.repo).unwrap();
+    tree.write_child(&sb.ctx(), "new.toml", "id = 1\n").unwrap();
+    let hash = tree.write(&sb.ctx()).unwrap();
     assert_ne!(hash, base, "a root-level write must change the tree hash");
 
     let mut reloaded = MutableTree::new(hash);
     assert_eq!(
-        reloaded.read_blob(&sb.repo, "existing.toml").unwrap().as_deref(),
+        reloaded.read_blob(&sb.ctx(), "existing.toml").unwrap().as_deref(),
         Some(&b"id = 0\n"[..]),
         "existing root sibling must be preserved",
     );
     assert_eq!(
-        reloaded.read_blob(&sb.repo, "new.toml").unwrap().as_deref(),
+        reloaded.read_blob(&sb.ctx(), "new.toml").unwrap().as_deref(),
         Some(&b"id = 1\n"[..]),
     );
 }
@@ -89,12 +89,12 @@ fn write_child_at_repo_root_preserves_siblings() {
 fn write_child_at_repo_root_into_empty() {
     let sb = Sandbox::new();
     let mut tree = MutableTree::empty();
-    tree.write_child(&sb.repo, "only.toml", "id = 1\n").unwrap();
-    let hash = tree.write(&sb.repo).unwrap();
+    tree.write_child(&sb.ctx(), "only.toml", "id = 1\n").unwrap();
+    let hash = tree.write(&sb.ctx()).unwrap();
 
     let mut reloaded = MutableTree::new(hash);
     assert_eq!(
-        reloaded.read_blob(&sb.repo, "only.toml").unwrap().as_deref(),
+        reloaded.read_blob(&sb.ctx(), "only.toml").unwrap().as_deref(),
         Some(&b"id = 1\n"[..]),
     );
 }
@@ -112,19 +112,19 @@ fn delete_child_deep_into_existing_tree_persists() {
     let base = sb.write_tree(&[("data/a.toml", "id = 1\n"), ("data/b.toml", "id = 2\n")]);
     let mut tree = MutableTree::new(base);
 
-    let deleted = tree.delete_child_deep(&sb.repo, "data/a.toml").unwrap();
+    let deleted = tree.delete_child_deep(&sb.ctx(), "data/a.toml").unwrap();
     assert!(deleted, "the record existed and should report deleted");
 
-    let new_hash = tree.write(&sb.repo).unwrap();
+    let new_hash = tree.write(&sb.ctx()).unwrap();
     assert_ne!(new_hash, base, "deletion must change the tree hash (the bug: it didn't)");
 
     let mut reloaded = MutableTree::new(new_hash);
     assert!(
-        reloaded.read_blob(&sb.repo, "data/a.toml").unwrap().is_none(),
+        reloaded.read_blob(&sb.ctx(), "data/a.toml").unwrap().is_none(),
         "deleted record must be gone after write()",
     );
     assert_eq!(
-        reloaded.read_blob(&sb.repo, "data/b.toml").unwrap().as_deref(),
+        reloaded.read_blob(&sb.ctx(), "data/b.toml").unwrap().as_deref(),
         Some(&b"id = 2\n"[..]),
         "sibling must be preserved",
     );
@@ -138,8 +138,8 @@ fn delete_child_deep_missing_is_noop() {
     let base = sb.write_tree(&[("data/a.toml", "id = 1\n")]);
     let mut tree = MutableTree::new(base);
 
-    assert!(!tree.delete_child_deep(&sb.repo, "data/missing.toml").unwrap());
-    assert_eq!(tree.write(&sb.repo).unwrap(), base, "no-op delete must not change the hash");
+    assert!(!tree.delete_child_deep(&sb.ctx(), "data/missing.toml").unwrap());
+    assert_eq!(tree.write(&sb.ctx()).unwrap(), base, "no-op delete must not change the hash");
 }
 
 // ── write_child_hash (#477): place an existing blob by hash ─────────────────
@@ -155,15 +155,15 @@ fn write_child_hash_matches_write_child_bytes() {
 
     let mut by_bytes = MutableTree::empty();
     by_bytes
-        .write_child_bytes(&sb.repo, "data/att.bin", content)
+        .write_child_bytes(&sb.ctx(), "data/att.bin", content)
         .unwrap();
-    let bytes_hash = by_bytes.write(&sb.repo).unwrap();
+    let bytes_hash = by_bytes.write(&sb.ctx()).unwrap();
 
     let mut by_hash = MutableTree::empty();
     by_hash
-        .write_child_hash(&sb.repo, "data/att.bin", blob, 0o100644)
+        .write_child_hash(&sb.ctx(), "data/att.bin", blob, 0o100644)
         .unwrap();
-    let hash_hash = by_hash.write(&sb.repo).unwrap();
+    let hash_hash = by_hash.write(&sb.ctx()).unwrap();
 
     assert_eq!(
         hash_hash, bytes_hash,
@@ -181,19 +181,19 @@ fn write_child_hash_preserves_siblings() {
     let blob = sb.repo.write_blob(b"id = 2\n").unwrap().detach();
 
     let mut tree = MutableTree::new(base);
-    tree.write_child_hash(&sb.repo, "data/b.toml", blob, 0o100644)
+    tree.write_child_hash(&sb.ctx(), "data/b.toml", blob, 0o100644)
         .unwrap();
-    let new_hash = tree.write(&sb.repo).unwrap();
+    let new_hash = tree.write(&sb.ctx()).unwrap();
     assert_ne!(new_hash, base);
 
     let mut reloaded = MutableTree::new(new_hash);
     assert_eq!(
-        reloaded.read_blob(&sb.repo, "data/a.toml").unwrap().as_deref(),
+        reloaded.read_blob(&sb.ctx(), "data/a.toml").unwrap().as_deref(),
         Some(&b"id = 1\n"[..]),
         "existing sibling must be preserved",
     );
     assert_eq!(
-        reloaded.read_blob(&sb.repo, "data/b.toml").unwrap().as_deref(),
+        reloaded.read_blob(&sb.ctx(), "data/b.toml").unwrap().as_deref(),
         Some(&b"id = 2\n"[..]),
         "placed-by-hash blob must be present",
     );
@@ -208,14 +208,14 @@ fn write_child_hash_honors_executable_mode() {
 
     let mut regular = MutableTree::empty();
     regular
-        .write_child_hash(&sb.repo, "run", blob, 0o100644)
+        .write_child_hash(&sb.ctx(), "run", blob, 0o100644)
         .unwrap();
-    let regular_hash = regular.write(&sb.repo).unwrap();
+    let regular_hash = regular.write(&sb.ctx()).unwrap();
 
     let mut exec = MutableTree::empty();
-    exec.write_child_hash(&sb.repo, "run", blob, 0o100755)
+    exec.write_child_hash(&sb.ctx(), "run", blob, 0o100755)
         .unwrap();
-    let exec_hash = exec.write(&sb.repo).unwrap();
+    let exec_hash = exec.write(&sb.ctx()).unwrap();
 
     assert_ne!(
         regular_hash, exec_hash,
@@ -234,7 +234,7 @@ fn write_child_hash_rejects_missing_object() {
 
     let mut tree = MutableTree::empty();
     let err = tree
-        .write_child_hash(&sb.repo, "x", absent, 0o100644)
+        .write_child_hash(&sb.ctx(), "x", absent, 0o100644)
         .unwrap_err();
     // Per specs/api/errors.md: assert the stable code, never message text.
     assert_eq!(err.code(), "OBJECT_NOT_FOUND", "got {err:?}");
@@ -249,7 +249,7 @@ fn write_child_hash_rejects_non_blob() {
 
     let mut tree = MutableTree::empty();
     let err = tree
-        .write_child_hash(&sb.repo, "x", tree_oid, 0o100644)
+        .write_child_hash(&sb.ctx(), "x", tree_oid, 0o100644)
         .unwrap_err();
     // Wrong object kind is a caller error: INVALID_ARGUMENT (not message prose).
     assert_eq!(err.code(), "INVALID_ARGUMENT", "got {err:?}");
@@ -265,13 +265,13 @@ fn write_child_hash_rejects_invalid_mode() {
     let mut tree = MutableTree::empty();
     // 040000 is a tree mode, not valid for a blob entry.
     let err = tree
-        .write_child_hash(&sb.repo, "x", blob, 0o040000)
+        .write_child_hash(&sb.ctx(), "x", blob, 0o040000)
         .unwrap_err();
     assert_eq!(err.code(), "INVALID_ARGUMENT", "got {err:?}");
     // The tree must be untouched by a rejected call.
     assert_eq!(
-        tree.write(&sb.repo).unwrap(),
-        MutableTree::empty().write(&sb.repo).unwrap(),
+        tree.write(&sb.ctx()).unwrap(),
+        MutableTree::empty().write(&sb.ctx()).unwrap(),
         "a rejected write_child_hash must not mutate the tree",
     );
 }

--- a/plans/holo-tree-ffi-robustness.md
+++ b/plans/holo-tree-ffi-robustness.md
@@ -1,9 +1,11 @@
 ---
-status: in-progress
+status: done
 depends: []
 specs:
   - specs/principles.md
+  - specs/api/errors.md
 issues: []
+pr: 490
 ---
 
 # holo-tree FFI robustness
@@ -27,11 +29,11 @@ Make holo-tree safe to embed: no panics reachable from public entry points, stru
 
 ## Validation
 
-- [ ] `specs/api/errors.md` accepted and merged
-- [ ] No `.unwrap()`/`.expect()` reachable from public holo-tree entry points (audited; enforced where practical by lint)
-- [ ] `holo_tree::Error` discriminants are matchable across the napi boundary (test asserts an error kind, not a message substring)
-- [ ] A deliberately-injected panic in a debug test build surfaces as a catchable JS error, not a process abort
-- [ ] Tree cache correctness no longer depends on thread identity (test exercising cross-thread dispatch, or the design removes the possibility)
+- [x] `specs/api/errors.md` accepted and merged (authored spec-first in PR #490; merges with it)
+- [x] No `.unwrap()`/`.expect()` reachable from public holo-tree entry points (audited; enforced where practical by lint)
+- [x] `holo_tree::Error` discriminants are matchable across the napi boundary (test asserts an error kind, not a message substring)
+- [x] A deliberately-injected panic in a debug test build surfaces as a catchable JS error, not a process abort
+- [x] Tree cache correctness no longer depends on thread identity (test exercising cross-thread dispatch, or the design removes the possibility)
 - [ ] gitsheets consumes the new tag and drops at least one string-parsing/formatted-wrap workaround
 
 ## Risks / unknowns
@@ -41,8 +43,35 @@ Make holo-tree safe to embed: no panics reachable from public entry points, stru
 
 ## Notes
 
-_(populated at closeout)_
+- The gitsheets-consumption criterion stays unchecked: `holo-tree-v*` releases
+  are deferred, so no tag was cut and gitsheets still pins `holo-tree-v0.4.0`.
+  It closes out when the v0.5.0 tag ships and gitsheets adopts the coded
+  errors + `Context` API (see Follow-ups).
+- Root cause of the finding-#6 abort: napi-rs's `catch_unwind` is **opt-in
+  per exported fn** (`#[napi(catch_unwind)]`); without it a panic hits the
+  generated `extern "C"` trampoline, which cannot unwind → SIGABRT
+  (reproduced: exit 134). The binding now wraps every export body in its own
+  `contained()` guard (stable `PANIC` code) with the attribute as a backstop
+  for napi marshalling code.
+- napi-rs custom error status gotcha: the `#[napi]` macro detects `Result`
+  **syntactically** — signatures must literally spell
+  `Result<T, ErrorCode>`; a type alias compiles the macro into a
+  ToNapiValue bound error.
+- The cache redesign is hash- and counter-identical on emergence-site
+  (1,482 hits / 1,869 misses; hash `de630914…`, matching the JS engine on
+  current upstream HEAD — CLAUDE.md's `0dc5566e…` predates newer
+  codeforphilly.org commits) and measured faster warm (66–86 ms vs
+  125–250 ms baseline on the same clone).
+- `MutableTree`/`toml` taking `&Context` is a crate-level breaking change;
+  the npm binding's JS API is unchanged.
 
 ## Follow-ups
 
-_(populated at closeout)_
+- Tracked as: `holo-tree-v0.5.0` tag deferred (releases paused) — cutting it
+  and bumping gitsheets (typed-error mapping onto the new codes, `Context`
+  adoption, dropping its formatted-string wraps) is the downstream half of
+  findings #4/#5/#6.
+- Tracked as: extend the panic audit + `cfg_attr(not(test), warn(...))` lint
+  gate to holo-projector's public paths (its `walk_mappings`/projection
+  helpers still `.unwrap()`), before it ships behind an FFI binding — same
+  policy, `specs/api/errors.md` § Panic policy.

--- a/plans/holo-tree-ffi-robustness.md
+++ b/plans/holo-tree-ffi-robustness.md
@@ -1,5 +1,5 @@
 ---
-status: planned
+status: in-progress
 depends: []
 specs:
   - specs/principles.md

--- a/specs/README.md
+++ b/specs/README.md
@@ -15,6 +15,8 @@ specs/
 ├── README.md              # This file
 ├── principles.md          # Project-wide decisive principles
 ├── architecture.md        # Crates, engines, bindings, release tracks, migration strategy
+├── api/                   # Library/binding contracts
+│   └── errors.md          # holo-tree error codes, panic policy, thread-safety expectations
 └── behaviors/             # Cross-cutting rules
     └── composition.md     # Projection/composition semantics (the core operation)
 ```
@@ -23,7 +25,6 @@ Expected to grow as work touches each area (spec-on-contact):
 
 - `behaviors/lensing.md` — lens execution model (write before porting lensing to Rust)
 - `behaviors/source-resolution.md` — if source semantics grow beyond what `composition.md` covers
-- `api/errors.md` — the holo-tree/FFI error contract (write as part of FFI-robustness work)
 - `api/` — napi binding surfaces as they stabilize
 
 ## Workflow

--- a/specs/api/errors.md
+++ b/specs/api/errors.md
@@ -1,0 +1,144 @@
+# API: holo-tree error contract
+
+The failure contract for `holo-tree` as an **embedded library**: the stable error
+codes consumers match on, the panic policy that keeps a violated invariant from
+taking down a host process, and the thread-safety expectations embedding
+consumers can rely on (and must uphold).
+
+## Applies to
+
+- The `holo-tree` crate's public API (everything reachable from `holo_tree::*`).
+- The `@hologit/holo-tree` napi binding (`holo-tree-napi`), which is the same
+  contract projected onto JS: every failure is a catchable `Error` carrying a
+  stable `code` property.
+- `holo-projector` inherits the crate-level contract for the `holo_tree::Error`
+  variants it forwards (`holo_projector::Error::Tree`).
+
+This contract was driven by hostile-consumer review from gitsheets, the first
+embedded consumer (`gitsheets:notes/holo-tree-findings.md` findings #4, #5, #6).
+
+## Error codes
+
+Every `holo_tree::Error` exposes a **stable, machine-matchable code** via
+`Error::code()`. The napi binding surfaces the same code as the thrown JS
+error's `code` property. Codes — not message text — are the API.
+
+| Code | Rust variant | Raised when |
+| --- | --- | --- |
+| `GIT` | `Error::Git` | An underlying git operation (ODB read/write, ref edit, rev-parse, repo open) failed in a way holo-tree does not classify further. |
+| `OBJECT_NOT_FOUND` | `Error::ObjectNotFound` | An object id that was expected to exist in the ODB does not — e.g. placing a blob by hash (`write_child_hash`) when the hash is unknown, or loading a tree whose object dangles. |
+| `NOT_A_TREE` | `Error::NotATree` | An object or path component expected to be a tree is some other kind — e.g. writing through `a/b/c` when `a/b` is a blob, or navigating into a non-tree object. |
+| `PATH_NOT_FOUND` | `Error::PathNotFound` | A fixed path could not be fully navigated where existence is required (`create_tree_from_path`). Operations specced to return "absent" (`read_blob`, `get_child`, `resolve_ref`) signal absence with `None`/`null`, **not** with this error. |
+| `GLOB` | `Error::Glob` | A glob pattern failed to compile. |
+| `TOML` | `Error::Toml` | A TOML blob is non-UTF-8 or failed to parse. |
+| `INVALID_ARGUMENT` | `Error::InvalidArgument` | A caller-supplied value is malformed regardless of repository state: a non-hex object id, an invalid blob filemode, an unknown merge mode, an object of the wrong kind passed by hash, an unparseable signature. |
+| `REF_CONFLICT` | `Error::RefConflict` | A compare-and-swap `update_ref` (with `expected_old`) failed because the ref's current value is not the expected one — it moved, disappeared, or unexpectedly exists. The optimistic-concurrency signal. |
+| `INTERNAL` | `Error::Internal` | A holo-tree internal invariant was violated. Always a holo-tree bug — report it. Exists so a violated invariant degrades to a catchable error instead of a panic (see Panic policy). |
+| `PANIC` | *(binding only)* | A Rust panic was contained at the FFI boundary and converted to a JS error. Always a bug — report it. |
+
+### Stability rules
+
+- Codes are **append-only**. A code, once shipped, is never renamed, removed,
+  or reused with a different meaning. New failure classes get new codes.
+- An operation may move to a *more specific* code in a minor release (e.g. a
+  failure formerly reported as `GIT` starts reporting `OBJECT_NOT_FOUND`).
+  Consumers must treat `GIT` as the residual class, not an exhaustive one.
+- **Message text is not part of the contract.** Messages are human-readable
+  prose and may change freely. Consumers (and holo-tree's own tests) must match
+  on codes, never on message substrings.
+- The Rust variant's *fields* (e.g. `RefConflict.refname`) are part of the
+  crate API and follow semver; the JS surface exposes only `code` + `message`.
+
+### JS surface
+
+Every error thrown by the binding is an `instanceof Error` with:
+
+- `code` — one of the codes above (string).
+- `message` — human-readable prose, non-contractual.
+
+Errors raised by the binding's own marshalling (bad hex id, unknown merge mode,
+invalid signature time, u16 overflow on a mode) use `INVALID_ARGUMENT`; a repo
+that fails to open uses `GIT`.
+
+## Panic policy
+
+`holo-tree` is consumed across FFI boundaries by long-running host processes.
+Per [`principles.md#never-abort-a-host-process`](../principles.md#never-abort-a-host-process),
+**a panic that crosses a public entry point is a critical bug** — proven in
+production when a violated `get_or_create_subtree` invariant aborted a whole
+Node process (`fatal runtime error: failed to initiate panic`, gitsheets
+findings #1/#6).
+
+1. **No panicking constructs on public paths.** `.unwrap()`, `.expect()`,
+   panicking indexing (`[]` on collections), and `unreachable!()` must not be
+   reachable from any public crate entry point. Violated invariants return
+   `Error::Internal` (code `INTERNAL`) instead. A `debug_assert!` alongside the
+   graceful error is encouraged — loud in development, contained in release.
+2. **Provably-infallible exceptions are eliminated, not excused.** Where a
+   value is infallible by construction (a compile-time constant, a
+   fixed-format render), prefer an API that cannot fail (e.g. gix's
+   `ObjectId::empty_tree`) over `.expect()` with a proof comment. An
+   `.expect()` may remain only when no non-panicking construction exists, with
+   a comment proving why it cannot fire.
+3. **The binding contains residual panics.** Every function the napi binding
+   exports must convert a Rust panic into a catchable JS error carrying code
+   `PANIC` — never an unwind across the `extern "C"` boundary (which aborts
+   the process). This holds for release builds, and is verified by a test that
+   deliberately panics through the real binding.
+4. **After `INTERNAL` or `PANIC`, object state is unspecified.** The `Tree` /
+   `MutableTree` involved may be inconsistent (memory-safe, but logically
+   undefined); consumers should discard it and rebuild from a ref. The process
+   itself must remain healthy — that is the whole point.
+
+## Thread-safety expectations
+
+What the library **guarantees**:
+
+- **No correctness dependence on thread identity.** No `thread_local!` (or
+  other thread-implicit) state may influence results. All caching flows
+  through objects the consumer explicitly owns and passes (`TreeCache`, lent
+  to operations via a `Context` that binds it to a `gix::Repository`). A host
+  that dispatches successive calls of one logical operation onto different
+  threads gets identical results — at worst a cold cache, never a wrong one.
+- **Tree data is content-addressed, so a `TreeCache` is safe to reuse across
+  trees, operations, and even repositories**: entries are keyed by tree
+  `ObjectId`, and per
+  [`principles.md#a-content-addressed-key-captures-exactly-what-determines-the-output`](../principles.md#a-content-addressed-key-captures-exactly-what-determines-the-output)
+  the key fully determines the content. Reuse is a performance choice, never a
+  correctness risk.
+- Stats counters (`holo_tree::stats()`) are process-global, monotonic, and
+  approximate — metrics only, never inputs to behavior.
+
+What **hosts must uphold**:
+
+- `MutableTree`, `TreeCache`, and `Context` are single-threaded values: they
+  may be **moved** between threads (`Send`) but not **shared** concurrently
+  (`!Sync` where interior mutability exists). One logical operation uses one
+  of each at a time.
+- A `gix::Repository` is thread-local by design; to cross threads, hold a
+  `gix::ThreadSafeRepository` and derive a per-thread `Repository` (as the
+  napi binding does), constructing a fresh `Context` around it per call.
+- The napi binding's `Repo`/`Tree` objects may be called from whichever thread
+  the JS engine dispatches on; because each `Tree` owns its cache, correctness
+  never depends on which thread that is.
+
+## Principles
+
+**Inherited** — project principles from `principles.md` that especially bite here:
+
+- [Never abort a host process](../principles.md#never-abort-a-host-process) —
+  this spec is that principle operationalized: the code table is the "stable,
+  matchable discriminants" requirement; the panic policy is the "no panics
+  across public entry points" requirement.
+- [Rough edges get fixed upstream, not papered over in glue](../principles.md#rough-edges-get-fixed-upstream-not-papered-over-in-glue) —
+  consumers map codes onto their own typed errors; a consumer found parsing
+  message prose is a signal this contract is missing a code, and the fix is a
+  new code here, not a regex there.
+
+**Local**:
+
+- **Absence is a value, not an error.** Operations whose question is "is
+  something there?" (`read_blob`, `get_child`, `resolve_ref`, `get_subtree`)
+  answer absence with `None`/`null`. Errors are reserved for operations that
+  could not answer their question at all. This keeps consumer probe-loops
+  (does this record exist?) off the error path entirely.


### PR DESCRIPTION
Makes holo-tree safe to embed across FFI: no panics reachable from public entry points, structured error discriminants that survive the napi boundary, and no correctness dependence on thread-implicit state. This is the production-safety item behind gitsheets findings [#4, #5, #6](https://github.com/JarvusInnovations/gitsheets/blob/develop/notes/holo-tree-findings.md) — gitsheets links holo-tree as a Cargo crate under codeforphilly.org's API server, where a violated invariant today aborts the whole Node process.

Closes out `plans/holo-tree-ffi-robustness.md`, implementing `specs/principles.md#never-abort-a-host-process` via the new **`specs/api/errors.md`** contract (spec-first — first commit after the plan flip).

## The error contract (`specs/api/errors.md`)

Stable, append-only codes; message text is explicitly non-contractual. Tests assert on codes, never message substrings.

| Code | Raised when |
| --- | --- |
| `GIT` | Unclassified underlying git failure (the residual class) |
| `OBJECT_NOT_FOUND` | An object id expected in the ODB is absent (e.g. `writeChildHash` with an unknown hash) |
| `NOT_A_TREE` | A path component / object expected to be a tree isn't |
| `PATH_NOT_FOUND` | Fixed-path navigation failed where existence is required (`create_tree_from_path`) |
| `GLOB` | Glob pattern failed to compile |
| `TOML` | TOML blob non-UTF-8 / unparseable |
| `INVALID_ARGUMENT` | Malformed caller value: bad hex oid, invalid blob mode, unknown merge mode, wrong object kind by hash, bad signature |
| `REF_CONFLICT` | Compare-and-swap `update_ref` lost the race (moved / missing / unexpectedly exists) — the optimistic-concurrency signal |
| `INTERNAL` | Violated holo-tree invariant, degraded to a catchable error (always a bug) |
| `PANIC` | *(binding only)* A Rust panic contained at the FFI boundary (always a bug) |

The spec also pins the **panic policy** (no `.unwrap()`/`.expect()`/indexing/`unreachable!()` on public paths; provably-infallible cases eliminated rather than excused; object state unspecified-but-memory-safe after `INTERNAL`/`PANIC`) and the **thread-safety contract** (no thread-implicit state; caches are consumer-owned and content-addressed; what's `Send` vs `Sync`; hosts re-derive per-thread repos).

## Error mapping across FFI (finding #4)

**Before** — every failure collapsed to prose:

```rust
fn ht_err(e: holo_tree::Error) -> napi::Error {
    napi::Error::from_reason(e.to_string())
}
```

**After** — the stable code rides napi's custom error status and lands as the JS error's `code` property:

```rust
fn ht_err(e: holo_tree::Error) -> napi::Error<ErrorCode> {
    napi::Error::new(ErrorCode(e.code()), e.to_string())
}
```

```js
try { repo.updateRef('main', next, expectedOld); }
catch (err) { if (err.code === 'REF_CONFLICT') retry(); }
```

New crate variants: `ObjectNotFound`, `InvalidArgument`, `RefConflict` (gix's `ReferenceOutOfDate`/`MustExist`/`MustNotExist` prepare failures are classified; everything else stays `GIT`), `Internal`.

## Panic → catchable, proven (finding #6)

Root cause: napi-rs's `catch_unwind` is **opt-in per function** (`#[napi(catch_unwind)]`); without it a panic unwinds into the generated `extern "C"` trampoline, which cannot unwind → `panic_cannot_unwind` → SIGABRT. Reproduced locally on this branch's test hook with the guard removed: exit 134, core dumped — exactly the `fatal runtime error: failed to initiate panic` class from finding #6.

The fix is two layers:

- every export's body runs inside a `contained()` guard (`std::panic::catch_unwind`) that converts a panic into a catchable JS error with the specced code `PANIC`;
- `#[napi(catch_unwind)]` on every export as a backstop for panics in napi's own marshalling code.

`__triggerPanicForTest` panics through the real production wrapping; `test/errors.mjs` asserts it throws `instanceof Error` with `code === 'PANIC'` **and that the binding keeps working afterwards**. The crate side is audited (children accessors, merge's `unreachable!()` arms, `EntryMode` conversions, `default_signature` now built from parts, `empty_tree_id` uses gix's infallible constant) and enforced by `warn(clippy::unwrap_used, expect_used, indexing_slicing, panic, unreachable)` on non-test builds; violated invariants return `INTERNAL` with a `debug_assert!` for development loudness.

## Consumer-owned cache (finding #5)

The `thread_local!` tree cache is gone. Design:

- **`TreeCache`** — consumer-owned, keyed by tree `ObjectId`. Content-addressed per `principles.md`, so one cache is safe to reuse across trees, operations, and even repositories (there's a test that reads a tree through a `Context` over an *empty* repo purely from the travelled cache). `Send` but not `Sync`: it moves with the operation. `try_borrow` throughout — even a re-entrant borrow degrades to a cache miss, never a `RefCell` panic.
- **`Context<'_>`** — binds a `&gix::Repository` to a `&TreeCache`; all `MutableTree`/`toml` operations take `&Context`. Hosts that re-derive a per-thread repo (the binding's `to_thread_local()`) build a fresh `Context` per call around the long-lived cache.
- **holo-projector**: `project_branch`/`project_plan` keep their public signatures (fresh cache per run, shared by all recursive sub-projections) and gain `*_in` variants for callers that own a `Context`.
- **napi `Tree`** owns its `TreeCache`, closing the binding's recorded debt: whichever thread libuv dispatches on sees the same cache.
- `holo_tree::reset()` now resets stats only; caches are dropped/cleared by their owners.

`tests/thread_dispatch.rs` exercises one logical operation dispatched across two threads (load on A, mutate+write on B) with hash-identical results.

### Benchmark (emergence-site, codeforphilly.org clone, release CLI)

Both sides produce hash `de630914a864e71ea45d2c61fcdeaa4107a2cbb6` (verified equal to the JS engine on the same HEAD; the hash in CLAUDE.md predates upstream commits) and **identical cache profiles** — 1,869 trees read, 3,057 written, 1,482 hits / 1,869 misses:

| | before (thread-local) | after (Context/TreeCache) |
| --- | --- | --- |
| total, 8 warm runs | 125–250 ms (min 124.8) | 66–86 ms (min 66.3) |

No regression (the machine was noisier during the baseline runs; the identical ODB/cache counters are the load-independent evidence the cache behaves byte-equivalently). `docs-site` (`119fbb83…`) and `github-action-projector` (`f0843567…`) also project hash-identically before/after.

## Breaking change / downstream

`MutableTree`/`toml` APIs take `&Context` instead of `&gix::Repository` (crate-level; the npm binding's JS API is unchanged). Downstream adoption — gitsheets mapping the new codes onto its typed errors (dropping its formatted-string wraps) and bumping its pinned crate/npm dependency — is follow-up work gated on the deferred `holo-tree-v0.5.0` tag. **No tags are pushed by this PR.**

## Test counts

- `cargo test --workspace`: 82 passing (61 holo-tree — 8 new: 2 thread-dispatch, REF_CONFLICT ×2, code-stability +2, reclassified write_child_hash ×3 — plus 19 holo-projector, 2 doc/unit shells)
- holo-tree-napi `node --test`: 17 passing (6 new in `test/errors.mjs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5fwEknfSxpaGCVEME5D4h
