### PR TITLE
feat(holo-tree-napi): supported npm primitive — spec, README, #464 optimizations + bench

### DIFF
--- a/holo-tree-napi/README.md
+++ b/holo-tree-napi/README.md
@@ -1,29 +1,53 @@
-# holo-tree-napi
+# @hologit/holo-tree
 
-Node.js native binding for [`holo-tree`](../holo-tree) — mutable in-memory git
-trees via [gitoxide](https://github.com/GitoxideLabs/gitoxide), with no `git`
-subprocess.
+Git tree, ref, blob, and commit primitives for Node.js — a native binding over
+the [`holo-tree`](../holo-tree) Rust crate, powered by
+[gitoxide](https://github.com/GitoxideLabs/gitoxide).
 
-This crate exposes the narrow slice of holo-tree that record-oriented consumers
-(notably [gitsheets](https://github.com/JarvusInnovations/gitsheets)) need for an
-upsert→commit path. It is intentionally a thin pass-through; it is also the first
-integrated consumer of the new Rust libs, so it doubles as a hardening vehicle —
-rough edges in holo-tree's API are recorded as `Phase-C finding` notes in the
-source and fixed upstream rather than worked around here.
+- **No `git` binary.** Everything runs in-process through gix; nothing shells
+  out. Works anywhere Node runs, including environments with no git installed.
+- **Bare-repo native.** Operates directly on git object databases and refs —
+  no working directory, no index. A bare clone is a full-fledged store.
+- **Mutable in-memory trees.** Load a tree from any ref, upsert/delete/merge
+  paths against it in memory, then flush only the dirty subtrees to the ODB
+  and commit — the natural substrate for record stores, content pipelines, and
+  anything that treats a git repo as a database.
+- **Built for embedding.** Stable machine-matchable error codes, panic
+  containment at the FFI boundary (a Rust bug can never abort your process),
+  and no reliance on thread-implicit state.
 
-## API
+This package is a supported, standalone primitive — the Node-side consumption
+mode of the same crate that Rust consumers (e.g.
+[gitsheets](https://github.com/JarvusInnovations/gitsheets)) link directly via
+Cargo. Both modes ship from `holo-tree-v*` tags and implement the same
+contract (`specs/architecture.md` § Embedding consumers).
+
+## Install
+
+```sh
+npm install @hologit/holo-tree
+```
+
+Prebuilt release binaries ship as `optionalDependencies` for:
+linux-x64-gnu, linux-arm64-gnu, linux-x64-musl, darwin-arm64, darwin-x64,
+win32-x64-msvc (full matrix under [Publishing](#publishing)). No Rust
+toolchain needed on supported platforms.
+
+## Quick start
 
 ```js
 const { Repo, emptyTreeHash } = require('@hologit/holo-tree');
 
-const repo = Repo.open('/path/to/repo/.git');
+const repo = Repo.open('/path/to/repo.git'); // bare or .git dir
 
+// load HEAD's tree, upsert a record, commit, advance the branch
 const tree = repo.createTreeFromRef('HEAD'); // or repo.createTree() for empty
 tree.writeChild('data/widgets/1.toml', 'id = 1\n'); // hash blob + deep insert
 const treeHash = tree.write(); // flush dirty subtrees → ODB, returns tree hash
 
-const commit = repo.commitTree(treeHash, [parentHash], 'add widget 1');
-repo.updateRef('refs/heads/main', commit);
+const parent = repo.resolveRef('HEAD');
+const commit = repo.commitTree(treeHash, [parent], 'add widget 1');
+repo.updateRef('refs/heads/main', commit, parent); // compare-and-swap
 
 const bytes = repo.createTreeFromRef(commit).readBlob('data/widgets/1.toml');
 ```
@@ -31,19 +55,82 @@ const bytes = repo.createTreeFromRef(commit).readBlob('data/widgets/1.toml');
 Conventions: object ids cross the boundary as lowercase 40-char hex strings;
 blob content crosses as `Buffer` (binary-safe).
 
-### Surface
+## Errors: match on `code`, never on message
+
+Every failure is a catchable `Error` carrying a **stable `code` property** —
+codes, not message prose, are the API (messages may change freely). The
+contract, including the full code table and stability rules, is
+[`specs/api/errors.md`](../specs/api/errors.md).
+
+```js
+try {
+  repo.updateRef('refs/heads/main', commit, expectedParent);
+} catch (err) {
+  switch (err.code) {
+    case 'REF_CONFLICT': // someone else moved the ref — reload and retry
+      return retryTransaction();
+    case 'OBJECT_NOT_FOUND': // a hash you passed isn't in the ODB
+      throw new StoreCorruptError(err.message);
+    default:
+      throw err;
+  }
+}
+```
+
+Common codes: `REF_CONFLICT` (lost a compare-and-swap `updateRef` — the
+optimistic-concurrency signal), `OBJECT_NOT_FOUND`, `NOT_A_TREE`,
+`PATH_NOT_FOUND`, `INVALID_ARGUMENT` (malformed hex id, bad merge mode, …),
+`GIT` (unclassified git failure), `INTERNAL` / `PANIC` (always a holo-tree
+bug — report it; the process stays healthy, but discard the involved objects).
+
+Absence is a value, not an error: probes like `readBlob`, `getChild`, and
+`resolveRef` return `null` for "not there".
+
+## Performance — release builds only
+
+> **⚠️ Never benchmark or ship a debug build.** The published npm prebuilds
+> are release builds — `npm install` users are fine. But if you build from
+> source, `napi build` *without* `--release` produces a debug binary measured
+> **~2.4× slower** than the equivalent JS + `git` subprocess path on the
+> reference workload, while the same code built with `--release`
+> (`npm run build`) is **~4–5× faster**. A debug build silently inverts the
+> entire performance story. Check at runtime with `buildProfile()`, which
+> returns `'release'` or `'debug'` — the bundled benchmark refuses debug
+> builds.
+
+Reference workload (real data: an 18k-record flat tree — see
+[`bench/`](bench/)): single-record upsert→commit ~25ms vs ~100ms for the JS
+hologit + `git` subprocess path; 500 records in one commit ~41ms vs ~186ms.
+Reproduce with:
+
+```sh
+npm run build && node bench/holo-tree-bench.mjs
+```
+
+## Thread safety
+
+`Repo` is backed by a `gix::ThreadSafeRepository` and is safe to hold
+anywhere. Each `Tree` owns its own tree cache, so behavior never depends on
+which thread the JS engine dispatches a call on — at worst a thread switch
+costs cache warmth, never correctness (`specs/api/errors.md` § Thread-safety
+expectations). Objects are not shareable across `worker_threads` (each worker
+must `Repo.open` its own handle); within one JS thread, calls are synchronous
+and complete before returning.
+
+## Surface
 
 | Method | holo-tree call | Notes |
-|---|---|---|
-| `Repo.open(gitDir)` | `gix::open().into_sync()` | factory |
+| --- | --- | --- |
+| `Repo.open(gitDir)` | `gix::open().into_sync()` | factory; bare repo or `.git` dir |
 | `repo.createTreeFromRef(ref)` → `Tree` | `repo::create_tree_from_ref` | resolves ref→commit→tree |
 | `repo.createTree()` → `Tree` | `MutableTree::empty` | |
-| `repo.commitTree(treeHash, parents[], msg)` → hash | `repo::commit_tree` | uses git-config identity |
+| `repo.commitTree(treeHash, parents[], msg, author?, committer?)` → hash | `repo::commit_tree` | identities fall back to git config |
 | `repo.updateRef(ref, hash, expectedOldHash?)` | `repo::update_ref` | compare-and-swap when `expectedOldHash` given; force otherwise |
 | `repo.resolveRef(ref)` → `hash\|null` | `repo::resolve_ref` | peels tags; `null` if unresolved |
 | `repo.writeBlob(buf)` → hash | `gix write_blob` | hash bytes into the ODB, no tree |
 | `tree.writeChild(path, text)` → hash | `MutableTree::write_child` | UTF-8 text |
 | `tree.writeChildBytes(path, buf)` → hash | `MutableTree::write_child_bytes` | binary |
+| `tree.writeChildHash(path, hash, mode)` → hash | `MutableTree::write_child_hash` | graft an existing ODB blob without re-hashing |
 | `tree.readBlob(path)` → `Buffer\|null` | `MutableTree::read_blob` | |
 | `tree.getChild(path)` → `{type,hash,mode}\|null` | `MutableTree::get_child` | read-only; deep path |
 | `tree.getChildren(path)` → `[{name,type,hash,mode}]` | `get_subtree`+`ensure_children` | read-only; direct children |
@@ -51,13 +138,28 @@ blob content crosses as `Buffer` (binary-safe).
 | `tree.deleteChildDeep(path)` → bool | `MutableTree::delete_child_deep` | |
 | `tree.clearChildren(path)` | `MutableTree::clear_children` | O(1) subtree wipe |
 | `tree.merge(other, {files?, mode})` | `MutableTree::merge` | `mode`: `overlay`/`replace`/`underlay` |
-| `tree.write()` → treeHash | `MutableTree::write` | |
+| `tree.write()` → treeHash | `MutableTree::write` | flush dirty subtrees |
 | `emptyTreeHash()` → hash | `tree::empty_tree_id` | module fn |
+| `buildProfile()` → `'release'\|'debug'` | — | guard against debug builds |
 
-`mode` values are the git filemode as a number (e.g. `33188` = `0o100644`). Tree
-hashes reported by the read-only navigators reflect the last `write()`/load and
-are stale for a subtree mutated since — flush with `write()` for canonical
-hashes.
+`mode` values are the git filemode as a number (e.g. `33188` = `0o100644`).
+Tree hashes reported by the read-only navigators reflect the last
+`write()`/load and are stale for a subtree mutated since — flush with
+`write()` for canonical hashes.
+
+The binding is a deliberately thin marshalling shell: rough edges are fixed
+upstream in the `holo-tree` crate, never papered over here
+(`specs/principles.md`). New capability requests belong against the crate.
+
+## Origins
+
+This binding began as the integration vehicle for the gitsheets holo-tree
+spike — the first embedded consumer of the Rust crates. The `Phase-C finding`
+comments in the source record rough edges discovered during that hardening
+pass, each fixed upstream in holo-tree (error codes, panic containment, the
+consumer-owned tree cache). gitsheets has since moved to linking holo-tree
+directly as a Cargo crate; this package continues as the supported Node-side
+surface of the same crate.
 
 ## Building
 
@@ -65,8 +167,10 @@ Requires a Rust toolchain and `@napi-rs/cli` (a devDependency):
 
 ```sh
 npm install
-npm run build:debug   # or: npm run build   (release)
+npm run build         # release — use this for anything you'll measure or ship
+npm run build:debug   # debug — compile-fast, runs SLOW (see Performance)
 npm test              # node --test against a scratch git repo
+npm run bench         # release-build benchmark (refuses debug builds)
 ```
 
 `napi build` emits `holo-tree.<triple>.node`. The generated `index.js` loader
@@ -95,20 +199,20 @@ workflow builds all six on every PR touching the binding, and on a
 
 Auth is **npm trusted publishing (OIDC)** — no tokens, matching hologit's
 `publish-npm.yml`. Trusted publishing is configured *per package*, and a package
-can't get a trusted publisher until it exists — so the four packages need a
+can't get a trusted publisher until it exists — so the packages need a
 **one-time manual bootstrap** before automated releases work.
 
 ### One-time bootstrap (manual first publish, then configure trusted publishing)
 
-The four packages all start at an early version (currently `0.0.1`). They must
+The packages all start at an early version (currently `0.0.1`). They must
 exist on npm before trusted publishing can be turned on.
 
 1. **Get the prebuilt binaries.** Run the `holo-tree-napi` workflow (push the
-   branch / open a PR, or trigger `workflow_dispatch`) and download its three
+   branch / open a PR, or trigger `workflow_dispatch`) and download its
    `bindings-*` artifacts — they hold the `.node` for each platform. A single
-   machine can't build all three natively, so use the CI artifacts.
+   machine can't build all of them natively, so use the CI artifacts.
 
-2. **Publish all four manually**, logged in as an `@hologit` org member
+2. **Publish all packages manually**, logged in as an `@hologit` org member
    (`npm login`):
 
    ```sh
@@ -121,7 +225,7 @@ exist on npm before trusted publishing can be turned on.
                                                          # prepublish hook
    ```
 
-3. **Turn on trusted publishing** on npmjs.com for **each** of the four packages
+3. **Turn on trusted publishing** on npmjs.com for **each** of the packages
    → Settings → Trusted Publisher → GitHub Actions, repo
    `JarvusInnovations/hologit`, workflow `holo-tree-napi.yml`.
 
@@ -131,14 +235,14 @@ exist on npm before trusted publishing can be turned on.
 git tag holo-tree-v0.1.1 && git push origin holo-tree-v0.1.1
 ```
 
-The tag drives the published version; CI builds all three platforms, then
+The tag drives the published version; CI builds all platforms, then
 publishes via OIDC (provenance). No secret needed. The `holo-tree-v*` tag is the
 release marker — napi runs with `--skip-gh-release` so it does **not** create a
 bare `v<version>` GitHub release/tag (which would collide with hologit's own
-`v*` JS-package release namespace).
+`v*` JS-package release namespace). The same tag serves as the Cargo
+git-dependency pin for Rust consumers of the `holo-tree` crate.
 
 To add or drop a platform later, edit `napi.triples.additional` +
 `optionalDependencies` in `package.json`, run `napi create-npm-dir -t .`, add the
 matching matrix entry in the workflow, and (since it's a new package) bootstrap
-
-+ trust that one package too.
+- trust that one package too.

--- a/holo-tree-napi/bench/holo-tree-bench.mjs
+++ b/holo-tree-napi/bench/holo-tree-bench.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+// Benchmark harness for @hologit/holo-tree.
+//
+// Canonical workload (the reference shape from the gitsheets spike: an
+// 18k-record flat tree — see issue #464):
+//
+//   1. bulk-load N records into one flat directory, write, commit, advance ref
+//   2. single-record upsert→commit against the big tree
+//   3. 500-record batch upsert→commit
+//   4. read paths: full getBlobMap, and repeated deep readBlob
+//
+// Usage:
+//   npm run bench                 # requires a RELEASE build (npm run build)
+//   node bench/holo-tree-bench.mjs --records 18000 --json
+//   node bench/holo-tree-bench.mjs --allow-debug   # only to demo the penalty
+//
+// Debug builds are refused by default: a debug binding measures SLOWER than
+// the JS + git-subprocess path it replaces (~2.4x on this workload), so any
+// number it produces is disinformation. See README § Performance.
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+import { parseArgs } from 'node:util';
+
+const require = createRequire(import.meta.url);
+
+let binding;
+try {
+  binding = require('../index.js');
+} catch (err) {
+  console.error(`holo-tree-napi addon not built — run \`npm run build\` first.\n  cause: ${err.message}`);
+  process.exit(1);
+}
+const { Repo } = binding;
+
+const { values: opts } = parseArgs({
+  options: {
+    records: { type: 'string', default: process.env.HOLO_TREE_BENCH_RECORDS ?? '18000' },
+    iterations: { type: 'string', default: '20' },
+    json: { type: 'boolean', default: false },
+    'allow-debug': { type: 'boolean', default: false },
+  },
+});
+const N = Number(opts.records);
+const ITERS = Number(opts.iterations);
+
+// ── build-profile guard ─────────────────────────────────────────────────────
+
+const profile = typeof binding.buildProfile === 'function' ? binding.buildProfile() : 'unknown';
+if (profile !== 'release' && !opts['allow-debug']) {
+  console.error(
+    `refusing to benchmark a ${profile} build — its numbers invert the real story ` +
+      '(debug is slower than the JS path this binding replaces).\n' +
+      'Build with `npm run build` first, or pass --allow-debug to demo the penalty.',
+  );
+  process.exit(1);
+}
+
+// ── scratch repo ────────────────────────────────────────────────────────────
+
+function git(cwd, ...args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+const dir = mkdtempSync(join(tmpdir(), 'holo-tree-bench-'));
+git(dir, 'init', '-q', '--bare');
+process.on('exit', () => rmSync(dir, { recursive: true, force: true }));
+
+const repo = Repo.open(dir);
+const REF = 'refs/heads/bench';
+const SIG = { name: 'Bench', email: 'bench@example.com' };
+
+const record = (i, rev = 0) =>
+  `id = ${i}\nrev = ${rev}\nname = "Record ${i}"\nemail = "record-${i}@example.com"\nactive = ${i % 2 === 0}\n`;
+const recordPath = (i) => `people/${String(i).padStart(6, '0')}.toml`;
+
+// ── timing helpers ──────────────────────────────────────────────────────────
+
+const ms = (t0, t1) => Number(t1 - t0) / 1e6;
+
+function bench(name, iters, fn) {
+  fn(-1); // warmup, not recorded
+  const samples = [];
+  for (let i = 0; i < iters; i++) {
+    const t0 = process.hrtime.bigint();
+    fn(i);
+    samples.push(ms(t0, process.hrtime.bigint()));
+  }
+  samples.sort((a, b) => a - b);
+  const median = samples[Math.floor(samples.length / 2)];
+  const mean = samples.reduce((a, b) => a + b, 0) / samples.length;
+  return { name, iters, min: samples[0], median, mean, max: samples[samples.length - 1] };
+}
+
+// ── 1. bulk load: N records → write → commit → ref advance ─────────────────
+
+let rev = 0;
+const t0 = process.hrtime.bigint();
+{
+  const tree = repo.createTree();
+  for (let i = 0; i < N; i++) tree.writeChild(recordPath(i), record(i));
+  const treeHash = tree.write();
+  const commit = repo.commitTree(treeHash, [], `seed ${N} records`, SIG, SIG);
+  repo.updateRef(REF, commit);
+}
+const bulkLoadMs = ms(t0, process.hrtime.bigint());
+
+// ── 2–3. upsert→commit scenarios (each iteration advances the ref) ─────────
+
+function upsert(count, iter) {
+  const parent = repo.resolveRef(REF);
+  const tree = repo.createTreeFromRef(REF);
+  for (let k = 0; k < count; k++) {
+    const i = ((iter + 1) * 7919 + k * 104729) % N; // deterministic spread
+    tree.writeChild(recordPath(i), record(i, ++rev));
+  }
+  const treeHash = tree.write();
+  const commit = repo.commitTree(treeHash, [parent], `upsert ${count} (iter ${iter})`, SIG, SIG);
+  repo.updateRef(REF, commit, parent); // compare-and-swap
+}
+
+const results = [];
+results.push(bench('single upsert→commit', ITERS, (i) => upsert(1, i)));
+results.push(bench('500-record batch upsert→commit', Math.max(3, Math.floor(ITERS / 4)), (i) => upsert(500, i)));
+
+// ── 4. read paths ───────────────────────────────────────────────────────────
+
+results.push(
+  bench('getBlobMap (full tree, fresh Tree)', ITERS, () => {
+    const n = repo.createTreeFromRef(REF).getBlobMap().length;
+    if (n !== N) throw new Error(`blob map size ${n} != ${N}`);
+  }),
+);
+
+const READS = 200;
+results.push(
+  bench(`readBlob x${READS} (fresh Tree)`, ITERS, (i) => {
+    const tree = repo.createTreeFromRef(REF);
+    for (let k = 0; k < READS; k++) {
+      const idx = (k * 92821 + (i + 1) * 31) % N;
+      if (tree.readBlob(recordPath(idx)) === null) throw new Error(`missing record ${idx}`);
+    }
+  }),
+);
+
+const warmTree = repo.createTreeFromRef(REF);
+results.push(
+  bench(`readBlob x${READS} (warm Tree, repeated)`, ITERS, () => {
+    for (let k = 0; k < READS; k++) {
+      const idx = (k * 92821) % N;
+      if (warmTree.readBlob(recordPath(idx)) === null) throw new Error(`missing record ${idx}`);
+    }
+  }),
+);
+
+// ── report ──────────────────────────────────────────────────────────────────
+
+const meta = {
+  profile,
+  records: N,
+  node: process.version,
+  platform: `${process.platform}-${process.arch}`,
+};
+
+if (opts.json) {
+  console.log(JSON.stringify({ meta, bulkLoadMs, results }, null, 2));
+} else {
+  console.log(`holo-tree bench — ${meta.platform}, node ${meta.node}, build: ${profile}, records: ${N}`);
+  if (profile !== 'release') console.log('!! NON-RELEASE BUILD — numbers below are not representative !!');
+  console.log(`\nbulk load (${N} writeChild + write + commit + ref): ${bulkLoadMs.toFixed(1)}ms\n`);
+  const pad = Math.max(...results.map((r) => r.name.length));
+  console.log(`${'scenario'.padEnd(pad)}  iters  median      min     mean      max`);
+  for (const r of results) {
+    console.log(
+      `${r.name.padEnd(pad)}  ${String(r.iters).padStart(5)}  ` +
+        `${r.median.toFixed(2).padStart(6)}ms ${r.min.toFixed(2).padStart(6)}ms ` +
+        `${r.mean.toFixed(2).padStart(6)}ms ${r.max.toFixed(2).padStart(6)}ms`,
+    );
+  }
+}

--- a/holo-tree-napi/index.d.ts
+++ b/holo-tree-napi/index.d.ts
@@ -6,6 +6,16 @@
 /** Git's well-known empty-tree hash (`4b825dc6…`). */
 export declare function emptyTreeHash(): string
 /**
+ * The compile profile of the loaded binding: `"release"` or `"debug"`.
+ *
+ * The runtime guard for the release-build requirement (#464 item 4): a debug
+ * build of this binding measures *slower* than the JS + `git`-subprocess path
+ * it replaces (~2.4x on the reference workload), while a release build is
+ * ~4–5x faster. The bundled benchmark refuses to run against a debug build;
+ * consumers embedding a from-source build can use this to assert the same.
+ */
+export declare function buildProfile(): string
+/**
  * Internal self-test hook: deliberately panics inside the binding so the
  * test suite can prove that a panic surfaces as a catchable JS error with
  * code `PANIC` rather than aborting the host process (specs/api/errors.md
@@ -63,8 +73,9 @@ export interface MergeOpts {
  * A handle to a git repository, backed by gix.
  *
  * Stored as a `ThreadSafeRepository` so the handle is `Send + Sync` and can be
- * cheaply cloned into each `Tree`; every call derives a thread-local
- * `gix::Repository` via `to_thread_local()`.
+ * cheaply cloned into each `Tree`; calls use a memoized thread-local
+ * `gix::Repository` (see [`local_repo`]), re-derived only when a call lands
+ * on a different thread.
  */
 export declare class Repo {
   /**
@@ -118,7 +129,8 @@ export declare class Repo {
  * Owns its `TreeCache` (Phase-C finding #5): the cache travels with the
  * `Tree` object rather than living in thread-implicit state, so whichever
  * thread the JS engine dispatches a call on sees the same cache — see
- * `specs/api/errors.md` § Thread-safety expectations.
+ * `specs/api/errors.md` § Thread-safety expectations. Likewise owns its
+ * memoized thread-local repo derivation (see [`local_repo`]).
  */
 export declare class Tree {
   /**

--- a/holo-tree-napi/index.js
+++ b/holo-tree-napi/index.js
@@ -310,9 +310,10 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { emptyTreeHash, __triggerPanicForTest, Repo, Tree } = nativeBinding
+const { emptyTreeHash, buildProfile, __triggerPanicForTest, Repo, Tree } = nativeBinding
 
 module.exports.emptyTreeHash = emptyTreeHash
+module.exports.buildProfile = buildProfile
 module.exports.__triggerPanicForTest = __triggerPanicForTest
 module.exports.Repo = Repo
 module.exports.Tree = Tree

--- a/holo-tree-napi/package.json
+++ b/holo-tree-napi/package.json
@@ -45,7 +45,7 @@
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
     "prepublishOnly": "napi prepublish -t npm --skip-gh-release",
-    "test": "node --test \"test/*.mjs\"",
+    "test": "node --test test/errors.mjs test/ops.mjs test/smoke.mjs",
     "version": "napi version"
   },
   "devDependencies": {

--- a/holo-tree-napi/package.json
+++ b/holo-tree-napi/package.json
@@ -41,6 +41,7 @@
   },
   "scripts": {
     "artifacts": "napi artifacts",
+    "bench": "node bench/holo-tree-bench.mjs",
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
     "prepublishOnly": "napi prepublish -t npm --skip-gh-release",

--- a/holo-tree-napi/package.json
+++ b/holo-tree-napi/package.json
@@ -44,7 +44,7 @@
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
     "prepublishOnly": "napi prepublish -t npm --skip-gh-release",
-    "test": "node --test test/",
+    "test": "node --test \"test/*.mjs\"",
     "version": "napi version"
   },
   "devDependencies": {

--- a/holo-tree-napi/src/lib.rs
+++ b/holo-tree-napi/src/lib.rs
@@ -113,6 +113,22 @@ pub fn empty_tree_hash() -> String {
     oid_hex(empty_tree_id())
 }
 
+/// The compile profile of the loaded binding: `"release"` or `"debug"`.
+///
+/// The runtime guard for the release-build requirement (#464 item 4): a debug
+/// build of this binding measures *slower* than the JS + `git`-subprocess path
+/// it replaces (~2.4x on the reference workload), while a release build is
+/// ~4–5x faster. The bundled benchmark refuses to run against a debug build;
+/// consumers embedding a from-source build can use this to assert the same.
+#[napi(catch_unwind)]
+pub fn build_profile() -> String {
+    if cfg!(debug_assertions) {
+        "debug".to_string()
+    } else {
+        "release".to_string()
+    }
+}
+
 /// Internal self-test hook: deliberately panics inside the binding so the
 /// test suite can prove that a panic surfaces as a catchable JS error with
 /// code `PANIC` rather than aborting the host process (specs/api/errors.md

--- a/holo-tree-napi/src/lib.rs
+++ b/holo-tree-napi/src/lib.rs
@@ -129,6 +129,60 @@ pub fn build_profile() -> String {
     }
 }
 
+// ── per-thread repo derivation (memoized) ───────────────────────────────────
+
+/// gix object cache size applied to every derived thread-local repository.
+///
+/// gix leaves the object cache at size 0 unless set (#464 item 2); read-heavy
+/// paths (repeated `readBlob`, deep navigation) then decode the same objects
+/// redundantly. 16 MiB follows gix's own sizing guidance (~10 MB per 10k
+/// objects of typical source-repo shape). Memoizing the derived repo (below)
+/// is what makes the cache effective at all — a per-call derivation would
+/// start cold every time.
+const OBJECT_CACHE_BYTES: usize = 16 * 1024 * 1024;
+
+/// A `gix::Repository` derived on — and only ever *used* on — one thread.
+struct ThreadLocalRepo {
+    thread: std::thread::ThreadId,
+    repo: gix::Repository,
+}
+
+// The memoized handle may be *moved* between threads with its owning object
+// (napi may finalize on another thread), which requires `gix::Repository:
+// Send`. Usage stays confined to the recorded thread via `local_repo`.
+const _: () = {
+    const fn assert_send<T: Send>() {}
+    assert_send::<gix::Repository>();
+};
+
+fn derive_local(shared: &gix::ThreadSafeRepository) -> ThreadLocalRepo {
+    let mut repo = shared.to_thread_local();
+    repo.object_cache_size_if_unset(OBJECT_CACHE_BYTES);
+    ThreadLocalRepo {
+        thread: std::thread::current().id(),
+        repo,
+    }
+}
+
+/// Reuse the memoized thread-local `gix::Repository`, re-deriving if this call
+/// landed on a different thread than the memo (#464 item 1 — previously every
+/// call paid a fresh `to_thread_local()`).
+///
+/// Sound per `specs/api/errors.md` § Thread-safety expectations: the memo is
+/// keyed by thread id, so a handle is only ever used on the thread it was
+/// derived on, and a thread switch costs at most warmth (a re-derivation and a
+/// cold object cache) — never a behavioral difference.
+fn local_repo<'a>(
+    slot: &'a mut Option<ThreadLocalRepo>,
+    shared: &gix::ThreadSafeRepository,
+) -> &'a gix::Repository {
+    let tid = std::thread::current().id();
+    if !matches!(slot, Some(memo) if memo.thread == tid) {
+        *slot = None; // discard a handle derived on another thread
+    }
+    &slot.get_or_insert_with(|| derive_local(shared)).repo
+}
+
 /// Internal self-test hook: deliberately panics inside the binding so the
 /// test suite can prove that a panic surfaces as a catchable JS error with
 /// code `PANIC` rather than aborting the host process (specs/api/errors.md
@@ -181,11 +235,13 @@ fn to_gix_signature(sig: Signature) -> CodedResult<gix::actor::Signature> {
 /// A handle to a git repository, backed by gix.
 ///
 /// Stored as a `ThreadSafeRepository` so the handle is `Send + Sync` and can be
-/// cheaply cloned into each `Tree`; every call derives a thread-local
-/// `gix::Repository` via `to_thread_local()`.
+/// cheaply cloned into each `Tree`; calls use a memoized thread-local
+/// `gix::Repository` (see [`local_repo`]), re-derived only when a call lands
+/// on a different thread.
 #[napi]
 pub struct Repo {
     inner: gix::ThreadSafeRepository,
+    local: Option<ThreadLocalRepo>,
 }
 
 #[napi]
@@ -198,20 +254,21 @@ impl Repo {
             let inner = gix::open(&git_dir)
                 .map_err(|e| git_err(format!("failed to open repo at '{git_dir}': {e}")))?
                 .into_sync();
-            Ok(Repo { inner })
+            Ok(Repo { inner, local: None })
         })
     }
 
     /// Resolve a ref (branch, tag, or commit hash) to its tree and return a
     /// mutable, in-memory view of it.
     #[napi(catch_unwind)]
-    pub fn create_tree_from_ref(&self, git_ref: String) -> Result<Tree, ErrorCode> {
+    pub fn create_tree_from_ref(&mut self, git_ref: String) -> Result<Tree, ErrorCode> {
         contained(|| {
-            let local = self.inner.to_thread_local();
-            let inner = ht_repo::create_tree_from_ref(&local, &git_ref).map_err(ht_err)?;
+            let local = local_repo(&mut self.local, &self.inner);
+            let inner = ht_repo::create_tree_from_ref(local, &git_ref).map_err(ht_err)?;
             Ok(Tree {
                 repo: self.inner.clone(),
                 cache: TreeCache::new(),
+                local: None,
                 inner,
             })
         })
@@ -223,6 +280,7 @@ impl Repo {
         Tree {
             repo: self.inner.clone(),
             cache: TreeCache::new(),
+            local: None,
             inner: MutableTree::empty(),
         }
     }
@@ -232,7 +290,7 @@ impl Repo {
     /// identity, then a "holo-tree" default. Returns the new commit hash.
     #[napi(catch_unwind)]
     pub fn commit_tree(
-        &self,
+        &mut self,
         tree_hash: String,
         parents: Vec<String>,
         message: String,
@@ -240,7 +298,7 @@ impl Repo {
         committer: Option<Signature>,
     ) -> Result<String, ErrorCode> {
         contained(|| {
-            let local = self.inner.to_thread_local();
+            let local = local_repo(&mut self.local, &self.inner);
             let tree = parse_oid(&tree_hash)?;
             let parent_oids = parents
                 .iter()
@@ -249,7 +307,7 @@ impl Repo {
             let author = author.map(to_gix_signature).transpose()?;
             let committer = committer.map(to_gix_signature).transpose()?;
             let commit =
-                ht_repo::commit_tree(&local, tree, &parent_oids, &message, author, committer)
+                ht_repo::commit_tree(local, tree, &parent_oids, &message, author, committer)
                     .map_err(ht_err)?;
             Ok(oid_hex(commit))
         })
@@ -265,16 +323,16 @@ impl Repo {
     /// `expectedOldHash` to force the ref (the prior unconditional behavior).
     #[napi(catch_unwind)]
     pub fn update_ref(
-        &self,
+        &mut self,
         refname: String,
         hash: String,
         expected_old_hash: Option<String>,
     ) -> Result<(), ErrorCode> {
         contained(|| {
-            let local = self.inner.to_thread_local();
+            let local = local_repo(&mut self.local, &self.inner);
             let oid = parse_oid(&hash)?;
             let expected = expected_old_hash.as_deref().map(parse_oid).transpose()?;
-            ht_repo::update_ref(&local, &refname, oid, expected).map_err(ht_err)
+            ht_repo::update_ref(local, &refname, oid, expected).map_err(ht_err)
         })
     }
 
@@ -283,10 +341,10 @@ impl Repo {
     /// resolve — the natural "does this ref exist?" probe before a CAS
     /// `updateRef`.
     #[napi(catch_unwind)]
-    pub fn resolve_ref(&self, git_ref: String) -> Result<Option<String>, ErrorCode> {
+    pub fn resolve_ref(&mut self, git_ref: String) -> Result<Option<String>, ErrorCode> {
         contained(|| {
-            let local = self.inner.to_thread_local();
-            let oid = ht_repo::resolve_ref(&local, &git_ref).map_err(ht_err)?;
+            let local = local_repo(&mut self.local, &self.inner);
+            let oid = ht_repo::resolve_ref(local, &git_ref).map_err(ht_err)?;
             Ok(oid.map(oid_hex))
         })
     }
@@ -294,9 +352,9 @@ impl Repo {
     /// Hash raw bytes as a loose blob in the ODB and return its hash, without
     /// inserting it into any tree. Binary-safe.
     #[napi(catch_unwind)]
-    pub fn write_blob(&self, content: Buffer) -> Result<String, ErrorCode> {
+    pub fn write_blob(&mut self, content: Buffer) -> Result<String, ErrorCode> {
         contained(|| {
-            let local = self.inner.to_thread_local();
+            let local = local_repo(&mut self.local, &self.inner);
             let oid = local
                 .write_blob(content.as_ref())
                 .map_err(git_err)?
@@ -369,11 +427,13 @@ fn classify(child: &holo_tree::Child) -> (&'static str, String, u32) {
 /// Owns its `TreeCache` (Phase-C finding #5): the cache travels with the
 /// `Tree` object rather than living in thread-implicit state, so whichever
 /// thread the JS engine dispatches a call on sees the same cache — see
-/// `specs/api/errors.md` § Thread-safety expectations.
+/// `specs/api/errors.md` § Thread-safety expectations. Likewise owns its
+/// memoized thread-local repo derivation (see [`local_repo`]).
 #[napi]
 pub struct Tree {
     repo: gix::ThreadSafeRepository,
     cache: TreeCache,
+    local: Option<ThreadLocalRepo>,
     inner: MutableTree,
 }
 
@@ -384,8 +444,8 @@ impl Tree {
     #[napi(catch_unwind)]
     pub fn write_child(&mut self, path: String, content: String) -> Result<String, ErrorCode> {
         contained(|| {
-            let local = self.repo.to_thread_local();
-            let ctx = Context::new(&local, &self.cache);
+            let local = local_repo(&mut self.local, &self.repo);
+            let ctx = Context::new(local, &self.cache);
             let oid = self
                 .inner
                 .write_child(&ctx, &path, &content)
@@ -398,8 +458,8 @@ impl Tree {
     #[napi(catch_unwind)]
     pub fn write_child_bytes(&mut self, path: String, content: Buffer) -> Result<String, ErrorCode> {
         contained(|| {
-            let local = self.repo.to_thread_local();
-            let ctx = Context::new(&local, &self.cache);
+            let local = local_repo(&mut self.local, &self.repo);
+            let ctx = Context::new(local, &self.cache);
             let oid = self
                 .inner
                 .write_child_bytes(&ctx, &path, content.as_ref())
@@ -422,8 +482,8 @@ impl Tree {
         mode: u32,
     ) -> Result<String, ErrorCode> {
         contained(|| {
-            let local = self.repo.to_thread_local();
-            let ctx = Context::new(&local, &self.cache);
+            let local = local_repo(&mut self.local, &self.repo);
+            let ctx = Context::new(local, &self.cache);
             let oid = parse_oid(&hash)?;
             let mode =
                 u16::try_from(mode).map_err(|_| invalid_arg(format!("invalid blob mode {mode:o}")))?;
@@ -438,8 +498,8 @@ impl Tree {
     #[napi(catch_unwind)]
     pub fn read_blob(&mut self, path: String) -> Result<Option<Buffer>, ErrorCode> {
         contained(|| {
-            let local = self.repo.to_thread_local();
-            let ctx = Context::new(&local, &self.cache);
+            let local = local_repo(&mut self.local, &self.repo);
+            let ctx = Context::new(local, &self.cache);
             let bytes = self.inner.read_blob(&ctx, &path).map_err(ht_err)?;
             Ok(bytes.map(Buffer::from))
         })
@@ -450,8 +510,8 @@ impl Tree {
     #[napi(catch_unwind)]
     pub fn get_child(&mut self, path: String) -> Result<Option<ChildInfo>, ErrorCode> {
         contained(|| {
-            let local = self.repo.to_thread_local();
-            let ctx = Context::new(&local, &self.cache);
+            let local = local_repo(&mut self.local, &self.repo);
+            let ctx = Context::new(local, &self.cache);
             let info = self
                 .inner
                 .get_child(&ctx, &path)
@@ -473,8 +533,8 @@ impl Tree {
     #[napi(catch_unwind)]
     pub fn get_children(&mut self, path: String) -> Result<Vec<NamedChildInfo>, ErrorCode> {
         contained(|| {
-            let local = self.repo.to_thread_local();
-            let ctx = Context::new(&local, &self.cache);
+            let local = local_repo(&mut self.local, &self.repo);
+            let ctx = Context::new(local, &self.cache);
             let subtree = match self.inner.get_subtree(&ctx, &path).map_err(ht_err)? {
                 Some(t) => t,
                 None => return Ok(vec![]),
@@ -500,8 +560,8 @@ impl Tree {
     #[napi(catch_unwind)]
     pub fn get_blob_map(&mut self, path: Option<String>) -> Result<Vec<BlobEntry>, ErrorCode> {
         contained(|| {
-            let local = self.repo.to_thread_local();
-            let ctx = Context::new(&local, &self.cache);
+            let local = local_repo(&mut self.local, &self.repo);
+            let ctx = Context::new(local, &self.cache);
             let path = path.unwrap_or_else(|| ".".to_string());
             let map = match self.inner.get_subtree(&ctx, &path).map_err(ht_err)? {
                 Some(subtree) => subtree.get_blob_map(&ctx).map_err(ht_err)?,
@@ -523,8 +583,8 @@ impl Tree {
     #[napi(catch_unwind)]
     pub fn delete_child_deep(&mut self, path: String) -> Result<bool, ErrorCode> {
         contained(|| {
-            let local = self.repo.to_thread_local();
-            let ctx = Context::new(&local, &self.cache);
+            let local = local_repo(&mut self.local, &self.repo);
+            let ctx = Context::new(local, &self.cache);
             self.inner.delete_child_deep(&ctx, &path).map_err(ht_err)
         })
     }
@@ -536,8 +596,8 @@ impl Tree {
     #[napi(catch_unwind)]
     pub fn clear_children(&mut self, path: String) -> Result<(), ErrorCode> {
         contained(|| {
-            let local = self.repo.to_thread_local();
-            let ctx = Context::new(&local, &self.cache);
+            let local = local_repo(&mut self.local, &self.repo);
+            let ctx = Context::new(local, &self.cache);
             self.inner.clear_children(&ctx, &path).map_err(ht_err)
         })
     }
@@ -548,8 +608,8 @@ impl Tree {
     #[napi(catch_unwind)]
     pub fn merge(&mut self, other: &mut Tree, options: MergeOpts) -> Result<(), ErrorCode> {
         contained(|| {
-            let local = self.repo.to_thread_local();
-            let ctx = Context::new(&local, &self.cache);
+            let local = local_repo(&mut self.local, &self.repo);
+            let ctx = Context::new(local, &self.cache);
             let mode = match options.mode.as_str() {
                 "overlay" => holo_tree::MergeMode::Overlay,
                 "replace" => holo_tree::MergeMode::Replace,
@@ -572,8 +632,8 @@ impl Tree {
     #[napi(catch_unwind)]
     pub fn write(&mut self) -> Result<String, ErrorCode> {
         contained(|| {
-            let local = self.repo.to_thread_local();
-            let ctx = Context::new(&local, &self.cache);
+            let local = local_repo(&mut self.local, &self.repo);
+            let ctx = Context::new(local, &self.cache);
             let oid = self.inner.write(&ctx).map_err(ht_err)?;
             Ok(oid_hex(oid))
         })

--- a/holo-tree-napi/test/smoke.mjs
+++ b/holo-tree-napi/test/smoke.mjs
@@ -45,6 +45,12 @@ test('emptyTreeHash matches git’s well-known empty tree', () => {
   assert.equal(emptyTreeHash(), '4b825dc642cb6eb9a060e54bf8d69288fbee4904');
 });
 
+test('buildProfile reports the compile profile', () => {
+  // The value depends on how the addon was built; the contract is that it is
+  // exactly one of the two profile strings (README § Performance).
+  assert.ok(['release', 'debug'].includes(binding.buildProfile()));
+});
+
 test('upsert→commit round-trips and advances the ref', () => {
   const dir = scratchRepo();
   try {

--- a/plans/holo-tree-napi-direction.md
+++ b/plans/holo-tree-napi-direction.md
@@ -1,9 +1,10 @@
 ---
-status: in-progress
+status: done
 depends: [holo-tree-ffi-robustness]
 specs:
   - specs/architecture.md
 issues: [464]
+pr: 491
 ---
 
 # Decide @hologit/holo-tree's direction, then take the optimization paths that fit
@@ -24,9 +25,9 @@ The napi binding's designed consumer (gitsheets) now links holo-tree as a Cargo 
 
 ## Validation
 
-- [ ] `specs/architecture.md` updated with the binding's declared role
-- [ ] #464 either executed (benchmarked improvement recorded) or closed with rationale
-- [ ] npm package README states its support posture
+- [x] `specs/architecture.md` updated with the binding's declared role
+- [x] #464 either executed (benchmarked improvement recorded) or closed with rationale
+- [x] npm package README states its support posture
 
 ## Risks / unknowns
 
@@ -34,8 +35,14 @@ The napi binding's designed consumer (gitsheets) now links holo-tree as a Cargo 
 
 ## Notes
 
-_(populated at closeout)_
+- **Decision: supported standalone npm primitive** (maintainer call — multiple npm consumers planned on it). Both consumption modes (Cargo git-tag pins, npm binding) are first-class surfaces of the same crate; recorded in `specs/architecture.md` § Embedding consumers / § Release tracks, with pre-1.0 semver posture. The freeze branch of the Approach was not taken, so the download-stats check was moot.
+- **#464 re-audit against post-#490 reality**: items 1 (per-call `to_thread_local()`) and 2 (gix object cache off) were still open and got executed — memoized thread-id-keyed repo derivation per `Repo`/`Tree` + 16 MiB `object_cache_size_if_unset`; item 3 (`cache_read` vec clone) turned out resolved-by-design after #490 (one clone per node per Tree lifetime, immediately consumed); item 4 became README warning + `buildProfile()` guard + bench refusing debug builds.
+- Item 2 depends on item 1: with per-call derivation the object cache was always cold — enabling it alone would have been a no-op. The dependency this plan declared on the cache redesign paid off the same way.
+- Headline numbers (18k-record reference workload, release, min-of-20): warm-tree `readBlob` ×200 11.2ms → 0.69ms (16×); batch-500 upsert −12%; bulk load −19%; full table in PR #491 and the #464 comment. Fresh debug-build measurements (~7–15× slower than release) re-confirmed the spike's warning with current code.
+- The soundness rule for the memoization (thread-id-keyed reuse; a handle never *used* off its deriving thread) was added to `specs/api/errors.md` § Thread-safety expectations *before* the code change — it generalizes to any future binding (pyo3).
+- Incidental: `node --test test/` (trailing-slash dir form) broke on newer Node 22.x; `npm test` now passes an explicit glob.
+- Publication of all of this rides the next `holo-tree-v*` tag, deferred with the release train.
 
 ## Follow-ups
 
-_(populated at closeout)_
+- Tracked as: `holo-tree-v*` release tag for the improved binding — deferred with the release train; cut per `holo-tree-napi/README.md` § Releases when trains resume.

--- a/plans/holo-tree-napi-direction.md
+++ b/plans/holo-tree-napi-direction.md
@@ -1,5 +1,5 @@
 ---
-status: planned
+status: in-progress
 depends: [holo-tree-ffi-robustness]
 specs:
   - specs/architecture.md

--- a/specs/api/errors.md
+++ b/specs/api/errors.md
@@ -118,6 +118,12 @@ What **hosts must uphold**:
 - A `gix::Repository` is thread-local by design; to cross threads, hold a
   `gix::ThreadSafeRepository` and derive a per-thread `Repository` (as the
   napi binding does), constructing a fresh `Context` around it per call.
+  Memoizing the derived `Repository` **keyed by thread id** is a sound warmth
+  optimization: a call landing on the memoized thread reuses the handle; a
+  call landing on any other thread re-derives. Results never depend on which
+  thread a call lands on — only warmth does — which is exactly the guarantee
+  above. (A memoized handle must never be *used* from a thread other than the
+  one it was derived on.)
 - The napi binding's `Repo`/`Tree` objects may be called from whichever thread
   the JS engine dispatches on; because each `Tree` owns its cache, correctness
   never depends on which thread that is.

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -11,7 +11,7 @@ The project is mid-migration from a Node.js engine to a Rust core. Both engines 
 | `lib/` + `commands/` + `bin/cli.js` | Node.js (CJS) | The shipping CLI (`git holo`). Sole owner of lensing, remote source fetching, watch mode, projection commits, and the studio. |
 | `holo-tree/` | Rust | Shared mutable git-tree primitives over gix: merge (overlay/replace/underlay), glob, blob/commit/ref ops, tree cache. Consumed by holo-projector and, as a Cargo git-tag dependency, by gitsheets-core. |
 | `holo-projector/` | Rust | The projection engine: `.holo/` config parsing, source resolution, mapping toposort, recursive sub-projection, composition. Pure — no network, containers, or ref writes. Benchmark CLI behind the `cli` feature. |
-| `holo-tree-napi/` | Rust (napi-rs) | Node binding over holo-tree only (tree/ref/blob CRUD), published to npm as `@hologit/holo-tree`. Does **not** expose projection. |
+| `holo-tree-napi/` | Rust (napi-rs) | Node binding over holo-tree only (tree/ref/blob CRUD), published to npm as `@hologit/holo-tree` — a supported standalone primitive for Node consumers (see Embedding consumers). Does **not** expose projection. |
 
 The three Rust crates form a Cargo workspace at the repo root.
 
@@ -26,14 +26,24 @@ The migration proceeds capability-by-capability, pure core outward (see [princip
 
 ## Embedding consumers
 
-holo-tree is a substrate for external git-backed systems. The reference consumer is **gitsheets** (`gitsheets-core` links holo-tree via Cargo git tags, `holo-tree-v*`). Embedding imposes the FFI robustness requirements in [principles.md — never abort a host process](principles.md#never-abort-a-host-process): no panics on public paths, structured error discriminants, and no reliance on thread-implicit state under host-controlled thread dispatch (napi/libuv, pyo3).
+holo-tree is a substrate for external git-backed systems, consumed in **two first-class modes** — both are supported surfaces of the same crate, neither is a stepping-stone for the other:
+
+- **Cargo git-dependency** — Rust consumers pin holo-tree directly via `holo-tree-v*` git tags. The reference consumer is **gitsheets** (`gitsheets-core`).
+- **npm `@hologit/holo-tree`** — the napi binding, a **supported standalone primitive** for Node consumers: git tree/ref/blob/commit operations on bare or normal repos with no `git` binary. It began as gitsheets' integration vehicle; it now stands on its own as the substrate for Node-side git-backed systems, with its own support posture, performance story, and optimization backlog (#464).
+
+Both modes implement the same contract:
+
+- The **error contract** in [api/errors.md](api/errors.md): stable machine-matchable codes (append-only), panic containment at the FFI boundary, and the thread-safety guarantees consumers rely on.
+- The FFI robustness requirements in [principles.md — never abort a host process](principles.md#never-abort-a-host-process): no panics on public paths, structured error discriminants, and no reliance on thread-implicit state under host-controlled thread dispatch (napi/libuv, pyo3).
+
+**Semver posture (npm binding)**: while the package is pre-1.0, breaking changes to the JS surface (removed/renamed methods, changed shapes) bump the minor version; additive changes and fixes bump the patch. Error codes are append-only regardless of version, per the stability rules in [api/errors.md](api/errors.md). The binding must ship as a release build — a debug build inverts its performance advantage (documented prominently in `holo-tree-napi/README.md`).
 
 ## Release tracks
 
 Two independent npm packages ship from this repo on prefix-namespaced git-tag tracks:
 
 - **`hologit`** (Node CLI/library) — `v*` tags via the develop→master Release-PR flow.
-- **`@hologit/holo-tree`** (napi binding) — `holo-tree-v*` tags; the same tags serve as Cargo git-dependency pins for Rust consumers. Never tag the binding with a bare `v*`.
+- **`@hologit/holo-tree`** (napi binding) — `holo-tree-v*` tags. One tag serves **both** consumption modes: it triggers the npm publish (platform prebuilds + trusted publishing) *and* is the Cargo git-dependency pin Rust consumers reference. Never tag the binding with a bare `v*`.
 
 The `actions/projector/v1` ref publishes the GitHub Action consumers use to project holobranches in CI.
 


### PR DESCRIPTION
## The decision (recorded, spec-first)

**`@hologit/holo-tree` is a supported, standalone npm primitive** — not a frozen stepping-stone. gitsheets moving to the Cargo-direct mode makes both consumption modes first-class surfaces of the same crate: Cargo git-dependency pins and the npm binding both ship from `holo-tree-v*` tags and implement the same error/thread-safety contract (`specs/api/errors.md`). Recorded in `specs/architecture.md` (§ Embedding consumers, § Release tracks), with a stated pre-1.0 semver posture.

Executes `plans/holo-tree-napi-direction.md` (#464).

## Spec changes

- `specs/architecture.md` — the binding's declared role: supported public primitive, two first-class consumption modes, one `holo-tree-v*` tag serving both npm publish and Cargo pins, semver posture, error-contract pointer, release-build requirement.
- `specs/api/errors.md` — thread-safety host expectations amended to cover **thread-id-keyed memoization** of the derived `gix::Repository`: reuse only on the deriving thread, re-derive on a thread switch — thread identity affects warmth, never results. This is the soundness basis for the perf change below.

## README repositioning

`holo-tree-napi/README.md` now leads for an external npm consumer: what it is (tree/ref/blob/commit primitives, no `git` binary, bare-repo native), install + prebuild coverage, quick start, **catch-and-match error-code example**, a prominent **release-build warning**, the thread-safety story, and the refreshed surface table (`writeChildHash` was missing). The Phase-C hardening history is now a short "Origins" note instead of the lead.

## #464 re-audit (post-#490) and execution

| # | Item | Post-#490 status | Action here |
| --- | --- | --- | --- |
| 1 | Per-call `to_thread_local()` | Still open — every method paid a fresh derivation | **Executed**: `Repo` and `Tree` memoize the derived repo keyed by thread id (`gix::Repository: Send` compile-asserted for the cross-thread-move case) |
| 2 | gix object cache default-disabled | Still open — and pointless before memoization (per-call derivation = always-cold cache) | **Executed**: 16 MiB `object_cache_size_if_unset` on every derived repo |
| 3 | `cache_read` full-vec clone | **Effectively resolved by design post-#490**: `TreeCache::read` clones at most once per node per `Tree` lifetime (`ensure_children` early-returns once loaded), and the clone is immediately consumed building the mutable `BTreeMap` — an `Rc`/`Arc` handle would still pay per-entry clones there. Not a per-access cost. | No code change; recorded on #464 |
| 4 | Release-build guidance | Open (doc gap) | **Executed**: README warning, `buildProfile()` runtime guard, bench refuses debug builds |

## Numbers

`bench/holo-tree-bench.mjs` (new; `npm run bench`) on the reference workload — 18k-record flat tree, linux-x64, quiet machine, min of 20 iterations:

| Scenario | Before (release) | After (release) | Δ | Debug build (after) |
| --- | --- | --- | --- | --- |
| bulk load 18k records → commit | 4353ms | 3510ms | −19% | 22053ms |
| single upsert→commit→ref | 47.8ms | 46.6ms | ~flat¹ | 701ms |
| 500-record batch upsert→commit | 152ms | 134ms | −12% | 1119ms |
| getBlobMap (18k entries) | 85ms | 72ms | −16% | 328ms |
| readBlob ×200 (fresh Tree) | 32ms | 24.0ms | −25% | 182ms |
| readBlob ×200 (warm Tree) | 11.2ms | **0.69ms** | **−94% (16×)** | 4.4ms |

¹ Single upsert on an 18k flat directory is dominated by serializing/hashing the ~800KB `people` tree object; one saved derivation is noise there.

**Debug vs release, called out explicitly:** the debug build is ~7–15× slower than release across scenarios (e.g. single upsert 701ms vs 46.6ms) — consistent with the spike's finding that a debug binding is *slower than the JS path it replaces*. That's why the warning is now unmissable in the README, `buildProfile()` exposes the profile at runtime, and the bench refuses debug builds without `--allow-debug`.

## Also

- `fix(holo-tree-napi)`: `npm test` now passes an explicit glob — `node --test test/` (trailing-slash dir) fails to resolve on newer Node 22.x.
- New smoke test for `buildProfile()`; napi suite 18/18, `cargo test` workspace green, clippy clean for the touched crates.

## Release note

Publication of these improvements rides the next `holo-tree-v*` tag, which is **deferred** with the release train — nothing here tags or publishes.

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01KeX12EPyjmRvqDzvB7Vn11>
