### PR TITLE
feat(holo-projector): projection-commit creation with oracle byte parity

### DIFF
--- a/holo-projector/src/commit.rs
+++ b/holo-projector/src/commit.rs
@@ -1,0 +1,344 @@
+//! Projection-commit creation: wrap a composed output tree in a git commit
+//! and advance a target ref.
+//!
+//! This is an explicit **edge capability** layered on pure composition —
+//! `project_branch` never writes refs or commits; hosts that want a
+//! projection committed call [`commit_projection`] with the composed tree.
+//! The commit's bytes are a pure function of the declared inputs, matching
+//! the legacy JS engine byte-for-byte (`specs/behaviors/projection-commits.md`).
+
+use std::borrow::Cow;
+
+use gix::ObjectId;
+
+use crate::error::{Error, Result};
+
+/// Maximum symbolic-ref links to follow when resolving the target ref
+/// (mirrors git's own symref depth limit).
+const MAX_SYMREF_DEPTH: usize = 10;
+
+/// Where a projection was taken from — decides the message's `from` clause
+/// and whether the ref-mode trailers (`Source-commit`, `Source`) are emitted.
+#[derive(Debug, Clone, Copy)]
+pub enum ProjectionSource<'a> {
+    /// Projected from a committed ref. `description` is the host-computed
+    /// provenance string — the oracle CLI uses `git describe --always --tags
+    /// <ref>` — and is treated as opaque: the engine never derives it, per
+    /// the spec's "provenance strings are inputs, not derivations".
+    Described { description: &'a str },
+    /// Projected from a working tree at `path`. The path appears in the
+    /// message's `from` clause; the ref-mode trailers are omitted (only
+    /// `Source-holobranch` is emitted).
+    WorkTree { path: &'a str },
+}
+
+/// Options for [`commit_projection`].
+#[derive(Debug, Clone)]
+pub struct CommitProjectionOptions<'a> {
+    /// Target ref to advance (the oracle's `commitTo`). Normalized per the
+    /// spec: `HEAD` passes through (and is dereferenced through symbolic
+    /// refs, so the branch HEAD points at is what advances), names starting
+    /// with `refs/` pass through, anything else becomes `refs/heads/<name>`.
+    pub commit_ref: &'a str,
+    /// The projected holobranch's name (message subject and
+    /// `Source-holobranch` trailer).
+    pub holobranch: &'a str,
+    /// The composed output tree to commit.
+    pub tree: ObjectId,
+    /// The source commit the projection was taken from; becomes the second
+    /// parent when present (in both ref and working-tree modes) and the
+    /// `Source-commit` trailer (ref mode only).
+    pub source_commit: Option<ObjectId>,
+    /// Provenance of the projection (ref mode vs. working-tree mode).
+    pub source: ProjectionSource<'a>,
+    /// Message override. Replaces the **entire** default message — subject
+    /// and all trailers (oracle quirk, ported). Parents are unaffected.
+    pub message: Option<&'a str>,
+    /// Explicit author; falls back to the repository's configured identity
+    /// (git config / `GIT_AUTHOR_*` env), then holo-tree's default. Pass an
+    /// explicit signature to reproduce a commit bit-for-bit.
+    pub author: Option<gix::actor::Signature>,
+    /// Explicit committer; same fallback chain as `author`.
+    pub committer: Option<gix::actor::Signature>,
+}
+
+/// Create a projection commit for a composed output tree and advance the
+/// target ref to it (`specs/behaviors/projection-commits.md`).
+///
+/// - **First parent**: the target ref's current value. When the ref does not
+///   resolve, a dangling **init commit** (empty tree, no parents,
+///   `↥ initialized <holobranch>`) is created and used instead; the ref
+///   itself advances directly to the projection commit.
+/// - **Second parent**: `source_commit`, when supplied.
+/// - **Ref advance**: compare-and-swap on the ancestor observed above; a
+///   concurrent writer surfaces as a structured `REF_CONFLICT` error rather
+///   than being clobbered. When the ref did not exist at resolution time the
+///   create is unconditional.
+///
+/// Returns the new projection commit's id.
+pub fn commit_projection(
+    repo: &gix::Repository,
+    options: CommitProjectionOptions<'_>,
+) -> Result<ObjectId> {
+    let normalized = normalize_commit_ref(options.commit_ref);
+    let (target_ref, ancestor) = resolve_target(repo, &normalized)?;
+    commit_and_advance(repo, &target_ref, ancestor, options)
+}
+
+/// Create the commit against an already-resolved target ref + ancestor.
+///
+/// Split from [`commit_projection`] so the CAS failure path (ancestor moved
+/// between resolution and advance) is directly testable.
+fn commit_and_advance(
+    repo: &gix::Repository,
+    target_ref: &str,
+    ancestor: Option<ObjectId>,
+    options: CommitProjectionOptions<'_>,
+) -> Result<ObjectId> {
+    let CommitProjectionOptions {
+        holobranch,
+        tree,
+        source_commit,
+        source,
+        message,
+        author,
+        committer,
+        ..
+    } = options;
+
+    let first_parent = match ancestor {
+        Some(id) => id,
+        None => init_commit(repo, holobranch, author.clone(), committer.clone())?,
+    };
+
+    let mut parents = vec![first_parent];
+    if let Some(src) = source_commit {
+        parents.push(src);
+    }
+
+    let message = match message {
+        Some(m) => ensure_trailing_newline(m),
+        None => default_message(holobranch, source, source_commit),
+    };
+
+    let commit =
+        holo_tree::repo::commit_tree(repo, tree, &parents, &message, author, committer)?;
+
+    // CAS on the observed ancestor; unconditional create when absent.
+    holo_tree::repo::update_ref(repo, target_ref, commit, ancestor)?;
+
+    Ok(commit)
+}
+
+/// Create the init commit used as first parent when the target ref does not
+/// exist yet: the empty tree, no parents, `↥ initialized <holobranch>`.
+fn init_commit(
+    repo: &gix::Repository,
+    holobranch: &str,
+    author: Option<gix::actor::Signature>,
+    committer: Option<gix::actor::Signature>,
+) -> Result<ObjectId> {
+    // Materialize the empty tree so the commit never references a missing
+    // object (git treats it as virtually present; not every consumer does).
+    let empty_tree = repo
+        .write_object(gix::objs::Tree::empty())
+        .map_err(|e| Error::Tree(holo_tree::Error::Git(e.to_string())))?
+        .detach();
+
+    let message = format!("↥ initialized {holobranch}\n");
+    Ok(holo_tree::repo::commit_tree(
+        repo, empty_tree, &[], &message, author, committer,
+    )?)
+}
+
+/// Normalize the oracle's `commitTo` value into a full ref name:
+/// `HEAD` and `refs/...` pass through; anything else — including names
+/// containing `/` — becomes `refs/heads/<name>`.
+fn normalize_commit_ref(commit_ref: &str) -> Cow<'_, str> {
+    if commit_ref == "HEAD" || commit_ref.starts_with("refs/") {
+        Cow::Borrowed(commit_ref)
+    } else {
+        Cow::Owned(format!("refs/heads/{commit_ref}"))
+    }
+}
+
+/// Resolve the normalized target ref to the concrete ref that will be
+/// advanced and its current value: symbolic refs (e.g. `HEAD`) are followed
+/// to their terminal ref name — matching `git update-ref HEAD` semantics —
+/// and a missing or unborn ref yields `None` for the ancestor.
+fn resolve_target(repo: &gix::Repository, refname: &str) -> Result<(String, Option<ObjectId>)> {
+    let mut name = refname.to_string();
+
+    for _ in 0..MAX_SYMREF_DEPTH {
+        let reference = repo
+            .try_find_reference(name.as_str())
+            .map_err(|e| Error::Tree(holo_tree::Error::Git(e.to_string())))?;
+
+        let Some(reference) = reference else {
+            // Missing ref (or the unborn branch a symbolic ref pointed at):
+            // this is the name to create, with no ancestor.
+            return Ok((name, None));
+        };
+
+        match reference.target() {
+            gix::refs::TargetRef::Object(id) => return Ok((name, Some(id.to_owned()))),
+            gix::refs::TargetRef::Symbolic(symbolic) => {
+                name = symbolic.as_bstr().to_string();
+            }
+        }
+    }
+
+    Err(Error::Other(format!(
+        "symbolic ref chain too deep resolving '{refname}'"
+    )))
+}
+
+/// Compose the default projection-commit message: subject, blank line, then
+/// the trailer block in fixed order. Ends with exactly one newline (the
+/// oracle inherits the same from `git commit-tree -m`).
+fn default_message(
+    holobranch: &str,
+    source: ProjectionSource<'_>,
+    source_commit: Option<ObjectId>,
+) -> String {
+    let from = match source {
+        ProjectionSource::Described { description } => description,
+        ProjectionSource::WorkTree { path } => path,
+    };
+
+    let mut message =
+        format!("☀ projected {holobranch} from {from}\n\nSource-holobranch: {holobranch}\n");
+
+    if let ProjectionSource::Described { description } = source {
+        if let Some(src) = source_commit {
+            message.push_str(&format!("Source-commit: {src}\n"));
+        }
+        message.push_str(&format!("Source: {description}\n"));
+    }
+
+    message
+}
+
+/// Append a trailing newline only when the message lacks one — the exact
+/// behavior of `git commit-tree -m`, which the oracle's messages pass
+/// through (a message already ending in `\n`, even several, is verbatim).
+fn ensure_trailing_newline(message: &str) -> String {
+    if message.ends_with('\n') {
+        message.to_string()
+    } else {
+        format!("{message}\n")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sig(name: &str, email: &str, time: &str) -> gix::actor::Signature {
+        gix::actor::SignatureRef {
+            name: name.into(),
+            email: email.into(),
+            time,
+        }
+        .to_owned()
+        .expect("valid signature")
+    }
+
+    fn test_repo() -> (tempfile::TempDir, gix::Repository) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let repo = gix::init_bare(dir.path()).expect("init bare repo");
+        (dir, repo)
+    }
+
+    fn write_commit(repo: &gix::Repository, msg: &str) -> ObjectId {
+        let tree = repo
+            .write_object(gix::objs::Tree::empty())
+            .unwrap()
+            .detach();
+        holo_tree::repo::commit_tree(
+            repo,
+            tree,
+            &[],
+            msg,
+            Some(sig("Test", "test@test", "1700000000 +0000")),
+            Some(sig("Test", "test@test", "1700000000 +0000")),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn normalize_commit_ref_matches_oracle_rule() {
+        assert_eq!(normalize_commit_ref("HEAD"), "HEAD");
+        assert_eq!(normalize_commit_ref("refs/holo/x"), "refs/holo/x");
+        assert_eq!(normalize_commit_ref("refs/heads/main"), "refs/heads/main");
+        assert_eq!(normalize_commit_ref("projected"), "refs/heads/projected");
+        // Names containing '/' still get the refs/heads/ prefix (oracle rule;
+        // differs from bare-name qualification elsewhere).
+        assert_eq!(
+            normalize_commit_ref("holo/projected"),
+            "refs/heads/holo/projected"
+        );
+    }
+
+    #[test]
+    fn ensure_trailing_newline_matches_commit_tree() {
+        assert_eq!(ensure_trailing_newline("plain"), "plain\n");
+        assert_eq!(ensure_trailing_newline("kept\n"), "kept\n");
+        assert_eq!(ensure_trailing_newline("multi\n\n"), "multi\n\n");
+    }
+
+    #[test]
+    fn stale_ancestor_surfaces_ref_conflict() {
+        let (_dir, repo) = test_repo();
+
+        let stale = write_commit(&repo, "stale\n");
+        let current = write_commit(&repo, "current\n");
+        holo_tree::repo::update_ref(&repo, "refs/heads/target", current, None).unwrap();
+
+        // The ref moved to `current` after we (hypothetically) observed `stale`.
+        let err = commit_and_advance(
+            &repo,
+            "refs/heads/target",
+            Some(stale),
+            CommitProjectionOptions {
+                commit_ref: "refs/heads/target",
+                holobranch: "proj",
+                tree: repo
+                    .write_object(gix::objs::Tree::empty())
+                    .unwrap()
+                    .detach(),
+                source_commit: None,
+                source: ProjectionSource::Described { description: "d" },
+                message: None,
+                author: Some(sig("Test", "test@test", "1700000000 +0000")),
+                committer: Some(sig("Test", "test@test", "1700000000 +0000")),
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code(), "REF_CONFLICT");
+
+        // The concurrent writer's value survived.
+        let (_, value) = resolve_target(&repo, "refs/heads/target").unwrap();
+        assert_eq!(value, Some(current));
+    }
+
+    #[test]
+    fn missing_ref_resolves_to_no_ancestor() {
+        let (_dir, repo) = test_repo();
+        let (name, value) = resolve_target(&repo, "refs/holo/projected").unwrap();
+        assert_eq!(name, "refs/holo/projected");
+        assert_eq!(value, None);
+    }
+
+    #[test]
+    fn unborn_head_resolves_to_its_branch() {
+        let (_dir, repo) = test_repo();
+        let (name, value) = resolve_target(&repo, "HEAD").unwrap();
+        assert!(
+            name.starts_with("refs/heads/"),
+            "HEAD should dereference to its branch, got {name}"
+        );
+        assert_eq!(value, None);
+    }
+}

--- a/holo-projector/src/lib.rs
+++ b/holo-projector/src/lib.rs
@@ -8,8 +8,10 @@
 //!
 //! - [`project_branch`] — TOML-driven: reads `.holo/` config from a git tree
 //! - [`project_plan`] — Programmatic: accepts structured source/mapping definitions
+//! - [`commit_projection`] — Edge capability: commit a composed tree and advance a ref
 
 pub mod branch;
+pub mod commit;
 pub mod config;
 pub mod error;
 pub mod projection;
@@ -20,6 +22,10 @@ use gix::ObjectId;
 
 // Re-export holo-tree for consumers that need the tree primitives
 pub use holo_tree;
+
+// Projection-commit creation (specs/behaviors/projection-commits.md):
+// the side-effecting edge capability layered on pure composition.
+pub use commit::{commit_projection, CommitProjectionOptions, ProjectionSource};
 
 // ── Public API ─────────────────────────────────────────────────────────────
 

--- a/holo-projector/tests/commit.rs
+++ b/holo-projector/tests/commit.rs
@@ -1,0 +1,303 @@
+//! Projection-commit parity with the JS oracle
+//! (`specs/behaviors/projection-commits.md`).
+//!
+//! Every `ORACLE_*` constant below is a commit hash produced by the legacy
+//! JS engine (`node bin/cli.js project proj --no-lens --commit-to=…`) under
+//! pinned identity on a deterministic fixture repo. The capture procedure is
+//! `tests/fixtures/capture-projection-commit-oracle.sh` — re-run it to
+//! regenerate/verify the constants. These tests rebuild the identical
+//! repository state through gix, drive `commit_projection` with the same
+//! inputs, and require **byte-identical** commits (asserted on raw object
+//! bytes first, so a mismatch shows *what* diverged, then on hashes).
+
+mod helpers;
+
+use gix::ObjectId;
+use helpers::Sandbox;
+use holo_projector::{commit_projection, CommitProjectionOptions, ProjectionSource};
+
+// ── Oracle capture (see tests/fixtures/capture-projection-commit-oracle.sh) ─
+
+const SOURCE_COMMIT: &str = "1b05a93bc326506d3640c9691b944f985879114c";
+const PROJECTED_TREE: &str = "cd141f028d135c0dd3aa871fe9a05db2087f8ccc";
+const DESCRIBE: &str = "1b05a93";
+/// The absolute fixture path used by the capture script; the working-tree
+/// mode commit embeds it in its message (oracle quirk, specced), so the
+/// capture pins it.
+const WORKING_PATH: &str = "/tmp/holo-oracle-fixture";
+
+const ORACLE_INIT: &str = "8a3bd1d9f6d849cdae6bb41215cf07040f8c2946";
+const ORACLE_FIRST: &str = "4ed3a7578aea4edc6f212c904eb00c9bfa84896d";
+const ORACLE_SECOND: &str = "a7f4efd541fdddaed7c9952650deab68678165d5";
+const ORACLE_CUSTOM: &str = "2d176173663d13ebbd5ec966189de992c5804183";
+const ORACLE_NO_SOURCE: &str = "91a5b430b2de8cb13400e92a4f11296d7cc4d2b5";
+const ORACLE_WORKING: &str = "22f6cef61d07b72bdd78acd1ea829e34813c9b90";
+
+// ── Fixture reconstruction ──────────────────────────────────────────────────
+
+fn oid(hex: &str) -> ObjectId {
+    ObjectId::from_hex(hex.as_bytes()).expect("valid hex")
+}
+
+fn author() -> gix::actor::Signature {
+    sig("Holo Author", "author@example.com", "1700000000 +0000")
+}
+
+fn committer() -> gix::actor::Signature {
+    sig("Holo Committer", "committer@example.com", "1700000001 +0000")
+}
+
+fn sig(name: &str, email: &str, time: &str) -> gix::actor::Signature {
+    gix::actor::SignatureRef {
+        name: name.into(),
+        email: email.into(),
+        time,
+    }
+    .to_owned()
+    .expect("valid signature")
+}
+
+/// Rebuild the capture script's fixture state: the same root tree and the
+/// same source commit (asserted — everything downstream keys off them), then
+/// project `proj` with the engine and assert the oracle's projected tree.
+fn fixture(sandbox: &Sandbox) -> (ObjectId, ObjectId) {
+    let root = sandbox.write_tree(&[
+        ("README.md", "hello\n"),
+        ("docs/index.md", "docs content\n"),
+        (".holo/config.toml", "[holospace]\nname = \"fixture\"\n"),
+        (
+            ".holo/branches/proj/_fixture.toml",
+            "[holomapping]\nfiles = \"**\"\n",
+        ),
+    ]);
+
+    let source_commit = holo_projector::holo_tree::repo::commit_tree(
+        &sandbox.repo,
+        root,
+        &[],
+        "initial commit\n",
+        Some(author()),
+        Some(committer()),
+    )
+    .expect("source commit");
+    assert_eq!(
+        source_commit.to_string(),
+        SOURCE_COMMIT,
+        "fixture source commit must match the oracle capture"
+    );
+
+    let tree = holo_projector::project_branch(&sandbox.repo, root, "proj").expect("projection");
+    assert_eq!(
+        tree.to_string(),
+        PROJECTED_TREE,
+        "projected tree must match the oracle capture"
+    );
+
+    (tree, source_commit)
+}
+
+fn options<'a>(tree: ObjectId, source_commit: ObjectId) -> CommitProjectionOptions<'a> {
+    CommitProjectionOptions {
+        commit_ref: "refs/holo/projected",
+        holobranch: "proj",
+        tree,
+        source_commit: Some(source_commit),
+        source: ProjectionSource::Described {
+            description: DESCRIBE,
+        },
+        message: None,
+        author: Some(author()),
+        committer: Some(committer()),
+    }
+}
+
+fn raw_commit(sandbox: &Sandbox, id: ObjectId) -> String {
+    let obj = sandbox.repo.find_object(id).expect("commit exists");
+    String::from_utf8_lossy(&obj.data).into_owned()
+}
+
+fn ref_value(sandbox: &Sandbox, name: &str) -> Option<ObjectId> {
+    sandbox
+        .repo
+        .try_find_reference(name)
+        .expect("ref lookup")
+        .map(|r| r.target().id().to_owned())
+}
+
+// ── Byte-for-byte parity ────────────────────────────────────────────────────
+
+#[test]
+fn first_projection_creates_init_commit_and_matches_oracle_bytes() {
+    let sandbox = Sandbox::new();
+    let (tree, source_commit) = fixture(&sandbox);
+
+    let commit = commit_projection(&sandbox.repo, options(tree, source_commit)).expect("commit");
+
+    // Byte comparison first: a mismatch shows exactly what diverged.
+    let expected = format!(
+        "tree {PROJECTED_TREE}\n\
+         parent {ORACLE_INIT}\n\
+         parent {SOURCE_COMMIT}\n\
+         author Holo Author <author@example.com> 1700000000 +0000\n\
+         committer Holo Committer <committer@example.com> 1700000001 +0000\n\
+         \n\
+         \u{2600} projected proj from {DESCRIBE}\n\
+         \n\
+         Source-holobranch: proj\n\
+         Source-commit: {SOURCE_COMMIT}\n\
+         Source: {DESCRIBE}\n"
+    );
+    assert_eq!(raw_commit(&sandbox, commit), expected);
+    assert_eq!(commit.to_string(), ORACLE_FIRST);
+
+    // The dangling init commit is byte-identical too.
+    let expected_init = "tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\n\
+         author Holo Author <author@example.com> 1700000000 +0000\n\
+         committer Holo Committer <committer@example.com> 1700000001 +0000\n\
+         \n\
+         \u{21a5} initialized proj\n";
+    assert_eq!(raw_commit(&sandbox, oid(ORACLE_INIT)), expected_init);
+
+    // The ref advanced to the projection commit — never to the init commit.
+    assert_eq!(
+        ref_value(&sandbox, "refs/holo/projected"),
+        Some(oid(ORACLE_FIRST))
+    );
+}
+
+#[test]
+fn second_projection_uses_previous_commit_as_first_parent() {
+    let sandbox = Sandbox::new();
+    let (tree, source_commit) = fixture(&sandbox);
+
+    let first = commit_projection(&sandbox.repo, options(tree, source_commit)).expect("first");
+    let second = commit_projection(&sandbox.repo, options(tree, source_commit)).expect("second");
+
+    assert_eq!(first.to_string(), ORACLE_FIRST);
+    assert_eq!(second.to_string(), ORACLE_SECOND);
+    assert!(raw_commit(&sandbox, second).contains(&format!("parent {ORACLE_FIRST}\n")));
+    assert_eq!(
+        ref_value(&sandbox, "refs/holo/projected"),
+        Some(oid(ORACLE_SECOND))
+    );
+}
+
+#[test]
+fn message_override_replaces_subject_and_trailers() {
+    let sandbox = Sandbox::new();
+    let (tree, source_commit) = fixture(&sandbox);
+
+    let commit = commit_projection(
+        &sandbox.repo,
+        CommitProjectionOptions {
+            message: Some("custom message here"),
+            ..options(tree, source_commit)
+        },
+    )
+    .expect("commit");
+
+    let raw = raw_commit(&sandbox, commit);
+    assert!(raw.ends_with("\n\ncustom message here\n"), "raw was: {raw}");
+    assert!(!raw.contains("Source-holobranch"), "trailers must be dropped");
+    // Parents are unaffected by the override.
+    assert!(raw.contains(&format!("parent {SOURCE_COMMIT}\n")));
+    assert_eq!(commit.to_string(), ORACLE_CUSTOM);
+}
+
+#[test]
+fn without_source_commit_single_parent_and_no_source_commit_trailer() {
+    let sandbox = Sandbox::new();
+    let (tree, _source_commit) = fixture(&sandbox);
+
+    let commit = commit_projection(
+        &sandbox.repo,
+        CommitProjectionOptions {
+            source_commit: None,
+            ..options(tree, oid(SOURCE_COMMIT))
+        },
+    )
+    .expect("commit");
+
+    let raw = raw_commit(&sandbox, commit);
+    assert!(!raw.contains("Source-commit:"));
+    assert!(raw.contains(&format!("Source: {DESCRIBE}\n")));
+    assert_eq!(raw.matches("\nparent ").count(), 1);
+    assert_eq!(commit.to_string(), ORACLE_NO_SOURCE);
+}
+
+#[test]
+fn working_tree_mode_embeds_path_and_drops_ref_mode_trailers() {
+    let sandbox = Sandbox::new();
+    let (tree, source_commit) = fixture(&sandbox);
+
+    let commit = commit_projection(
+        &sandbox.repo,
+        CommitProjectionOptions {
+            source: ProjectionSource::WorkTree { path: WORKING_PATH },
+            ..options(tree, source_commit)
+        },
+    )
+    .expect("commit");
+
+    let raw = raw_commit(&sandbox, commit);
+    assert!(raw.contains(&format!("\u{2600} projected proj from {WORKING_PATH}\n")));
+    assert!(raw.contains("Source-holobranch: proj\n"));
+    assert!(!raw.contains("Source-commit:"));
+    assert!(!raw.contains("\nSource:"));
+    // The source commit is still the second parent in working-tree mode.
+    assert!(raw.contains(&format!("parent {SOURCE_COMMIT}\n")));
+    assert_eq!(commit.to_string(), ORACLE_WORKING);
+}
+
+// ── Ref semantics ───────────────────────────────────────────────────────────
+
+#[test]
+fn bare_ref_name_normalizes_to_heads_and_matches_oracle() {
+    let sandbox = Sandbox::new();
+    let (tree, source_commit) = fixture(&sandbox);
+
+    let commit = commit_projection(
+        &sandbox.repo,
+        CommitProjectionOptions {
+            commit_ref: "projected-bare",
+            ..options(tree, source_commit)
+        },
+    )
+    .expect("commit");
+
+    // Same inputs as case A -> same bytes, landed under refs/heads/.
+    assert_eq!(commit.to_string(), ORACLE_FIRST);
+    assert_eq!(
+        ref_value(&sandbox, "refs/heads/projected-bare"),
+        Some(oid(ORACLE_FIRST))
+    );
+}
+
+#[test]
+fn head_dereferences_to_its_branch() {
+    let sandbox = Sandbox::new();
+    let (tree, source_commit) = fixture(&sandbox);
+
+    let commit = commit_projection(
+        &sandbox.repo,
+        CommitProjectionOptions {
+            commit_ref: "HEAD",
+            ..options(tree, source_commit)
+        },
+    )
+    .expect("commit");
+
+    // HEAD itself stays symbolic; the branch it points at advanced.
+    let head = sandbox
+        .repo
+        .find_reference("HEAD")
+        .expect("HEAD exists");
+    let gix::refs::TargetRef::Symbolic(branch) = head.target() else {
+        panic!("HEAD must remain symbolic");
+    };
+    let branch = branch.as_bstr().to_string();
+    assert_eq!(ref_value(&sandbox, &branch), Some(commit));
+
+    // Unborn HEAD -> init-commit first parent, same bytes as case A.
+    assert_eq!(commit.to_string(), ORACLE_FIRST);
+}

--- a/holo-projector/tests/fixtures/capture-projection-commit-oracle.sh
+++ b/holo-projector/tests/fixtures/capture-projection-commit-oracle.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Capture the JS engine's projection-commit bytes on a deterministic fixture
+# repo — the oracle side of holo-projector/tests/commit.rs (see
+# specs/behaviors/projection-commits.md § Conformance fixtures).
+#
+# Usage:  holo-projector/tests/fixtures/capture-projection-commit-oracle.sh
+#
+# The fixture path is fixed because the working-tree-mode commit embeds the
+# absolute path in its message (oracle quirk, specced): changing the path
+# changes ORACLE_WORKING's hash. Every value printed under "summary"
+# corresponds to a constant in tests/commit.rs.
+set -euo pipefail
+
+CLONE=$(cd "$(dirname "$0")/../../.." && pwd)
+FIXTURE=/tmp/holo-oracle-fixture
+
+export GIT_AUTHOR_NAME='Holo Author'
+export GIT_AUTHOR_EMAIL='author@example.com'
+export GIT_AUTHOR_DATE='1700000000 +0000'
+export GIT_COMMITTER_NAME='Holo Committer'
+export GIT_COMMITTER_EMAIL='committer@example.com'
+export GIT_COMMITTER_DATE='1700000001 +0000'
+export HOLO_ENGINE=js
+export HOLO_CACHE_FROM=
+
+rm -rf "$FIXTURE"
+git init -q -b main "$FIXTURE"
+cd "$FIXTURE"
+git config user.name "$GIT_AUTHOR_NAME"
+git config user.email "$GIT_AUTHOR_EMAIL"
+git config commit.gpgsign false
+
+mkdir -p docs .holo/branches/proj
+printf 'hello\n' > README.md
+printf 'docs content\n' > docs/index.md
+printf '[holospace]\nname = "fixture"\n' > .holo/config.toml
+printf '[holomapping]\nfiles = "**"\n' > .holo/branches/proj/_fixture.toml
+git add -A
+git commit -q -m 'initial commit'
+
+echo "SOURCE_COMMIT=$(git rev-parse HEAD)"
+echo "DESCRIBE=$(git describe --always --tags HEAD)"
+
+project() {
+    node "$CLONE/bin/cli.js" project proj --no-lens "$@" 2>/dev/null
+}
+
+# Case A: ref absent -> init commit + projection commit
+project --commit-to=refs/holo/projected > /dev/null
+echo "ORACLE_INIT=$(git rev-parse 'refs/holo/projected^')"
+echo "ORACLE_FIRST=$(git rev-parse refs/holo/projected)"
+echo "PROJECTED_TREE=$(git rev-parse 'refs/holo/projected^{tree}')"
+
+# Case B: ref exists -> previous projection commit as first parent
+project --commit-to=refs/holo/projected > /dev/null
+echo "ORACLE_SECOND=$(git rev-parse refs/holo/projected)"
+
+# Case C: custom message (trailers dropped)
+project --commit-to=refs/holo/projected-msg --commit-message='custom message here' > /dev/null
+echo "ORACLE_CUSTOM=$(git rev-parse refs/holo/projected-msg)"
+
+# Case D: no source parent (single parent, no Source-commit trailer)
+project --commit-to=refs/holo/projected-nosrc --no-commit-source-parent > /dev/null
+echo "ORACLE_NO_SOURCE=$(git rev-parse refs/holo/projected-nosrc)"
+
+# Case E: working-tree mode (path in message, only Source-holobranch trailer)
+project --working --commit-to=refs/holo/projected-working > /dev/null
+echo "ORACLE_WORKING=$(git rev-parse refs/holo/projected-working)"
+
+# Case F: bare ref name -> refs/heads/ prefix (same bytes as case A)
+project --commit-to=projected-bare > /dev/null
+echo "ORACLE_BARE=$(git rev-parse refs/heads/projected-bare)"
+
+echo
+echo "--- raw commit bytes (case B) ---"
+git cat-file commit refs/holo/projected

--- a/plans/projection-commits.md
+++ b/plans/projection-commits.md
@@ -1,9 +1,11 @@
 ---
-status: in-progress
+status: done
 depends: []
 specs:
   - specs/behaviors/composition.md
+  - specs/behaviors/projection-commits.md
 issues: [438]
+pr: 495
 ---
 
 # Projection commit creation with trailers (Rust engine)
@@ -25,10 +27,10 @@ Wire projection-commit creation into holo-projector: after composing a tree, cre
 
 ## Validation
 
-- [ ] `specs/behaviors/projection-commits.md` accepted and merged
-- [ ] Commit shape (tree, parents, trailers) matches JS engine output on the reference projections
-- [ ] With pinned identity/timestamp, commit hash matches the JS engine bit-for-bit
-- [ ] `commitTo` ref advance uses CAS and surfaces a structured error on race
+- [x] `specs/behaviors/projection-commits.md` accepted and merged (lands with this PR)
+- [x] Commit shape (tree, parents, trailers) matches JS engine output on the reference projections (`docs-site` `8c1d5581…`, `github-action-projector` `2c4ad1dd…` — identical commit hashes from `node bin/cli.js project <branch> --no-lens --commit-to=…` and `commit_projection` on the same pinned inputs, including a real tag-bearing `git describe` string)
+- [x] With pinned identity/timestamp, commit hash matches the JS engine bit-for-bit (`holo-projector/tests/commit.rs` asserts raw commit bytes, then hashes, against six oracle captures; capture procedure committed as `tests/fixtures/capture-projection-commit-oracle.sh`)
+- [x] `commitTo` ref advance uses CAS and surfaces a structured error on race (`REF_CONFLICT` unit test; the concurrent writer's ref value survives)
 
 ## Risks / unknowns
 
@@ -36,8 +38,12 @@ Wire projection-commit creation into holo-projector: after composing a tree, cre
 
 ## Notes
 
-_(populated at closeout)_
+- The risk above materialized as three ported quirks, now specced: a `--commit-message` override drops the **entire** trailer block; working-tree mode embeds the machine-specific absolute worktree path and gates `Source-commit`/`Source` on the mode (not data availability) while keeping the source commit as second parent; `git commit-tree -m` appends a trailing newline only when absent (pinned empirically).
+- **Provenance is host-supplied**: the `Source`/`from` description is a parameter, never computed in the engine — reproducing `git describe --always --tags` (abbreviation rules, tag state) in gix would be an undeclared-input determinism hazard. Captured as a Local principle in the spec; the future CLI wiring passes the string in, exactly as `lib/Projection.js` computes it today.
+- Two declared desired-state divergences from the oracle: CAS ref advance (`REF_CONFLICT` instead of blind `update-ref`; absent-ref creation stays unconditional), and first-parent resolution reading the ref directly with symbolic-ref following (`commit_ref: "HEAD"` advances the branch HEAD points at, matching `git update-ref HEAD`; holo-tree's `update_ref` is `deref: false`, so the deref happens during resolution).
+- The dangling init commit's empty tree is materialized in the ODB (git treats it as virtually present; not every consumer does). No effect on commit bytes.
+- No holo-tree changes were needed — `commit_tree` + CAS `update_ref` sufficed, as planned.
 
 ## Follow-ups
 
-_(populated at closeout)_
+- Deferred to [`watch-mode`](watch-mode.md) — napi/CLI wiring of the Rust commit path (binding export + hybrid-dispatcher use); lands with the warm-context work, per `specs/behaviors/engine-selection.md` (JS owns commits in the hybrid CLI today).

--- a/plans/projection-commits.md
+++ b/plans/projection-commits.md
@@ -1,5 +1,5 @@
 ---
-status: planned
+status: in-progress
 depends: []
 specs:
   - specs/behaviors/composition.md

--- a/plans/watch-mode.md
+++ b/plans/watch-mode.md
@@ -21,6 +21,7 @@ Continuous re-projection on change: monitor the working tree and/or git refs and
 1. Spec from `commands/watch.js` behavior (watchman for working tree, chokidar for refs), then decide the Rust shape: `notify` crate + gix ref monitoring, or a callback/event boundary where the host (CLI or embedding consumer) owns watching and triggers re-projection.
 2. Prefer the event-boundary design: it keeps the engine pure (per principles) and gives embedding consumers (gitsheets watch mode is its own tracked want, gitsheets#135) the same primitive.
 3. Depends on projector-napi-cli (delegation path exists) and projection-commits (watch cycles that commit).
+   Wire the engine's `commit_projection` through the napi binding and the CLI's commit path (deferred from [`projection-commits`](projection-commits.md)): expose it as a binding export per `specs/api/projector-napi.md` conventions, and have the hybrid dispatcher use it — the host supplies the `git describe --always --tags` string and identity, per `specs/behaviors/projection-commits.md` (provenance is host-supplied).
 4. Warm engine context across binding calls (deferred from [`projector-napi-cli`](projector-napi-cli.md)): the napi binding currently opens the repo and builds a fresh `TreeCache` per call (~130ms/composition on emergence-site). Hold a persistent handle + cache across watch cycles via holo-projector's `*_in` Context variants — designing for the staleness hazards (refs and packs written between projections) — to reach the warm target. Consider holo-tree-napi's thread-id-memoized `local_repo` pattern (PR #491) for the handle.
 5. For lensed holobranches, watch-cycle latency depends on the warm lens-container pool from `specs/behaviors/lensing.md` (Container lifecycle): one container per image digest held for the session, jobs multiplexed over per-job refs, incremental object transfer to warm containers. Watch mode is that design's primary beneficiary — without it, container churn dwarfs the ~27ms composition budget. Not a hard dependency (unlensed branches watch fine; hybrid can lens via JS), but full-speed lensed watch requires lens-execution.
 
@@ -31,6 +32,7 @@ Continuous re-projection on change: monitor the working tree and/or git refs and
 - [ ] Repeat projections reuse a warm engine context (persistent repo handle + `TreeCache` across binding calls; deferred from [`projector-napi-cli`](projector-napi-cli.md))
 - [ ] Rapid successive changes coalesce (debounce) and stale in-flight projections are superseded
 - [ ] `--working` projections reflect uncommitted changes correctly (watch is the main consumer of working-tree trees)
+- [ ] Watch cycles that commit do so through the Rust `commit_projection` path via the binding, hash-identical to the JS commit path (deferred from [`projection-commits`](projection-commits.md))
 
 ## Risks / unknowns
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -17,10 +17,13 @@ specs/
 ├── architecture.md        # Crates, engines, bindings, release tracks, migration strategy
 ├── api/                   # Library/binding contracts
 │   ├── errors.md          # holo-tree error codes, panic policy, thread-safety expectations
-│   └── lens-sdk.md        # The in-image SDK's author-facing contract (env, modes, isolation)
+│   ├── lens-sdk.md        # The in-image SDK's author-facing contract (env, modes, isolation)
+│   └── projector-napi.md  # holo-projector-napi binding surface and error codes
 └── behaviors/             # Cross-cutting rules
     ├── composition.md     # Projection/composition semantics (the core operation)
-    └── lensing.md         # Lens execution: spec/cache model, v2 job protocol, lifecycle, transfer tiers
+    ├── engine-selection.md    # Hybrid Rust/JS dispatch: per-phase seam, fallback, HOLO_ENGINE
+    ├── lensing.md         # Lens execution: spec/cache model, v2 job protocol, lifecycle, transfer tiers
+    └── projection-commits.md  # Projection-commit shape (parents, trailers, message, ref advance)
 ```
 
 Expected to grow as work touches each area (spec-on-contact):

--- a/specs/behaviors/composition.md
+++ b/specs/behaviors/composition.md
@@ -19,7 +19,7 @@ Projecting a holobranch is a pure, deterministic transformation: given a root tr
 3. **Source resolution** — each mapping's holosource resolves in this order: self-source (the repo projecting itself) → gitlink (submodule pointer) → spec-ref (`refs/holo/source/...`) → local ref from the source's configured `ref`. Refs that point at annotated tags are peeled to commits. A `source=>holobranch` or `=>holobranch` reference triggers **recursive sub-projection**: the referenced holobranch is projected first (against the source's tree or the current tree respectively) and its output tree becomes the mapping's input.
 4. **Merge** — each mapping's source tree (optionally re-rooted via `root`) merges into the output at the mapping's target path, filtered by the mapping's `files` globs. Later mappings win over earlier ones for overlapping paths (overlay semantics), subject to each merge's mode.
 5. **Metadata strip** — `.holo/` is removed from the output tree.
-6. **Output** — the final tree is written and its hash returned. Composition itself never writes refs or commits.
+6. **Output** — the final tree is written and its hash returned. Composition itself never writes refs or commits; wrapping the output in a projection commit and advancing a ref is an explicit edge capability specced in `projection-commits.md`.
 
 ### Glob semantics
 

--- a/specs/behaviors/projection-commits.md
+++ b/specs/behaviors/projection-commits.md
@@ -1,0 +1,180 @@
+# Behavior: Projection commits
+
+## Rule
+
+Committing a projection — wrapping a composed output tree in a git commit and
+advancing a target ref to it — is an **explicit edge capability layered on
+pure composition** (composition itself never writes refs or commits; see
+`composition.md`). The commit's bytes are a pure function of its declared
+inputs: projected tree, target-ref state, holobranch name, source commit,
+source description, message override, and identity/timestamps. Given identical
+inputs, engines must produce **byte-identical commit objects** and therefore
+identical commit hashes.
+
+This spec captures the legacy JS engine's behavior (the conformance oracle)
+exactly, with two deliberate desired-state divergences called out inline and
+summarized under [Ported vs. desired state](#ported-vs-desired-state).
+
+## Applies To
+
+- `holo_projector::commit_projection` (Rust engine capability)
+- `lib/Projection.js` `Projection#commit` — the conformance oracle, and the
+  hybrid CLI's `--commit-to` path today (JS owns commits per
+  `specs/behaviors/engine-selection.md`; wiring the Rust capability into the
+  CLI lands with watch-mode's warm-context work)
+
+## Details
+
+### Inputs
+
+| Input | Oracle (JS CLI) source | Rust engine |
+| --- | --- | --- |
+| Target ref (`commitTo`) | `--commit-to` | `commit_ref` parameter |
+| Projected tree | the composed (and optionally lensed) output tree | `tree` parameter |
+| Holobranch name | the projected holobranch | `holobranch` parameter |
+| Source commit | `<ref>^{commit}` of the projected ref; omitted with `--no-commit-source-parent` | `source_commit` parameter |
+| Source description | `git describe --always --tags <ref>` (ref mode) or the absolute work-tree path (working-tree mode), computed at commit time | `source` parameter (`Described { description }` / `WorkTree { path }`) |
+| Message override | `--commit-message` | `message` parameter |
+| Identity | ambient git config / `GIT_AUTHOR_*` + `GIT_COMMITTER_*` env | explicit signatures → repo config (incl. env) → `holo-tree` fallback |
+
+The **source description is host-supplied, never engine-computed**: `git
+describe` output depends on repository tag state and on git's hash-abbreviation
+algorithm, and reproducing that algorithm in a second git implementation is a
+determinism hazard. The engine treats the description as an opaque string; the
+host (the CLI) computes it exactly as the oracle does.
+
+### Target ref normalization
+
+Exact port of the oracle's rule:
+
+| `commitTo` value | Normalized target |
+| --- | --- |
+| `HEAD` | `HEAD`, **dereferenced through symbolic refs** at resolution/update time — the branch HEAD points at is what advances (matching `git update-ref HEAD`); a detached HEAD advances itself |
+| starts with `refs/` | unchanged |
+| anything else — including names containing `/` (e.g. `holo/projected` → `refs/heads/holo/projected`) | `refs/heads/<name>` |
+
+### Parents
+
+1. **First parent** — the normalized ref's current value (symbolic refs
+   followed). When the ref does not resolve (missing, or unborn `HEAD`), an
+   **init commit** is created and becomes the first parent instead:
+   - tree: the empty tree (`4b825dc642cb6eb9a060e54bf8d69288fbee4904`)
+   - parents: none
+   - message: `↥ initialized <holobranch>` + trailing newline
+   - identity: same resolution as the projection commit
+
+   The target ref never points at the init commit — it advances directly to
+   the projection commit; the init commit exists only as its first parent.
+2. **Second parent** — the source commit, when supplied. Included in **both**
+   ref mode and working-tree mode.
+
+### Message
+
+Default message, exact bytes (`<from>` = the source description in ref mode,
+the work-tree path in working-tree mode; `\n` line endings throughout):
+
+```
+☀ projected <holobranch> from <from>
+
+<trailers>
+```
+
+Trailers, one per line, `:` separator, **fixed order**:
+
+| # | Trailer | Included when |
+| --- | --- | --- |
+| 1 | `Source-holobranch: <holobranch>` | always |
+| 2 | `Source-commit: <full 40-hex source commit>` | ref mode **and** a source commit was supplied |
+| 3 | `Source: <source description>` | ref mode |
+
+Working-tree mode therefore carries only `Source-holobranch` — the trailer
+gate is the mode, not data availability (oracle quirk, ported).
+
+- The stored message gains **exactly one trailing newline when it lacks one**
+  (the oracle inherits this from `git commit-tree -m`, which appends `\n` only
+  if absent; a message already ending in `\n` — even several — is stored
+  verbatim). Ported exactly.
+- A **message override replaces the entire message**: no default subject and
+  **no trailers** (oracle quirk, ported). Parents are unaffected. The
+  trailing-newline rule still applies.
+
+### Ref advance
+
+- The oracle performs a blind `git update-ref <ref> <commit>`.
+- **Desired-state divergence (deliberate):** the Rust engine advances with a
+  **compare-and-swap** on the ancestor it observed when resolving the first
+  parent. A concurrent writer that moved the ref mid-projection surfaces as a
+  structured `REF_CONFLICT` error (`specs/api/errors.md`) instead of being
+  clobbered. When the ref did not exist at resolution time, the advance is
+  unconditional (create); the create-create race window is accepted — it is
+  no worse than the oracle's behavior in every case.
+- Reflog contents are **not contractual** (engines may stamp different reflog
+  identities/messages); only the ref's target and the commit bytes are.
+
+### Return value
+
+The new projection commit's id. Hosts that requested a commit substitute it
+for the tree hash as the projection's output (the oracle's `projectBranch`
+returns the commit hash when `commitTo` is set).
+
+### Ported vs. desired state
+
+Everything above is a pure port of the oracle, including its quirks (message
+override drops trailers; working-tree mode embeds a machine-specific absolute
+path in the message and drops the `Source*` trailers; the init commit is
+re-created — at the same hash under pinned identity — whenever the ref is
+absent). Exactly two deliberate divergences:
+
+1. **CAS ref advance** (above) — structured `REF_CONFLICT` instead of blind
+   last-writer-wins.
+2. **First-parent resolution reads the ref directly** (following symbolic
+   refs) rather than `git rev-parse <ref>`. For branch refs — the only valid
+   projection targets — the two are identical; a `commitTo` ref pointing at
+   an annotated tag would give the oracle the unpeeled tag id as first parent
+   (a broken commit), where the Rust engine uses the ref's raw target the same
+   way. No behavioral difference for commit-valued refs.
+
+## Conformance fixtures
+
+Byte-for-byte oracle captures under pinned identity (`Holo Author
+<author@example.com> 1700000000 +0000` / `Holo Committer
+<committer@example.com> 1700000001 +0000`) on a deterministic fixture repo
+(source commit `1b05a93b…`, projected tree `cd141f02…`, describe `1b05a93`):
+
+| Case | Oracle commit |
+| --- | --- |
+| Ref absent → init (`8a3bd1d9…`) + projection commit | `4ed3a757…` |
+| Ref exists → previous projection commit as first parent | `a7f4efd5…` |
+| Message override (trailers dropped) | `2d176173…` |
+| No source commit (single parent, no `Source-commit`) | `91a5b430…` |
+| Bare ref name (`projected-bare` → `refs/heads/projected-bare`) | `4ed3a757…` |
+
+The Rust engine must reproduce these hashes from the same inputs. The parity
+tests (with the capture procedure documented alongside) live in
+`holo-projector/tests/commit.rs`.
+
+## Principles
+
+**Inherited** — from [`principles.md`](../principles.md):
+
+- [Composition is pure; side effects live at the edges](../principles.md#composition-is-pure-side-effects-live-at-the-edges) —
+  this spec *is* one of those edges: commit creation is layered around
+  `project_branch`, never folded into it.
+- [The legacy engine is the conformance oracle](../principles.md#the-legacy-engine-is-the-conformance-oracle) —
+  quirks are ported first (trailer gating, override-drops-trailers, trailing
+  newline); the two desired-state changes are declared here, not slipped in.
+- [Determinism is the product](../principles.md#determinism-is-the-product) —
+  commit bytes are a pure function of declared inputs; nothing the engine
+  derives from environment (clock, cwd, tag state) may leak into them.
+- [Never abort a host process](../principles.md#never-abort-a-host-process) —
+  the concurrency failure is a stable, matchable `REF_CONFLICT`, not a panic
+  or a clobber.
+
+**Local:**
+
+- **Provenance strings are inputs, not derivations.** Any human-readable
+  provenance embedded in commit bytes (the describe string, the work-tree
+  path) is supplied by the host, never computed inside the engine. If the
+  engine computed it, two engines with different derivation details would
+  produce different bytes from the same logical state — the description would
+  become an undeclared input.


### PR DESCRIPTION
Executes `plans/projection-commits.md`: wire projection-commit creation into the Rust engine as an explicit edge capability, byte-for-byte compatible with the JS engine.

## What was specced

New accepted-form spec **`specs/behaviors/projection-commits.md`**, captured from `lib/Projection.js` `Projection#commit` (the conformance oracle):

- **Message**: `☀ projected <holobranch> from <from>` + blank line + trailer block; trailers in fixed order `Source-holobranch` → `Source-commit` → `Source`; the stored message gains exactly one trailing newline when it lacks one (inherited from `git commit-tree -m`, pinned empirically).
- **Parents**: the target ref's current value is the first parent; when the ref doesn't resolve, a dangling init commit (empty tree, no parents, `↥ initialized <holobranch>`) is created and used instead — the ref never points at it. The source commit is the optional second parent in both provenance modes.
- **Ref normalization**: `HEAD` passes through and dereferences through symbolic refs (the branch HEAD points at is what advances); `refs/...` passes through; anything else — including names containing `/` — becomes `refs/heads/<name>`.
- **Provenance is host-supplied**: the `Source`/`from` description (`git describe --always --tags` output, or the worktree path) is an input parameter, never engine-derived — reproducing git's hash-abbreviation algorithm in gix would be an undeclared-input determinism hazard (specced as a Local principle).

Two declared desired-state divergences (everything else is a pure port):

1. **CAS ref advance** — the Rust engine advances with a compare-and-swap on the ancestor it observed, surfacing a structured `REF_CONFLICT` (`specs/api/errors.md`) on a race instead of the oracle's blind `git update-ref` clobber. Absent-ref creation is unconditional (no worse than the oracle anywhere).
2. **First-parent resolution reads the ref directly** (following symbolic refs) instead of `git rev-parse` — identical for commit-valued refs, and the only valid targets are branch refs.

## Quirks found in the JS oracle (ported, not fixed)

- `--commit-message` **drops the entire trailer block**, not just the subject (`m: commitMessage || template`).
- Working-tree mode embeds the **machine-specific absolute worktree path** in the message and gates the `Source-commit`/`Source` trailers on the mode rather than on data availability — the source commit still becomes the second parent there.
- The init commit is re-created (dangling, same hash under pinned identity) every time the target ref is absent.
- The blind `update-ref` race (no CAS) — this one is deliberately *not* ported, per divergence 1 above.

## Implementation

`holo_projector::commit_projection(repo, CommitProjectionOptions)` in a new `holo-projector/src/commit.rs` — `project_branch` stays side-effect-free (composition-is-pure principle). Built entirely on existing holo-tree primitives (`commit_tree`, CAS `update_ref`); **no holo-tree changes**. Errors follow the post-#490 contract (coded, no panicking constructs on public paths). napi/CLI wiring is out of scope — the hybrid CLI keeps committing via JS (`specs/behaviors/engine-selection.md`); the deferral to `watch-mode` is recorded in both plan files.

## Parity evidence

- **Pinned-input byte parity** (`holo-projector/tests/commit.rs`): a deterministic fixture repo is rebuilt through gix and every oracle capture reproduced — raw commit bytes asserted first (so a mismatch names the diverging byte), then hashes. Covers: init-commit case (`4ed3a757…`), previous-commit-as-first-parent (`a7f4efd5…`), message override (`2d176173…`), no source parent (`91a5b430…`), working-tree mode (`22f6cef6…`), bare-name normalization, and `HEAD` dereference. The capture procedure ships as `tests/fixtures/capture-projection-commit-oracle.sh`.
- **On-repo check** (this branch's HEAD, pinned identity, real `git describe` output `holo-tree-v0.4.0-58-gc769fb0`): `node bin/cli.js project <branch> --no-lens --commit-to=…` vs `commit_projection` on the same inputs —
  - `docs-site`: `8c1d5581…` both engines
  - `github-action-projector`: `2c4ad1dd…` both engines
- `REF_CONFLICT` on a stale ancestor has a direct unit test; the concurrent writer's value survives.

Local runs: workspace `cargo test` green, `npm test` green (98 passed), binding tests green, and the dual-engine composition gate reproduced (`docs-site` `eecd425e…`, `github-action-projector` `d56c03f7…` identical under `HOLO_ENGINE=js|rust`).

Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01X4KHfjZQG7nS4c6R2pP2DJ>
