### PR TITLE
feat: watch mode — warm engine sessions, Rust commit dispatch, latest-wins watch loop

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -84,6 +84,29 @@ jobs:
           echo "rust: ${rust_hash}"
           test "${js_hash}" = "${rust_hash}"
 
+      # Commit parity (specs/behaviors/projection-commits.md +
+      # specs/behaviors/engine-selection.md § Commit dispatch): under pinned
+      # identity, both engines must produce byte-identical projection commits
+      # — HOLO_ENGINE=rust routes the commit through the binding's
+      # commitProjection, so equal commit hashes prove the Rust commit path
+      # ran and matches the JS oracle byte-for-byte.
+      - name: 'Test projection commit: docs-site --commit-to (JS vs Rust engine, pinned identity)'
+        env:
+          GIT_AUTHOR_NAME: 'Holo Author'
+          GIT_AUTHOR_EMAIL: 'author@example.com'
+          GIT_AUTHOR_DATE: '1700000000 +0000'
+          GIT_COMMITTER_NAME: 'Holo Committer'
+          GIT_COMMITTER_EMAIL: 'committer@example.com'
+          GIT_COMMITTER_DATE: '1700000001 +0000'
+        run: |
+          set -euo pipefail
+          js_commit=$(HOLO_ENGINE=js node bin/cli.js project --no-cache-from --no-lens --commit-to=refs/holo-ci/js docs-site | tail -1)
+          rust_commit=$(HOLO_ENGINE=rust node bin/cli.js project --no-cache-from --no-lens --commit-to=refs/holo-ci/rust docs-site | tail -1)
+          echo "js:   ${js_commit}"
+          echo "rust: ${rust_commit}"
+          test "${js_commit}" = "${rust_commit}"
+          test "$(git rev-parse refs/holo-ci/js)" = "$(git rev-parse refs/holo-ci/rust)"
+
   test-action:
 
     runs-on: ubuntu-latest

--- a/commands/project.js
+++ b/commands/project.js
@@ -133,34 +133,32 @@ exports.handler = async function project ({
     }
 
 
-    /**
-     * create a reusable block for the rest of the process so it can be repeated
-     * in watch mode--until a more efficient watch response can be developed
-     */
-    let outputHash = await Projection.projectBranch(workspaceBranch, {
-        debug,
-        lens,
-        commitTo,
-        commitMessage,
-        parentCommit: commitSourceParent ? parentCommit : null,
-        fetch,
-        cacheFrom,
-        cacheTo
-    });
-    console.log(outputHash);
+    let outputHash = null;
 
-
-    // watch for changes (specs/behaviors/watch.md): cycles are serialized
-    // and latest-wins — rapid changes coalesce, and a cycle whose input was
-    // superseded mid-flight discards its result at the publication gate,
-    // before the output line and any commit
-    if (watch) {
+    if (!watch) {
+        outputHash = await Projection.projectBranch(workspaceBranch, {
+            debug,
+            lens,
+            commitTo,
+            commitMessage,
+            parentCommit: commitSourceParent ? parentCommit : null,
+            fetch,
+            cacheFrom,
+            cacheTo
+        });
+        console.log(outputHash);
+    } else {
+        // watch for changes (specs/behaviors/watch.md): cycles are
+        // serialized and latest-wins — rapid changes coalesce, and a cycle
+        // whose input was superseded mid-flight discards its result at the
+        // publication gate, before the output line and any commit
         const watchLoop = new WatchLoop({
-            cycle: async ({ treeHash }) => {
+            cycle: async ({ treeHash, fetch: cycleFetch = false }) => {
                 const cycleWorkspace = await repo.createWorkspaceFromTreeHash(treeHash);
                 return Projection.projectBranch(cycleWorkspace.getBranch(holobranch), {
                     debug,
                     lens,
+                    fetch: cycleFetch,
                     cacheFrom,
                     cacheTo
                 });
@@ -186,8 +184,10 @@ exports.handler = async function project ({
 
         // suppress re-projection of an input state identical to the last
         // queued one (duplicate suppression is by hash, not by event)
-        let lastQueuedTreeHash = await workspace.root.write();
+        let lastQueuedTreeHash = null;
 
+        // establish the watcher before the initial projection so a change
+        // racing watch startup supersedes it instead of being lost
         const { watching } = await repo.watch({
             callback: (newTreeHash, newCommitHash = null) => {
                 logger.info('watch new hash: %s (from:%s)', newTreeHash, newCommitHash || 'unknown');
@@ -201,6 +201,12 @@ exports.handler = async function project ({
                 watchLoop.push({ treeHash: newTreeHash, commitHash: newCommitHash });
             }
         });
+
+        // initial cycle: a watch session's first publication is the current
+        // state, through the same loop as every later cycle (fetch, when
+        // requested, is a startup-only side effect)
+        lastQueuedTreeHash = await workspace.root.write();
+        watchLoop.push({ treeHash: lastQueuedTreeHash, commitHash: parentCommit, fetch });
 
         await watching;
     }

--- a/commands/project.js
+++ b/commands/project.js
@@ -63,7 +63,7 @@ exports.handler = async function project ({
     cacheTo = null
 }) {
     const logger = require('../lib/logger.js');
-    const { Repo, Projection } = require('../lib');
+    const { Repo, Projection, WatchLoop } = require('../lib');
 
 
     // check inputs
@@ -150,23 +150,55 @@ exports.handler = async function project ({
     console.log(outputHash);
 
 
-    // watch for changes
+    // watch for changes (specs/behaviors/watch.md): cycles are serialized
+    // and latest-wins — rapid changes coalesce, and a cycle whose input was
+    // superseded mid-flight discards its result at the publication gate,
+    // before the output line and any commit
     if (watch) {
-        const { watching } = await repo.watch({
-            callback: async (newTreeHash, newCommitHash=null) => {
-                logger.info('watch new hash: %s (from:%s)', newTreeHash, newCommitHash||'unknown');
-
-                const newWorkspace = await repo.createWorkspaceFromTreeHash(newTreeHash);
-                outputHash = await Projection.projectBranch(newWorkspace.getBranch(holobranch), {
+        const watchLoop = new WatchLoop({
+            cycle: async ({ treeHash }) => {
+                const cycleWorkspace = await repo.createWorkspaceFromTreeHash(treeHash);
+                return Projection.projectBranch(cycleWorkspace.getBranch(holobranch), {
                     debug,
                     lens,
-                    commitTo,
-                    commitMessage,
-                    parentCommit: commitSourceParent ? newCommitHash : null,
                     cacheFrom,
                     cacheTo
                 });
-                console.log(outputHash);
+            },
+            publish: async (projectedHash, { commitHash }) => {
+                if (commitTo) {
+                    projectedHash = await Projection.commitTree(repo, holobranch, projectedHash, commitTo, {
+                        parentCommit: commitSourceParent ? commitHash : null,
+                        commitMessage
+                    });
+                }
+
+                outputHash = projectedHash;
+                console.log(projectedHash);
+            },
+            onError: (err, { treeHash }) => {
+                // a failed cycle publishes nothing and never stops the
+                // watch; the next change triggers a normal cycle
+                logger.error('projection cycle failed for %s: %s', treeHash, err.message);
+                lastQueuedTreeHash = null; // allow an identical re-trigger to retry
+            }
+        });
+
+        // suppress re-projection of an input state identical to the last
+        // queued one (duplicate suppression is by hash, not by event)
+        let lastQueuedTreeHash = await workspace.root.write();
+
+        const { watching } = await repo.watch({
+            callback: (newTreeHash, newCommitHash = null) => {
+                logger.info('watch new hash: %s (from:%s)', newTreeHash, newCommitHash || 'unknown');
+
+                if (newTreeHash == lastQueuedTreeHash) {
+                    logger.debug('input tree unchanged, skipping cycle');
+                    return;
+                }
+
+                lastQueuedTreeHash = newTreeHash;
+                watchLoop.push({ treeHash: newTreeHash, commitHash: newCommitHash });
             }
         });
 

--- a/holo-projector-napi/README.md
+++ b/holo-projector-napi/README.md
@@ -30,6 +30,28 @@ const composed = projectPlan('/repo/.git',
     [{ source: 'base' }]);
 ```
 
+The top-level functions are one-shot (open repo, project, drop). Hosts making
+repeat projections — watch cycles, servers, embedders — hold a
+**`ProjectionSession`**: a warm context (persistent repository handle +
+tree cache) that only ever caches content-addressed state, re-resolving refs
+on every call. It also exposes `commitProjection` — create a projection
+commit and advance a ref per `specs/behaviors/projection-commits.md`, with a
+compare-and-swap advance that surfaces concurrent writers as `REF_CONFLICT`:
+
+```js
+const { ProjectionSession } = require('@hologit/holo-projector');
+
+const session = new ProjectionSession('/repo/.git');
+const tree = session.projectBranch(rootTreeOrCommitHash, 'docs-site'); // warm across calls
+const commit = session.commitProjection({
+    commitRef: 'holo/docs-site',
+    holobranch: 'docs-site',
+    tree,
+    sourceCommit: rootCommitHash,
+    sourceDescription: 'v1.2.3-4-gdeadbee', // host-computed `git describe`
+});
+```
+
 Errors carry a stable `code` property (`SOURCE_RESOLUTION`,
 `LENSED_SUBPROJECTION`, `CONFIG`, …, plus the holo-tree codes and `PANIC`);
 match on codes, never message prose. Panics are contained at the FFI boundary

--- a/holo-projector-napi/index.d.ts
+++ b/holo-projector-napi/index.d.ts
@@ -50,6 +50,58 @@ export interface JsPlanMapping {
  * tree hash (full projection, metadata stripped).
  */
 export declare function projectPlan(gitDir: string, sources: Array<JsPlanSource>, mappings: Array<JsPlanMapping>): string
+/**
+ * A commit identity (author or committer). `timeSeconds`/`offsetMinutes`
+ * are optional; when omitted the current wall-clock time at UTC is used.
+ * Pass them explicitly to reproduce a specific commit byte-for-byte.
+ */
+export interface Signature {
+  name: string
+  email: string
+  timeSeconds?: number
+  offsetMinutes?: number
+}
+/**
+ * Options for [`ProjectionSession::commit_projection`]
+ * (`specs/behaviors/projection-commits.md`). Exactly one of
+ * `sourceDescription` (ref mode) / `workTreePath` (working-tree mode) is
+ * required — the provenance string is host-computed, never engine-derived.
+ */
+export interface CommitProjectionOptions {
+  /**
+   * Target ref to advance (the oracle's `commitTo`); normalized by the
+   * engine (`HEAD` and `refs/...` pass through, else `refs/heads/<name>`).
+   */
+  commitRef: string
+  /** The projected holobranch's name. */
+  holobranch: string
+  /**
+   * The composed output tree to commit (tree hash, or a commit/tag hash
+   * peeled to its tree).
+   */
+  tree: string
+  /**
+   * The source commit the projection was taken from; second parent when
+   * present.
+   */
+  sourceCommit?: string
+  /** Ref-mode provenance: the host's `git describe --always --tags` output. */
+  sourceDescription?: string
+  /** Working-tree-mode provenance: the absolute work-tree path. */
+  workTreePath?: string
+  /**
+   * Message override — replaces the entire default message, trailers
+   * included (oracle quirk, ported).
+   */
+  message?: string
+  /**
+   * Explicit author; omitted, identity resolves from repo config
+   * (including `GIT_AUTHOR_*` env), then holo-tree's fallback.
+   */
+  author?: Signature
+  /** Explicit committer; same fallback chain as `author`. */
+  committer?: Signature
+}
 /** Engine performance counters — process-global, monotonic, metrics only. */
 export interface Stats {
   treesRead: number
@@ -63,3 +115,47 @@ export interface Stats {
 export declare function stats(): Stats
 /** Reset engine counters and module-level caches. */
 export declare function resetStats(): void
+/**
+ * Warm engine context for repeat projections (`specs/api/projector-napi.md`
+ * § ProjectionSession): a persistent repository handle plus one consumer-
+ * owned [`TreeCache`] reused across calls.
+ *
+ * Staleness contract: only content-addressed state is cached (parsed trees
+ * keyed by tree id, the gix object cache keyed by object id) — immutable by
+ * construction. Refs are re-resolved from the repository on every call, and
+ * objects written behind the session (new loose objects/packs) are found
+ * without reopening it: gix stats loose refs and revalidates its packed-refs
+ * snapshot per access, and refreshes its pack list on an object miss. The
+ * session test suite proves both by writing refs/objects behind an open
+ * session.
+ */
+export declare class ProjectionSession {
+  /**
+   * Open a repository at `gitDir` (a `.git` directory, or any path gix can
+   * discover a repo from) and bind a fresh `TreeCache` to it.
+   */
+  constructor(gitDir: string)
+  /** [`composite_branch`] against this session's warm context. */
+  compositeBranch(rootTree: string, holobranch: string): string
+  /** [`project_branch`] against this session's warm context. */
+  projectBranch(rootTree: string, holobranch: string): string
+  /** [`project_plan`] against this session's warm context. */
+  projectPlan(sources: Array<JsPlanSource>, mappings: Array<JsPlanMapping>): string
+  /**
+   * Create a projection commit for a composed tree and advance the target
+   * ref (`specs/behaviors/projection-commits.md`). Returns the new commit
+   * id; a concurrent ref move surfaces as `REF_CONFLICT`.
+   */
+  commitProjection(options: CommitProjectionOptions): string
+  /**
+   * Number of trees held in this session's `TreeCache` — observability so
+   * warmth is provable in tests; metrics only, never an input to behavior.
+   */
+  cachedTrees(): number
+  /**
+   * Drop the session's `TreeCache`. Never required for correctness —
+   * content-addressed entries cannot go stale — this is a memory valve for
+   * long-lived hosts.
+   */
+  clearCache(): void
+}

--- a/holo-projector-napi/index.js
+++ b/holo-projector-napi/index.js
@@ -310,11 +310,12 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { __triggerPanicForTest, compositeBranch, projectBranch, projectPlan, stats, resetStats } = nativeBinding
+const { __triggerPanicForTest, compositeBranch, projectBranch, projectPlan, ProjectionSession, stats, resetStats } = nativeBinding
 
 module.exports.__triggerPanicForTest = __triggerPanicForTest
 module.exports.compositeBranch = compositeBranch
 module.exports.projectBranch = projectBranch
 module.exports.projectPlan = projectPlan
+module.exports.ProjectionSession = ProjectionSession
 module.exports.stats = stats
 module.exports.resetStats = resetStats

--- a/holo-projector-napi/src/lib.rs
+++ b/holo-projector-napi/src/lib.rs
@@ -7,6 +7,7 @@
 //!   compositeBranch(gitDir, rootTree, holobranch)  // → pre-lens tree hash
 //!   projectBranch(gitDir, rootTree, holobranch)    // → full composition-only projection
 //!   projectPlan(gitDir, sources, mappings)         // → structured-config composition
+//!   new ProjectionSession(gitDir)                  // → warm context for repeat projections
 //! ```
 //!
 //! Conventions across the FFI boundary (matching holo-tree-napi):
@@ -26,7 +27,10 @@ use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
 use holo_projector::error::Error as ProjectorError;
-use holo_projector::{PlanMapping, PlanSource};
+use holo_projector::{
+    CommitProjectionOptions as EngineCommitOptions, PlanMapping, PlanSource, ProjectionSource,
+};
+use holo_projector::holo_tree::{Context, TreeCache};
 
 type ObjectId = gix::ObjectId;
 
@@ -71,7 +75,8 @@ fn git_err(message: impl ToString) -> napi::Error<ErrorCode> {
 /// Per `specs/api/errors.md` § Panic policy. `AssertUnwindSafe` is sound here
 /// because after a `PANIC` error the involved objects are contractually in an
 /// unspecified (memory-safe) state and must be discarded by the consumer —
-/// and this binding holds no state across calls anyway.
+/// including a [`ProjectionSession`], the one object that holds state across
+/// calls.
 fn contained<T>(f: impl FnOnce() -> CodedResult<T>) -> CodedResult<T> {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).unwrap_or_else(|payload| {
         let message = if let Some(s) = payload.downcast_ref::<String>() {
@@ -107,15 +112,11 @@ pub fn trigger_panic_for_test() -> Result<(), ErrorCode> {
 /// across mappings and recursive sub-projections). 16 MiB follows gix's own
 /// sizing guidance and mirrors holo-tree-napi's `OBJECT_CACHE_BYTES`.
 ///
-/// Unlike holo-tree-napi — whose `Repo`/`Tree` objects persist across many
-/// short calls and therefore memoize the derived thread-local repository per
-/// thread id (see its `local_repo`) — this binding's entry points are
-/// one-shot: one call opens one handle, runs one whole projection (thousands
-/// of object reads), and drops it. The cache is warm for exactly the lifetime
-/// that matters here; holding a handle *across* calls (watch mode's repeat
-/// projections) is deliberately deferred to the watch-mode plan, where the
-/// staleness questions (refs and packs written between projections) get
-/// designed rather than assumed.
+/// The top-level entry points are one-shot: one call opens one handle, runs
+/// one whole projection (thousands of object reads), and drops it. Hosts
+/// making repeat projections hold a [`ProjectionSession`] instead, whose
+/// memoized thread-local handle (see [`local_repo`]) keeps this cache warm
+/// across calls.
 const OBJECT_CACHE_BYTES: usize = 16 * 1024 * 1024;
 
 fn open_repo(git_dir: &str) -> CodedResult<gix::Repository> {
@@ -237,6 +238,46 @@ pub struct JsPlanMapping {
     pub before: Option<Vec<String>>,
 }
 
+fn convert_plan_sources(sources: Vec<JsPlanSource>) -> Vec<PlanSource> {
+    sources
+        .into_iter()
+        .map(|s| PlanSource {
+            name: s.name,
+            url: s.url,
+            git_ref: s.git_ref,
+            project_holobranch: s.project_holobranch,
+        })
+        .collect()
+}
+
+fn convert_plan_mappings(mappings: Vec<JsPlanMapping>) -> Vec<PlanMapping> {
+    mappings
+        .into_iter()
+        .map(|m| {
+            let mut mapping = PlanMapping::new(&m.source);
+            if let Some(files) = m.files {
+                mapping.files = files;
+            }
+            if let Some(root) = m.root {
+                mapping.root = root;
+            }
+            if let Some(output) = m.output {
+                mapping.output = output;
+            }
+            if let Some(layer) = m.layer {
+                mapping.layer = layer;
+            }
+            if let Some(after) = m.after {
+                mapping.after = after;
+            }
+            if let Some(before) = m.before {
+                mapping.before = before;
+            }
+            mapping
+        })
+        .collect()
+}
+
 /// Compose git trees from structured source/mapping definitions — the
 /// `ProjectionPlan` path, no `.holo/` config needed. Returns the composed
 /// tree hash (full projection, metadata stripped).
@@ -248,47 +289,279 @@ pub fn project_plan(
 ) -> Result<String, ErrorCode> {
     contained(|| {
         let repo = open_repo(&git_dir)?;
-
-        let plan_sources: Vec<PlanSource> = sources
-            .into_iter()
-            .map(|s| PlanSource {
-                name: s.name,
-                url: s.url,
-                git_ref: s.git_ref,
-                project_holobranch: s.project_holobranch,
-            })
-            .collect();
-
-        let plan_mappings: Vec<PlanMapping> = mappings
-            .into_iter()
-            .map(|m| {
-                let mut mapping = PlanMapping::new(&m.source);
-                if let Some(files) = m.files {
-                    mapping.files = files;
-                }
-                if let Some(root) = m.root {
-                    mapping.root = root;
-                }
-                if let Some(output) = m.output {
-                    mapping.output = output;
-                }
-                if let Some(layer) = m.layer {
-                    mapping.layer = layer;
-                }
-                if let Some(after) = m.after {
-                    mapping.after = after;
-                }
-                if let Some(before) = m.before {
-                    mapping.before = before;
-                }
-                mapping
-            })
-            .collect();
-
+        let plan_sources = convert_plan_sources(sources);
+        let plan_mappings = convert_plan_mappings(mappings);
         let out =
             holo_projector::project_plan(&repo, &plan_sources, &plan_mappings).map_err(hp_err)?;
         Ok(oid_hex(out))
     })
+}
+
+// ── warm projection session ─────────────────────────────────────────────────
+
+/// A `gix::Repository` derived on — and only ever *used* on — one thread
+/// (the holo-tree-napi `local_repo` pattern, PR #491).
+struct ThreadLocalRepo {
+    thread: std::thread::ThreadId,
+    repo: gix::Repository,
+}
+
+// The memoized handle may be *moved* between threads with its owning object
+// (napi may finalize on another thread), which requires `gix::Repository:
+// Send`. Usage stays confined to the recorded thread via `local_repo`.
+const _: () = {
+    const fn assert_send<T: Send>() {}
+    assert_send::<gix::Repository>();
+};
+
+fn derive_local(shared: &gix::ThreadSafeRepository) -> ThreadLocalRepo {
+    let mut repo = shared.to_thread_local();
+    repo.object_cache_size_if_unset(OBJECT_CACHE_BYTES);
+    ThreadLocalRepo {
+        thread: std::thread::current().id(),
+        repo,
+    }
+}
+
+/// Reuse the memoized thread-local `gix::Repository`, re-deriving when a call
+/// lands on a different thread than the memo. Sound per `specs/api/errors.md`
+/// § Thread-safety expectations: a thread switch costs at most warmth (a
+/// re-derivation and a cold object cache), never a behavioral difference.
+fn local_repo<'a>(
+    slot: &'a mut Option<ThreadLocalRepo>,
+    shared: &gix::ThreadSafeRepository,
+) -> &'a gix::Repository {
+    let tid = std::thread::current().id();
+    if !matches!(slot, Some(memo) if memo.thread == tid) {
+        *slot = None; // discard a handle derived on another thread
+    }
+    &slot.get_or_insert_with(|| derive_local(shared)).repo
+}
+
+/// A commit identity (author or committer). `timeSeconds`/`offsetMinutes`
+/// are optional; when omitted the current wall-clock time at UTC is used.
+/// Pass them explicitly to reproduce a specific commit byte-for-byte.
+#[napi(object)]
+pub struct Signature {
+    pub name: String,
+    pub email: String,
+    pub time_seconds: Option<i64>,
+    pub offset_minutes: Option<i32>,
+}
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Render git's `"<seconds> ±HHMM"` signature-time format.
+fn format_git_time(seconds: i64, offset_minutes: i32) -> String {
+    let sign = if offset_minutes < 0 { '-' } else { '+' };
+    let abs = offset_minutes.unsigned_abs();
+    format!("{seconds} {sign}{:02}{:02}", abs / 60, abs % 60)
+}
+
+fn to_gix_signature(sig: Signature) -> CodedResult<gix::actor::Signature> {
+    let seconds = sig.time_seconds.unwrap_or_else(now_secs);
+    let time = format_git_time(seconds, sig.offset_minutes.unwrap_or(0));
+    gix::actor::SignatureRef {
+        name: sig.name.as_str().into(),
+        email: sig.email.as_str().into(),
+        time: &time,
+    }
+    .to_owned()
+    .map_err(|e| invalid_arg(format!("invalid signature time: {e}")))
+}
+
+/// Options for [`ProjectionSession::commit_projection`]
+/// (`specs/behaviors/projection-commits.md`). Exactly one of
+/// `sourceDescription` (ref mode) / `workTreePath` (working-tree mode) is
+/// required — the provenance string is host-computed, never engine-derived.
+#[napi(object)]
+pub struct CommitProjectionOptions {
+    /// Target ref to advance (the oracle's `commitTo`); normalized by the
+    /// engine (`HEAD` and `refs/...` pass through, else `refs/heads/<name>`).
+    pub commit_ref: String,
+    /// The projected holobranch's name.
+    pub holobranch: String,
+    /// The composed output tree to commit (tree hash, or a commit/tag hash
+    /// peeled to its tree).
+    pub tree: String,
+    /// The source commit the projection was taken from; second parent when
+    /// present.
+    pub source_commit: Option<String>,
+    /// Ref-mode provenance: the host's `git describe --always --tags` output.
+    pub source_description: Option<String>,
+    /// Working-tree-mode provenance: the absolute work-tree path.
+    pub work_tree_path: Option<String>,
+    /// Message override — replaces the entire default message, trailers
+    /// included (oracle quirk, ported).
+    pub message: Option<String>,
+    /// Explicit author; omitted, identity resolves from repo config
+    /// (including `GIT_AUTHOR_*` env), then holo-tree's fallback.
+    pub author: Option<Signature>,
+    /// Explicit committer; same fallback chain as `author`.
+    pub committer: Option<Signature>,
+}
+
+/// Warm engine context for repeat projections (`specs/api/projector-napi.md`
+/// § ProjectionSession): a persistent repository handle plus one consumer-
+/// owned [`TreeCache`] reused across calls.
+///
+/// Staleness contract: only content-addressed state is cached (parsed trees
+/// keyed by tree id, the gix object cache keyed by object id) — immutable by
+/// construction. Refs are re-resolved from the repository on every call, and
+/// objects written behind the session (new loose objects/packs) are found
+/// without reopening it: gix stats loose refs and revalidates its packed-refs
+/// snapshot per access, and refreshes its pack list on an object miss. The
+/// session test suite proves both by writing refs/objects behind an open
+/// session.
+#[napi]
+pub struct ProjectionSession {
+    repo: gix::ThreadSafeRepository,
+    local: Option<ThreadLocalRepo>,
+    cache: TreeCache,
+}
+
+#[napi]
+impl ProjectionSession {
+    /// Open a repository at `gitDir` (a `.git` directory, or any path gix can
+    /// discover a repo from) and bind a fresh `TreeCache` to it.
+    #[napi(constructor)]
+    pub fn new(git_dir: String) -> Result<ProjectionSession, ErrorCode> {
+        contained(|| {
+            let repo = gix::open(&git_dir)
+                .map_err(|e| git_err(format!("failed to open repo at '{git_dir}': {e}")))?
+                .into_sync();
+            Ok(ProjectionSession {
+                repo,
+                local: None,
+                cache: TreeCache::new(),
+            })
+        })
+    }
+
+    /// [`composite_branch`] against this session's warm context.
+    #[napi(catch_unwind)]
+    pub fn composite_branch(
+        &mut self,
+        root_tree: String,
+        holobranch: String,
+    ) -> Result<String, ErrorCode> {
+        let ProjectionSession { repo, local, cache } = self;
+        contained(|| {
+            let repo = local_repo(local, repo);
+            let tree_id = peel_to_tree(repo, &root_tree)?;
+            let ctx = Context::new(repo, cache);
+            let out = holo_projector::composite_branch_in(&ctx, tree_id, &holobranch)
+                .map_err(hp_err)?;
+            Ok(oid_hex(out))
+        })
+    }
+
+    /// [`project_branch`] against this session's warm context.
+    #[napi(catch_unwind)]
+    pub fn project_branch(
+        &mut self,
+        root_tree: String,
+        holobranch: String,
+    ) -> Result<String, ErrorCode> {
+        let ProjectionSession { repo, local, cache } = self;
+        contained(|| {
+            let repo = local_repo(local, repo);
+            let tree_id = peel_to_tree(repo, &root_tree)?;
+            let ctx = Context::new(repo, cache);
+            let out =
+                holo_projector::project_branch_in(&ctx, tree_id, &holobranch).map_err(hp_err)?;
+            Ok(oid_hex(out))
+        })
+    }
+
+    /// [`project_plan`] against this session's warm context.
+    #[napi(catch_unwind)]
+    pub fn project_plan(
+        &mut self,
+        sources: Vec<JsPlanSource>,
+        mappings: Vec<JsPlanMapping>,
+    ) -> Result<String, ErrorCode> {
+        let ProjectionSession { repo, local, cache } = self;
+        contained(|| {
+            let repo = local_repo(local, repo);
+            let ctx = Context::new(repo, cache);
+            let plan_sources = convert_plan_sources(sources);
+            let plan_mappings = convert_plan_mappings(mappings);
+            let out = holo_projector::project_plan_in(&ctx, &plan_sources, &plan_mappings)
+                .map_err(hp_err)?;
+            Ok(oid_hex(out))
+        })
+    }
+
+    /// Create a projection commit for a composed tree and advance the target
+    /// ref (`specs/behaviors/projection-commits.md`). Returns the new commit
+    /// id; a concurrent ref move surfaces as `REF_CONFLICT`.
+    #[napi(catch_unwind)]
+    pub fn commit_projection(
+        &mut self,
+        options: CommitProjectionOptions,
+    ) -> Result<String, ErrorCode> {
+        let ProjectionSession { repo, local, .. } = self;
+        contained(|| {
+            let repo = local_repo(local, repo);
+
+            let source = match (&options.source_description, &options.work_tree_path) {
+                (Some(description), None) => ProjectionSource::Described { description },
+                (None, Some(path)) => ProjectionSource::WorkTree { path },
+                _ => {
+                    return Err(invalid_arg(
+                        "exactly one of sourceDescription or workTreePath is required",
+                    ))
+                }
+            };
+
+            let tree = peel_to_tree(repo, &options.tree)?;
+            let source_commit = options
+                .source_commit
+                .as_deref()
+                .map(parse_oid)
+                .transpose()?;
+            let author = options.author.map(to_gix_signature).transpose()?;
+            let committer = options.committer.map(to_gix_signature).transpose()?;
+
+            let commit = holo_projector::commit_projection(
+                repo,
+                EngineCommitOptions {
+                    commit_ref: &options.commit_ref,
+                    holobranch: &options.holobranch,
+                    tree,
+                    source_commit,
+                    source,
+                    message: options.message.as_deref(),
+                    author,
+                    committer,
+                },
+            )
+            .map_err(hp_err)?;
+
+            Ok(oid_hex(commit))
+        })
+    }
+
+    /// Number of trees held in this session's `TreeCache` — observability so
+    /// warmth is provable in tests; metrics only, never an input to behavior.
+    #[napi(catch_unwind)]
+    pub fn cached_trees(&self) -> u32 {
+        self.cache.len() as u32
+    }
+
+    /// Drop the session's `TreeCache`. Never required for correctness —
+    /// content-addressed entries cannot go stale — this is a memory valve for
+    /// long-lived hosts.
+    #[napi(catch_unwind)]
+    pub fn clear_cache(&mut self) {
+        self.cache.clear();
+    }
 }
 
 // ── stats ───────────────────────────────────────────────────────────────────

--- a/holo-projector-napi/test/session.mjs
+++ b/holo-projector-napi/test/session.mjs
@@ -36,24 +36,39 @@ function write(dir, path, content) {
   writeFileSync(join(dir, path), content);
 }
 
-/** A workspace whose `site` holobranch maps the self-source plus a
- * ref-resolved sibling source (`dep`, pinned to refs/heads/dep in the same
- * repository) — the ref is what the staleness tests advance. */
+const DEP_URL = 'https://example.com/dep';
+const DEP_REF = 'refs/heads/dep';
+
+/** The spec-ref where source resolution looks for the `dep` source's head
+ * (specs/behaviors/source-resolution.md): the spec hash is the git blob hash
+ * of the canonical holospec TOML for the source url; the suffix is the
+ * configured ref minus `refs/`. */
+function depSpecRef(dir) {
+  const specToml = '[holospec.source]\nhost = "example.com"\npath = "/dep"\n';
+  const hash = execFileSync('git', ['hash-object', '--stdin'], { cwd: dir, input: specToml, encoding: 'utf8' }).trim();
+  return `refs/holo/source/${hash.slice(0, 2)}/${hash.slice(2)}/${DEP_REF.slice('refs/'.length)}`;
+}
+
+/** A workspace whose `site` holobranch maps the self-source plus a sibling
+ * source (`dep`) resolved via its spec-ref — the ref the staleness tests
+ * advance behind the open session. A local `dep` branch tracks the same
+ * commits for the test's own bookkeeping. */
 function scratchWorkspace() {
   const dir = mkdtempSync(join(tmpdir(), 'holo-projector-session-'));
   git(dir, 'init', '-q', '-b', 'master');
   git(dir, 'config', 'user.name', 'Test');
   git(dir, 'config', 'user.email', 'test@example.com');
 
-  // dep branch: content the site holobranch pulls in by ref
+  // dep branch: content the site holobranch pulls in through the spec-ref
   write(dir, 'dep-file.txt', 'dep v1\n');
   git(dir, 'add', '-A');
   git(dir, 'commit', '-q', '-m', 'dep v1');
   git(dir, 'branch', 'dep');
+  git(dir, 'update-ref', depSpecRef(dir), git(dir, 'rev-parse', 'dep'));
   git(dir, 'rm', '-q', 'dep-file.txt');
 
   write(dir, '.holo/config.toml', '[holospace]\nname = "myapp"\n');
-  write(dir, '.holo/sources/dep.toml', '[holosource]\nurl = "."\nref = "refs/heads/dep"\n');
+  write(dir, '.holo/sources/dep.toml', `[holosource]\nurl = "${DEP_URL}"\nref = "${DEP_REF}"\n`);
   write(dir, '.holo/branches/site/_myapp.toml', '[holomapping]\nfiles = "**"\n');
   write(dir, '.holo/branches/site/vendor/_dep.toml', '[holomapping]\nfiles = "**"\n');
   write(dir, 'index.html', '<html>\n');
@@ -113,13 +128,14 @@ test('a ref advanced behind the session is observed by the next call', (t) => {
   const before = session.compositeBranch(root, 'site');
   assert.ok(lsTree(dir, before).includes('vendor/dep-file.txt'));
 
-  // Advance refs/heads/dep behind the open session with the external git
-  // CLI: new commit objects land in the ODB and the ref moves, all without
-  // the session's involvement.
+  // Advance the dep source's spec-ref behind the open session with the
+  // external git CLI: new commit objects land in the ODB and the ref moves,
+  // all without the session's involvement.
   git(dir, 'switch', '-q', 'dep');
   write(dir, 'dep-file-2.txt', 'dep v2\n');
   git(dir, 'add', '-A');
   git(dir, 'commit', '-q', '-m', 'dep v2');
+  git(dir, 'update-ref', depSpecRef(dir), git(dir, 'rev-parse', 'dep'));
   git(dir, 'switch', '-q', 'master');
 
   const after = session.compositeBranch(root, 'site');

--- a/holo-projector-napi/test/session.mjs
+++ b/holo-projector-napi/test/session.mjs
@@ -1,0 +1,253 @@
+// ProjectionSession tests: warm-context reuse, the staleness contract, and
+// commitProjection (specs/api/projector-napi.md § ProjectionSession,
+// specs/behaviors/watch.md § Warm session and staleness).
+//
+// The staleness tests are the load-bearing ones: they advance refs and write
+// objects *behind an open session* via the external git CLI and assert the
+// next call observes them — serving stale state would be a correctness bug,
+// not a performance trade-off.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+let binding;
+try {
+  binding = require('../index.js');
+} catch (err) {
+  throw new Error(
+    `holo-projector-napi addon not built — run \`npm run build:debug\` first.\n  cause: ${err.message}`,
+  );
+}
+const { ProjectionSession, compositeBranch, stats } = binding;
+
+function git(cwd, ...args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function write(dir, path, content) {
+  mkdirSync(join(dir, dirname(path)), { recursive: true });
+  writeFileSync(join(dir, path), content);
+}
+
+/** A workspace whose `site` holobranch maps the self-source plus a
+ * ref-resolved sibling source (`dep`, pinned to refs/heads/dep in the same
+ * repository) — the ref is what the staleness tests advance. */
+function scratchWorkspace() {
+  const dir = mkdtempSync(join(tmpdir(), 'holo-projector-session-'));
+  git(dir, 'init', '-q', '-b', 'master');
+  git(dir, 'config', 'user.name', 'Test');
+  git(dir, 'config', 'user.email', 'test@example.com');
+
+  // dep branch: content the site holobranch pulls in by ref
+  write(dir, 'dep-file.txt', 'dep v1\n');
+  git(dir, 'add', '-A');
+  git(dir, 'commit', '-q', '-m', 'dep v1');
+  git(dir, 'branch', 'dep');
+  git(dir, 'rm', '-q', 'dep-file.txt');
+
+  write(dir, '.holo/config.toml', '[holospace]\nname = "myapp"\n');
+  write(dir, '.holo/sources/dep.toml', '[holosource]\nurl = "."\nref = "refs/heads/dep"\n');
+  write(dir, '.holo/branches/site/_myapp.toml', '[holomapping]\nfiles = "**"\n');
+  write(dir, '.holo/branches/site/vendor/_dep.toml', '[holomapping]\nfiles = "**"\n');
+  write(dir, 'index.html', '<html>\n');
+
+  git(dir, 'add', '-A');
+  git(dir, 'commit', '-q', '-m', 'workspace');
+  return dir;
+}
+
+function rootTree(dir, ref = 'HEAD') {
+  return git(dir, 'rev-parse', `${ref}^{tree}`);
+}
+
+function lsTree(dir, hash) {
+  const out = git(dir, 'ls-tree', '-r', '--name-only', hash);
+  return out ? out.split('\n') : [];
+}
+
+test('session projections match one-shot projections and reuse the cache', (t) => {
+  const dir = scratchWorkspace();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const session = new ProjectionSession(dir);
+  const root = rootTree(dir);
+
+  const oneShot = compositeBranch(dir, root, 'site');
+  const first = session.compositeBranch(root, 'site');
+  assert.equal(first, oneShot, 'session output must be hash-identical to one-shot');
+
+  const cached = session.cachedTrees();
+  assert.ok(cached > 0, `first call should populate the TreeCache (got ${cached})`);
+
+  const hitsBefore = stats().cacheHits;
+  const second = session.compositeBranch(root, 'site');
+  assert.equal(second, first, 'repeat projection must be hash-identical');
+  assert.ok(
+    stats().cacheHits > hitsBefore,
+    'repeat projection should hit the warm TreeCache',
+  );
+
+  session.clearCache();
+  assert.equal(session.cachedTrees(), 0, 'clearCache drops all entries');
+  assert.equal(
+    session.compositeBranch(root, 'site'),
+    first,
+    'a cleared cache is a warmth loss, never a behavior change',
+  );
+});
+
+test('a ref advanced behind the session is observed by the next call', (t) => {
+  const dir = scratchWorkspace();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const session = new ProjectionSession(dir);
+  const root = rootTree(dir);
+
+  const before = session.compositeBranch(root, 'site');
+  assert.ok(lsTree(dir, before).includes('vendor/dep-file.txt'));
+
+  // Advance refs/heads/dep behind the open session with the external git
+  // CLI: new commit objects land in the ODB and the ref moves, all without
+  // the session's involvement.
+  git(dir, 'switch', '-q', 'dep');
+  write(dir, 'dep-file-2.txt', 'dep v2\n');
+  git(dir, 'add', '-A');
+  git(dir, 'commit', '-q', '-m', 'dep v2');
+  git(dir, 'switch', '-q', 'master');
+
+  const after = session.compositeBranch(root, 'site');
+  assert.notEqual(after, before, 'advanced source ref must change the output');
+  assert.ok(
+    lsTree(dir, after).includes('vendor/dep-file-2.txt'),
+    'output must include content only reachable from the advanced ref',
+  );
+});
+
+test('objects written behind the session are visible without reopening', (t) => {
+  const dir = scratchWorkspace();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const session = new ProjectionSession(dir);
+  session.compositeBranch(rootTree(dir), 'site'); // warm the session first
+
+  // New root commit written by the external git CLI after the session opened.
+  write(dir, 'new-page.html', '<html>new</html>\n');
+  git(dir, 'add', '-A');
+  git(dir, 'commit', '-q', '-m', 'add page');
+
+  const out = session.compositeBranch(rootTree(dir), 'site');
+  assert.ok(
+    lsTree(dir, out).includes('new-page.html'),
+    'projection from externally written objects must succeed and include them',
+  );
+});
+
+test('commitProjection creates the specced commit and advances the ref', (t) => {
+  const dir = scratchWorkspace();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const session = new ProjectionSession(dir);
+  const root = rootTree(dir);
+  const tree = session.projectBranch(root, 'site');
+  const sourceCommit = git(dir, 'rev-parse', 'HEAD');
+
+  const sig = { name: 'Holo Test', email: 'holo@example.com', timeSeconds: 1700000000, offsetMinutes: 0 };
+  const commit = session.commitProjection({
+    commitRef: 'projected',
+    holobranch: 'site',
+    tree,
+    sourceCommit,
+    sourceDescription: 'v1-test-describe',
+    author: sig,
+    committer: sig,
+  });
+
+  assert.equal(git(dir, 'rev-parse', 'refs/heads/projected'), commit, 'bare name normalizes to refs/heads/ and advances');
+  assert.equal(git(dir, 'rev-parse', `${commit}^{tree}`), tree);
+
+  // First parent is a fresh init commit (ref was absent), second the source.
+  const parents = git(dir, 'log', '-1', '--format=%P', commit).split(' ');
+  assert.equal(parents.length, 2);
+  assert.equal(parents[1], sourceCommit);
+  assert.equal(git(dir, 'log', '-1', '--format=%s', parents[0]), '↥ initialized site');
+
+  const message = git(dir, 'log', '-1', '--format=%B', commit);
+  assert.equal(
+    message,
+    `☀ projected site from v1-test-describe\n\nSource-holobranch: site\nSource-commit: ${sourceCommit}\nSource: v1-test-describe`,
+  );
+
+  // Second cycle: previous projection commit becomes the first parent.
+  const commit2 = session.commitProjection({
+    commitRef: 'projected',
+    holobranch: 'site',
+    tree,
+    sourceCommit,
+    sourceDescription: 'v1-test-describe',
+    author: sig,
+    committer: sig,
+  });
+  assert.equal(git(dir, 'log', '-1', '--format=%P', commit2).split(' ')[0], commit);
+  assert.equal(git(dir, 'rev-parse', 'refs/heads/projected'), commit2);
+});
+
+test('commitProjection work-tree mode carries only the holobranch trailer', (t) => {
+  const dir = scratchWorkspace();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const session = new ProjectionSession(dir);
+  const tree = session.projectBranch(rootTree(dir), 'site');
+  const sig = { name: 'Holo Test', email: 'holo@example.com', timeSeconds: 1700000000, offsetMinutes: 0 };
+
+  const commit = session.commitProjection({
+    commitRef: 'refs/heads/projected-wt',
+    holobranch: 'site',
+    tree,
+    workTreePath: '/work/tree/path',
+    author: sig,
+    committer: sig,
+  });
+
+  const message = git(dir, 'log', '-1', '--format=%B', commit);
+  assert.equal(message, '☀ projected site from /work/tree/path\n\nSource-holobranch: site');
+});
+
+test('commitProjection requires exactly one provenance input', (t) => {
+  const dir = scratchWorkspace();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const session = new ProjectionSession(dir);
+  const tree = session.projectBranch(rootTree(dir), 'site');
+  const base = { commitRef: 'refs/heads/x', holobranch: 'site', tree };
+
+  for (const options of [
+    base,
+    { ...base, sourceDescription: 'd', workTreePath: '/p' },
+  ]) {
+    assert.throws(
+      () => session.commitProjection(options),
+      (err) => err.code === 'INVALID_ARGUMENT',
+      'zero or two provenance inputs must raise INVALID_ARGUMENT',
+    );
+  }
+});
+
+test('session errors carry stable codes', (t) => {
+  const dir = scratchWorkspace();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const session = new ProjectionSession(dir);
+
+  assert.throws(
+    () => session.compositeBranch('not-a-hash', 'site'),
+    (err) => err.code === 'INVALID_ARGUMENT',
+  );
+  assert.throws(() => new ProjectionSession(join(dir, 'nope')), (err) => err.code === 'GIT');
+});

--- a/holo-projector/src/lib.rs
+++ b/holo-projector/src/lib.rs
@@ -32,6 +32,11 @@ pub use commit::{commit_projection, CommitProjectionOptions, ProjectionSource};
 // capability that populates refs/holo/source/... for the *_fetching entries.
 pub use fetch::{FetchKind, GitCliFetcher, SourceFetcher};
 
+// Warm-context variants: run against a caller-supplied [`holo_tree::Context`]
+// so embedding hosts can hold a repository handle + `TreeCache` across calls
+// (specs/api/projector-napi.md § ProjectionSession).
+pub use projection::{composite_branch_in, project_branch_in, project_plan_in};
+
 // ── Public API ─────────────────────────────────────────────────────────────
 
 /// Project a holobranch by reading `.holo/` config from a git tree.

--- a/lib/Projection.js
+++ b/lib/Projection.js
@@ -20,6 +20,42 @@ class Projection {
             cacheTo = null
         } = {}
     ) {
+        // resolve lensing intent from branch config when not explicit
+        if (lens === null) {
+            ({ lens } = await branch.getCachedConfig());
+
+            if (typeof lens != 'boolean') {
+                lens = true;
+            }
+        }
+
+
+        // unlensed fast path: the Rust engine's full projection (final
+        // metadata strip included) is spec'd hash-equal to the oracle with
+        // lensing disabled (specs/api/projector-napi.md), so no JS tree
+        // operations are needed at all — watch cycles live on this path
+        if (!lens) {
+            const rustProjectedHash = await RustEngine.projectBranch(branch, { fetch });
+
+            if (rustProjectedHash) {
+                let outputHash = rustProjectedHash;
+
+                if (commitTo) {
+                    outputHash = await Projection.commitTree(
+                        branch.getRepo(),
+                        branch.name,
+                        rustProjectedHash,
+                        commitTo,
+                        { parentCommit, commitMessage }
+                    );
+                }
+
+                logger.info('projection ready');
+                return outputHash;
+            }
+        }
+
+
         // instantiate projection
         const projection = new Projection({ branch });
 
@@ -39,15 +75,6 @@ class Projection {
             await projection.composite({ fetch, cacheFrom, cacheTo });
         }
 
-
-        // apply lensing
-        if (lens === null) {
-            ({ lens } = await branch.getCachedConfig());
-
-            if (typeof lens != 'boolean') {
-                lens = true;
-            }
-        }
 
         if (lens) {
             // write and output pre-lensing hash if debug enabled

--- a/lib/Projection.js
+++ b/lib/Projection.js
@@ -87,10 +87,6 @@ class Projection {
 
         // update commitTo
         if (commitTo) {
-            if (commitTo != 'HEAD' && !commitTo.startsWith('refs/')) {
-                commitTo = `refs/heads/${commitTo}`;
-            }
-
             outputHash = await projection.commit(commitTo, { parentCommit, commitMessage });
         }
 
@@ -209,14 +205,47 @@ class Projection {
         }
     }
 
-    async commit (ref, { parentCommit=null, commitMessage = null } = {}) {
-        const repo = this.branch.getRepo();
+    async commit (ref, options = {}) {
+        return Projection.commitTree(
+            this.branch.getRepo(),
+            this.branch.name,
+            await this.output.root.write(),
+            ref,
+            options
+        );
+    }
+
+    /**
+     * Commit a projected tree to a target ref per
+     * specs/behaviors/projection-commits.md — static so watch cycles can
+     * gate publication (specs/behaviors/watch.md § Supersession) between
+     * projecting and committing. Dispatches to the Rust engine when commits
+     * are routed there (specs/behaviors/engine-selection.md § Commit
+     * dispatch), with the JS path below remaining the conformance oracle
+     * and default committer.
+     */
+    static async commitTree (repo, branchName, treeHash, ref, { parentCommit = null, commitMessage = null } = {}) {
+        if (ref != 'HEAD' && !ref.startsWith('refs/')) {
+            ref = `refs/heads/${ref}`;
+        }
+
+        const rustCommitHash = await RustEngine.commitProjection(repo, {
+            commitRef: ref,
+            holobranch: branchName,
+            tree: treeHash,
+            sourceCommit: parentCommit,
+            commitMessage
+        });
+        if (rustCommitHash) {
+            return rustCommitHash;
+        }
+
         const git = await repo.getGit();
 
         let ancestor = await git.revParse(ref, { $nullOnError: true });
         if (!ancestor) {
             ancestor = await git.commitTree(hololib.TreeObject.getEmptyTreeHash(), {
-                m: `↥ initialized ${this.branch.name}`
+                m: `↥ initialized ${branchName}`
             });
         }
 
@@ -226,7 +255,7 @@ class Projection {
         }
 
         const commitTrailers = [
-            `Source-holobranch: ${this.branch.name}`
+            `Source-holobranch: ${branchName}`
         ];
 
         if (!repo.workTree) {
@@ -236,9 +265,9 @@ class Projection {
             commitTrailers.push(`Source: ${await git.describe({ always: true, tags: true }, repo.ref)}`);
         }
 
-        const commitHash = await git.commitTree(await this.output.root.write(), {
+        const commitHash = await git.commitTree(treeHash, {
             p: parents,
-            m: commitMessage || `☀ projected ${this.branch.name} from ${repo.workTree || await git.describe({ always: true, tags: true }, repo.ref)}\n\n${commitTrailers.join('\n')}`
+            m: commitMessage || `☀ projected ${branchName} from ${repo.workTree || await git.describe({ always: true, tags: true }, repo.ref)}\n\n${commitTrailers.join('\n')}`
         });
 
         await git.updateRef(ref, commitHash);

--- a/lib/Repo.js
+++ b/lib/Repo.js
@@ -314,37 +314,54 @@ class Repo {
             };
         } else {
             const { default: chokidar } = await import('chokidar');
+
+            // Watch each ref's *parent directory* rather than the ref file:
+            // git updates refs by renaming a lock file over them, which
+            // orphans a file-level inotify watch — later updates then fire
+            // no event at all (observed: rapid successive commits silently
+            // dropped). A directory's inode survives every child rename, so
+            // a directory-level watch (depth 0, filtered by path below)
+            // never goes dead. Event coalescing is harmless: the handler
+            // reads the ref's current value at processing time.
             const watcher = chokidar.watch([], {
                 persistent: true,
                 cwd: this.gitDir,
-                ignoreInitial: true
+                ignoreInitial: true,
+                depth: 0,
+                // rename-over is git's atomic write; chokidar's own atomic
+                // stabilization window would only add ~100ms of latency to
+                // every ref event
+                atomic: false
             });
 
-            // watcher.on('all', logger.debug);
-            // watcher.on('error', logger.error);
-
             const symbolicRefs = new Map();
+            const watchedRefs = new Set();
             const addRef = async ref => {
-                // add watch for ref
-                watcher.add(ref);
+                // add watch for ref via its parent directory
+                if (!watchedRefs.has(ref)) {
+                    watchedRefs.add(ref);
+                    watcher.add(path.dirname(ref)); // '.' for HEAD
+                }
 
-                // debug output watcher.add result
-                // setTimeout(() => {
-                //     const watched = watcher.getWatched();
-                //     logger.debug('watcher.add(%s)', ref, [].concat(...Object.keys(watched).map(watchedDir => watched[watchedDir].map(watchedFile => path.join(watchedDir, watchedFile)))));
-                // }, 100);
-
-                // resolve any symbolic target
+                // resolve any symbolic target (a missing ref file — unborn
+                // branch or packed ref — is simply not symbolic)
                 let targetRef;
-                const refContents = await fs.readFile(path.join(this.gitDir, ref), 'ascii');
-                if (refContents.startsWith('ref:')) {
+                let refContents = null;
+                try {
+                    refContents = await fs.readFile(path.join(this.gitDir, ref), 'ascii');
+                } catch (err) {
+                    if (err.code != 'ENOENT') {
+                        throw err;
+                    }
+                }
+                if (refContents && refContents.startsWith('ref:')) {
                     targetRef = refContents.substr(4).trim();
                 }
 
-                // remove existing watch on any symbolic target
+                // drop tracking of any previous symbolic target
                 const oldTargetRef = symbolicRefs.get(ref);
                 if (oldTargetRef && oldTargetRef != targetRef) {
-                    watcher.unwatch(oldTargetRef);
+                    watchedRefs.delete(oldTargetRef);
                     symbolicRefs.delete(ref);
                 }
 
@@ -358,22 +375,33 @@ class Repo {
             // make initial call to addRef
             await addRef(this.ref);
 
-            // monitor for tree hash changes
+            // monitor for tree hash changes; events are processed strictly
+            // in order so concurrent handlers can't race the dedupe state
             let lastRefHash, lastTreeHash;
-            watcher.on('change', async ref => {
-                await addRef(ref); // add watch if contents is symbolic ref
-
-                const git = await this.getGit();
-                const refHash = await git.revParse({ verify: true }, ref);
-
-                if (refHash != lastRefHash) {
-                    lastRefHash = refHash;
-                    const treeHash = await git.getTreeHash(refHash);
-                    if (treeHash != lastTreeHash) {
-                        lastTreeHash = treeHash;
-                        callback(treeHash, refHash);
-                    }
+            let processing = Promise.resolve();
+            watcher.on('all', (event, changedPath) => {
+                if (event != 'add' && event != 'change') {
+                    return;
                 }
+                if (!watchedRefs.has(changedPath)) {
+                    return; // directory noise (e.g. gitDir root for HEAD)
+                }
+
+                processing = processing.then(async () => {
+                    await addRef(changedPath); // update watch if contents is symbolic ref
+
+                    const git = await this.getGit();
+                    const refHash = await git.revParse({ verify: true }, changedPath);
+
+                    if (refHash != lastRefHash) {
+                        lastRefHash = refHash;
+                        const treeHash = await git.getTreeHash(refHash);
+                        if (treeHash != lastTreeHash) {
+                            lastTreeHash = treeHash;
+                            callback(treeHash, refHash);
+                        }
+                    }
+                }).catch(err => logger.error('watch event handling failed for %s: %s', changedPath, err.message));
             });
 
             // return cancel method and watching promise

--- a/lib/Repo.js
+++ b/lib/Repo.js
@@ -334,6 +334,19 @@ class Repo {
                 atomic: false
             });
 
+            // Inode-based events remain the low-latency path, but they can
+            // still coalesce a rapid burst into one event delivered *before*
+            // the burst's final state (observed with back-to-back commits) —
+            // which would leave the newest state unpublished, the one
+            // failure watch may never have (specs/behaviors/watch.md). Each
+            // watched ref therefore also gets a stat-polling safety net
+            // (fs.watchFile): worst case it detects a dropped update one
+            // interval late, and the handler's hash dedupe makes the overlap
+            // harmless.
+            const WATCHFILE_INTERVAL = 500;
+            const nodeFs = require('fs');
+            const statWatchedPaths = new Set();
+
             const symbolicRefs = new Map();
             const watchedRefs = new Set();
             const addRef = async ref => {
@@ -341,6 +354,14 @@ class Repo {
                 if (!watchedRefs.has(ref)) {
                     watchedRefs.add(ref);
                     watcher.add(path.dirname(ref)); // '.' for HEAD
+
+                    const absPath = path.join(this.gitDir, ref);
+                    if (!statWatchedPaths.has(absPath)) {
+                        statWatchedPaths.add(absPath);
+                        nodeFs.watchFile(absPath, { interval: WATCHFILE_INTERVAL }, () => {
+                            enqueueRef(ref);
+                        });
+                    }
                 }
 
                 // resolve any symbolic target (a missing ref file — unborn
@@ -372,26 +393,17 @@ class Repo {
                 }
             };
 
-            // make initial call to addRef
-            await addRef(this.ref);
-
-            // monitor for tree hash changes; events are processed strictly
-            // in order so concurrent handlers can't race the dedupe state
+            // monitor for tree hash changes; ref checks are processed
+            // strictly in order so concurrent handlers can't race the
+            // dedupe state, and re-checks of an unchanged ref are no-ops
             let lastRefHash, lastTreeHash;
             let processing = Promise.resolve();
-            watcher.on('all', (event, changedPath) => {
-                if (event != 'add' && event != 'change') {
-                    return;
-                }
-                if (!watchedRefs.has(changedPath)) {
-                    return; // directory noise (e.g. gitDir root for HEAD)
-                }
-
+            const enqueueRef = ref => {
                 processing = processing.then(async () => {
-                    await addRef(changedPath); // update watch if contents is symbolic ref
+                    await addRef(ref); // update watch if contents is symbolic ref
 
                     const git = await this.getGit();
-                    const refHash = await git.revParse({ verify: true }, changedPath);
+                    const refHash = await git.revParse({ verify: true }, ref);
 
                     if (refHash != lastRefHash) {
                         lastRefHash = refHash;
@@ -401,7 +413,21 @@ class Repo {
                             callback(treeHash, refHash);
                         }
                     }
-                }).catch(err => logger.error('watch event handling failed for %s: %s', changedPath, err.message));
+                }).catch(err => logger.error('watch event handling failed for %s: %s', ref, err.message));
+            };
+
+            // make initial call to addRef
+            await addRef(this.ref);
+
+            watcher.on('all', (event, changedPath) => {
+                if (event != 'add' && event != 'change') {
+                    return;
+                }
+                if (!watchedRefs.has(changedPath)) {
+                    return; // directory noise (e.g. gitDir root for HEAD)
+                }
+
+                enqueueRef(changedPath);
             });
 
             // return cancel method and watching promise
@@ -412,6 +438,9 @@ class Repo {
                     cancel = () => {
                         logger.debug('cancelling watcher');
                         watcher.close();
+                        for (const absPath of statWatchedPaths) {
+                            nodeFs.unwatchFile(absPath);
+                        }
                         resolve();
                     };
                 }),

--- a/lib/RustEngine.js
+++ b/lib/RustEngine.js
@@ -1,3 +1,6 @@
+const path = require('path');
+const fs = require('fs').promises;
+
 const logger = require('./logger');
 
 
@@ -11,6 +14,11 @@ const logger = require('./logger');
  * `rust` turns every would-be fallback into a thrown error so CI can assert
  * the Rust path actually ran.
  *
+ * Rust-path work runs through a per-Repo ProjectionSession (a warm engine
+ * context: persistent repository handle + TreeCache), so repeat projections
+ * in one process — watch cycles above all — skip the ~100ms cold open
+ * (specs/api/projector-napi.md § ProjectionSession).
+ *
  * The binding is loaded from the in-repo crate build (publication deferred);
  * when it isn't built, every dispatch degrades gracefully to the JS engine.
  */
@@ -18,6 +26,10 @@ const logger = require('./logger');
 // undefined = not probed yet, null = unavailable
 let addon;
 let addonLoadError = null;
+
+// warm engine context per Repo instance (host-owned, explicit lifecycle:
+// lives exactly as long as the Repo object that projections run against)
+const sessions = new WeakMap();
 
 function getAddon () {
     if (addon !== undefined) {
@@ -46,16 +58,37 @@ function getEngineOverride () {
 }
 
 /**
+ * Whether any source sub-worktree is checked out under
+ * `<workTree>/.holo/sources/` — the one working-tree condition the Rust
+ * engine can't reproduce: the JS oracle hashes such checkouts into synthetic
+ * source heads (filesystem state outside the object database). Without them,
+ * source heads resolve from gitlinks and refs exactly as the Rust engine
+ * does, so a working-tree projection whose root tree was already hashed is
+ * tree-pure (specs/behaviors/engine-selection.md).
+ */
+async function hasSourceSubWorktrees (repo) {
+    try {
+        const entries = await fs.readdir(path.join(repo.workTree, '.holo', 'sources'), { withFileTypes: true });
+        return entries.some(entry => entry.isDirectory());
+    } catch (err) {
+        if (err.code == 'ENOENT' || err.code == 'ENOTDIR') {
+            return false;
+        }
+        throw err;
+    }
+}
+
+/**
  * Evaluate the fallback conditions shared by both entry points. Returns a
  * reason string when the Rust path can't be used, or null when it can.
  */
-function getFallbackReason ({ repo, fetch = false }) {
+async function getFallbackReason ({ repo, fetch = false }) {
     if (fetch) {
         return 'fetch requested (fetching is a JS-owned side effect)';
     }
 
-    if (repo.workTree) {
-        return 'working tree mode (source heads may be hashed from checked-out worktrees)';
+    if (repo.workTree && await hasSourceSubWorktrees(repo)) {
+        return 'checked-out source sub-worktree(s) present (filesystem state the Rust engine does not read)';
     }
 
     const sourceOverrides = Object.keys(process.env).filter(name => name.startsWith('HOLO_SOURCE_'));
@@ -67,11 +100,25 @@ function getFallbackReason ({ repo, fetch = false }) {
 }
 
 /**
+ * The warm engine context bound to this Repo instance, created on first use
+ * (specs/api/projector-napi.md § ProjectionSession). Callers must have
+ * verified the addon is loadable via shouldUseRust()/getAddon() first.
+ */
+function getSession (repo) {
+    let session = sessions.get(repo);
+    if (!session) {
+        session = new (getAddon().ProjectionSession)(repo.gitDir);
+        sessions.set(repo, session);
+    }
+    return session;
+}
+
+/**
  * Dispatch decision + fallback logging shared by both entry points. Returns
  * true when the Rust path should be attempted; throws under HOLO_ENGINE=rust
  * when it can't be.
  */
-function shouldUseRust ({ what, repo, fetch, extraReason = null }) {
+async function shouldUseRust ({ what, repo, fetch, extraReason = null }) {
     const engine = getEngineOverride();
 
     if (engine == 'js') {
@@ -79,7 +126,7 @@ function shouldUseRust ({ what, repo, fetch, extraReason = null }) {
         return false;
     }
 
-    const reason = extraReason || getFallbackReason({ repo, fetch });
+    const reason = extraReason || await getFallbackReason({ repo, fetch });
     if (reason) {
         if (engine == 'rust') {
             throw new Error(`HOLO_ENGINE=rust but the Rust engine cannot project ${what}: ${reason}`);
@@ -130,14 +177,14 @@ class RustEngine {
             : workspace.hasPhantomSources ? 'programmatic (phantom) source config'
             : null;
 
-        if (!shouldUseRust({ what, repo, fetch, extraReason })) {
+        if (!await shouldUseRust({ what, repo, fetch, extraReason })) {
             return null;
         }
 
         const rootHash = await workspace.root.write();
 
         try {
-            const outputHash = getAddon().compositeBranch(repo.gitDir, rootHash, branch.name);
+            const outputHash = getSession(repo).compositeBranch(rootHash, branch.name);
             logger.info(`composited tree for ${what} with rust engine: ${outputHash}`);
             return outputHash;
         } catch (err) {
@@ -152,7 +199,7 @@ class RustEngine {
     static async projectPlan (repo, sources, mappings, { fetch = false } = {}) {
         const what = 'projection plan';
 
-        if (!shouldUseRust({ what, repo, fetch })) {
+        if (!await shouldUseRust({ what, repo, fetch })) {
             return null;
         }
 
@@ -177,12 +224,53 @@ class RustEngine {
         }));
 
         try {
-            const outputHash = getAddon().projectPlan(repo.gitDir, planSources, planMappings);
+            const outputHash = getSession(repo).projectPlan(planSources, planMappings);
             logger.info(`composited tree for ${what} with rust engine: ${outputHash}`);
             return outputHash;
         } catch (err) {
             return handleBindingError(what, err);
         }
+    }
+
+    /**
+     * Create a projection commit via the Rust engine when commits are routed
+     * there (specs/behaviors/engine-selection.md § Commit dispatch): only
+     * under HOLO_ENGINE=rust — the JS engine remains the default committer
+     * until the CI parity gate has proven commit-hash equality. Returns the
+     * new commit hash, or null when JS owns the commit. The provenance
+     * string is host-computed here, exactly as the oracle computes it
+     * (specs/behaviors/projection-commits.md).
+     */
+    static async commitProjection (repo, { commitRef, holobranch, tree, sourceCommit = null, commitMessage = null }) {
+        if (getEngineOverride() != 'rust') {
+            return null;
+        }
+
+        if (!getAddon()) {
+            throw new Error(`HOLO_ENGINE=rust but the holo-projector addon is not built: ${addonLoadError.message}\nrun: npm run build:projector-addon`);
+        }
+
+        const options = {
+            commitRef,
+            holobranch,
+            tree,
+            sourceCommit: sourceCommit || undefined,
+            message: commitMessage || undefined
+        };
+
+        if (repo.workTree) {
+            options.workTreePath = repo.workTree;
+        } else {
+            const git = await repo.getGit();
+            options.sourceDescription = await git.describe({ always: true, tags: true }, repo.ref);
+        }
+
+        // no fallback handling: under HOLO_ENGINE=rust every failure —
+        // REF_CONFLICT above all — must surface to the caller, never
+        // degrade silently
+        const commitHash = getSession(repo).commitProjection(options);
+        logger.info(`committed projection ${holobranch} to ${commitRef} with rust engine: ${commitHash}`);
+        return commitHash;
     }
 }
 

--- a/lib/RustEngine.js
+++ b/lib/RustEngine.js
@@ -193,6 +193,38 @@ class RustEngine {
     }
 
     /**
+     * Project a holobranch fully — composition plus the final metadata
+     * strip, hash-equal to the oracle with lensing disabled — via the Rust
+     * engine. The composition-only fast path for unlensed projections: no
+     * JS tree operations at all. Returns the projected tree hash, or null
+     * when the caller should run the JS path instead.
+     */
+    static async projectBranch (branch, { fetch = false } = {}) {
+        const workspace = branch.getWorkspace();
+        const repo = branch.getRepo();
+        const what = `holobranch ${branch.name}`;
+
+        const extraReason =
+            branch.phantom || branch.hasPhantomMappings ? 'programmatic (phantom) branch config'
+            : workspace.hasPhantomSources ? 'programmatic (phantom) source config'
+            : null;
+
+        if (!await shouldUseRust({ what, repo, fetch, extraReason })) {
+            return null;
+        }
+
+        const rootHash = await workspace.root.write();
+
+        try {
+            const outputHash = getSession(repo).projectBranch(rootHash, branch.name);
+            logger.info(`projected tree for ${what} with rust engine: ${outputHash}`);
+            return outputHash;
+        } catch (err) {
+            return handleBindingError(what, err);
+        }
+    }
+
+    /**
      * Compose a ProjectionPlan's structured sources/mappings via the Rust
      * engine. Returns the composed tree hash, or null for JS fallback.
      */

--- a/lib/WatchLoop.js
+++ b/lib/WatchLoop.js
@@ -1,0 +1,77 @@
+/**
+ * WatchLoop — serialized, latest-wins cycle runner for watch mode
+ * (specs/behaviors/watch.md).
+ *
+ * Inputs pushed while a cycle is in flight coalesce: however many arrive, at
+ * most one follow-up cycle runs, using the newest input at the moment it
+ * starts. A cycle whose input has been superseded mid-flight discards its
+ * result at the publication gate — after `cycle` produced it, before
+ * `publish` sees it — so results are never published out of input order and
+ * the last published result always corresponds to the newest input.
+ *
+ * A cycle or publication error is reported via `onError` and never stops the
+ * loop: the next pushed input triggers a normal cycle.
+ */
+class WatchLoop {
+
+    /**
+     * @param {object} handlers
+     * @param {function} handlers.cycle - async (input) => result; runs the projection
+     * @param {function} handlers.publish - async (result, input) => void; the publication gate has passed when called
+     * @param {function} [handlers.onError] - (err, input) => void; cycle/publication failures land here
+     */
+    constructor ({ cycle, publish, onError = null }) {
+        if (!cycle || !publish) {
+            throw new Error('cycle and publish handlers required');
+        }
+
+        this.cycle = cycle;
+        this.publish = publish;
+        this.onError = onError || (() => {});
+        this.pending = null;
+        this.draining = null;
+
+        Object.seal(this);
+    }
+
+    /**
+     * Queue an input state, replacing any not-yet-started one, and start
+     * draining if idle. Returns a promise resolving when the loop next goes
+     * idle (all queued work done — for tests and graceful shutdown; watch
+     * callbacks may ignore it).
+     */
+    push (input) {
+        this.pending = { input };
+
+        if (!this.draining) {
+            this.draining = this.drain().finally(() => {
+                this.draining = null;
+            });
+        }
+
+        return this.draining;
+    }
+
+    async drain () {
+        while (this.pending) {
+            const { input } = this.pending;
+            this.pending = null;
+
+            try {
+                const result = await this.cycle(input);
+
+                // publication gate: a newer input superseded this cycle —
+                // discard the result and let the loop continue with it
+                if (this.pending) {
+                    continue;
+                }
+
+                await this.publish(result, input);
+            } catch (err) {
+                this.onError(err, input);
+            }
+        }
+    }
+}
+
+module.exports = WatchLoop;

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ exports.Lens = require('./Lens.js');
 exports.Workspace = require('./Workspace.js');
 exports.Projection = require('./Projection.js');
 exports.ProjectionPlan = require('./ProjectionPlan.js');
+exports.WatchLoop = require('./WatchLoop.js');
 exports.Studio = require('./Studio.js');
 
 exports.BlobObject = require('./BlobObject.js');

--- a/plans/watch-mode.md
+++ b/plans/watch-mode.md
@@ -1,9 +1,14 @@
 ---
-status: in-progress
+status: done
 depends: [projector-napi-cli, projection-commits]
 specs:
+  - specs/behaviors/watch.md
   - specs/behaviors/composition.md
+  - specs/behaviors/engine-selection.md
+  - specs/behaviors/projection-commits.md
+  - specs/api/projector-napi.md
 issues: [437]
+pr: 499
 ---
 
 # Watch mode for continuous projection (Rust engine)
@@ -27,12 +32,12 @@ Continuous re-projection on change: monitor the working tree and/or git refs and
 
 ## Validation
 
-- [ ] `specs/behaviors/watch.md` accepted and merged
-- [ ] Edit → re-projection latency on emergence-site-scale workspace is sub-100ms warm
-- [ ] Repeat projections reuse a warm engine context (persistent repo handle + `TreeCache` across binding calls; deferred from [`projector-napi-cli`](projector-napi-cli.md))
-- [ ] Rapid successive changes coalesce (debounce) and stale in-flight projections are superseded
-- [ ] `--working` projections reflect uncommitted changes correctly (watch is the main consumer of working-tree trees)
-- [ ] Watch cycles that commit do so through the Rust `commit_projection` path via the binding, hash-identical to the JS commit path (deferred from [`projection-commits`](projection-commits.md))
+- [x] `specs/behaviors/watch.md` accepted and merged (same PR, with amendments to `engine-selection.md`, `projector-napi.md`, `projection-commits.md`)
+- [x] Edit → re-projection latency on emergence-site-scale workspace is sub-100ms warm (~90ms commit→publication e2e for output-changing edits; 62–82ms in-process warm projection)
+- [x] Repeat projections reuse a warm engine context (persistent repo handle + `TreeCache` across binding calls; deferred from [`projector-napi-cli`](projector-napi-cli.md)) — first call 123–195ms vs 62–82ms warm; warm cycles do 0 tree reads (3,380 cache hits); binding tests prove cache reuse via `cachedTrees()`/stats
+- [x] Rapid successive changes coalesce (debounce) and stale in-flight projections are superseded (burst of 5 commits → 2 publications, final matches one-shot of final state; `WatchLoop` unit tests + `project --watch` child-process integration tests)
+- [x] `--working` projections reflect uncommitted changes correctly (emergence-site with an uncommitted mapped file: `2e36d5fe…` both engines, change present in output)
+- [x] Watch cycles that commit do so through the Rust `commit_projection` path via the binding, hash-identical to the JS commit path (deferred from [`projection-commits`](projection-commits.md)) — `docs-site --commit-to` under pinned identity: `4ceee3a4…` byte-identical from both engines; CI dual-engine gate extended with the commit-parity step; dispatch is `HOLO_ENGINE=rust`-gated (JS remains the default committer per `engine-selection.md` § Commit dispatch)
 
 ## Risks / unknowns
 
@@ -41,8 +46,17 @@ Continuous re-projection on change: monitor the working tree and/or git refs and
 
 ## Notes
 
-_(populated at closeout)_
+- **Event-boundary design confirmed**: the engine gained no watch dependency; the host owns watching and triggers re-projection through a warm `ProjectionSession` (explicit consumer-owned object per the post-#490 philosophy; thread-id-memoized handle per holo-tree-napi's `local_repo`). Watchman (working tree) and chokidar (refs) both stay.
+- **Staleness contract proven, not assumed**: only content-addressed state is cached across calls; refs re-resolve every call and externally written objects are visible — binding tests advance a source spec-ref and write commits behind an open session via the git CLI and assert the next call observes them. gix's stat-revalidated packed-refs snapshot and refresh-on-miss ODB behave as required.
+- **Two real inotify failure modes found and specced** (`watch.md` § Triggers): a file-level watch dies permanently at the first rename-over of a ref, and even a directory-level watch can coalesce a burst into one event delivered *before* the final state. Implementation: directory-level events (fast path) + per-ref `fs.watchFile` stat poll (500ms safety net); coalescing is harmless because the handler reads the ref's current value at processing time.
+- **Watch startup race fixed**: the watcher subscribes before the initial projection, which runs through the same latest-wins loop — previously an edit landing between the first output and subscription was silently lost.
+- **Unlensed fast path**: with lensing disabled the CLI uses the binding's full `projectBranch` (spec'd hash-equal with lensing disabled), skipping all JS tree operations per cycle — this took the e2e cycle from ~150ms to ~90ms. Working-tree eligibility was refined in `engine-selection.md`: only checked-out source sub-worktrees under `.holo/sources/` force the JS engine.
+- **Working-tree hashing did not dominate** at emergence-site scale (~40–50ms warm via the holoindex `git reset`/`add`/`write-tree` sequence vs ~80ms projection); incremental hashing not needed yet — revisit only if larger workspaces change the balance.
+- The historical ~27ms warm figure is machine-dependent; on this box the warm engine cycle is 62–82ms, ~60ms of which is re-hashing/re-writing all 3,057 output trees every cycle (0 reads, `treesSkippedClean=0`) — see follow-up #498.
+- Rebased over [`remote-source-fetching`](remote-source-fetching.md) (PR #496): `*_in` signatures were unchanged (separate `*_fetching_in` variants), `SOURCE_FETCH` flows through the binding's generic code mapping, and the session test fixture moved from local-ref to spec-ref resolution when #496 removed the local-ref fallback.
 
 ## Follow-ups
 
-_(populated at closeout)_
+- Issue [#497](https://github.com/JarvusInnovations/hologit/issues/497) — wire source fetching through the projector binding (lift the `fetch requested` fallback; engine capability landed with #496; watch's `--fetch` startup cycle falls back to JS until then)
+- Issue [#498](https://github.com/JarvusInnovations/hologit/issues/498) — avoid redundant tree writes on warm projection cycles (~60ms of the ~80ms emergence-site warm cycle)
+- Tracked as: warm lens-container pool for lensed watch cycles is [`lens-execution`](lens-execution.md)'s scope (in progress — not edited here per plan protocol); lensed branches meanwhile watch via the hybrid path (Rust composite → JS lens per cycle), seam at `Projection.projectBranch`'s lens branch

--- a/plans/watch-mode.md
+++ b/plans/watch-mode.md
@@ -1,5 +1,5 @@
 ---
-status: planned
+status: in-progress
 depends: [projector-napi-cli, projection-commits]
 specs:
   - specs/behaviors/composition.md

--- a/specs/api/projector-napi.md
+++ b/specs/api/projector-napi.md
@@ -22,9 +22,51 @@ to its tree.
 | `compositeBranch(gitDir, rootTree, holobranch)` | tree hash | The **pre-lens composed tree**: the extends chain and all mappings composed per `specs/behaviors/composition.md`, with `.holo/{branches,sources}` stripped but the final `.holo` strip **skipped** (`.holo/config.toml` and `.holo/lenses` are retained for the JS lens phase). |
 | `projectBranch(gitDir, rootTree, holobranch)` | tree hash | Full composition-only projection, including the final metadata strip. Hash-equal to the oracle with lensing disabled. |
 | `projectPlan(gitDir, sources, mappings)` | tree hash | Structured-config composition (the `ProjectionPlan` path); no `.holo/` config needed. `sources`: `{ name, url?, ref?, projectHolobranch? }`. `mappings`: `{ source, files?, root?, output?, layer?, after?, before? }` with the same defaults as `ProjectionPlan.addMapping`. |
+| `new ProjectionSession(gitDir)` | session | Warm engine context: a persistent repository handle + `TreeCache` reused across calls (see § ProjectionSession). |
 | `stats()` | `{ treesRead, treesWritten, treesSkippedClean, cacheHits, cacheMisses, blobsRead }` | Process-global monotonic counters (metrics only). |
 | `resetStats()` | — | Reset counters and module caches. |
 | `__triggerPanicForTest()` | throws `PANIC` | Test hook proving panic containment; never call outside tests. |
+
+The top-level functions are one-shot: each call opens the repository and
+builds a fresh cache. Hosts making repeat projections (watch cycles, servers,
+gitsheets-style embedders) hold a `ProjectionSession` instead.
+
+## ProjectionSession
+
+An explicitly consumer-owned warm context — never hidden module state (the
+post-`TreeCache` philosophy from `specs/api/errors.md` § Thread-safety
+expectations, projected onto this binding). Construction opens the repository
+once (`GIT` on failure); the session holds a `ThreadSafeRepository`, a
+thread-id-memoized derived handle (the holo-tree-napi `local_repo` pattern —
+a call landing on a new thread re-derives, costing warmth, never
+correctness), and one `TreeCache`.
+
+| Method | Returns | Semantics |
+| --- | --- | --- |
+| `compositeBranch(rootTree, holobranch)` | tree hash | As the top-level export, against the session's warm context. |
+| `projectBranch(rootTree, holobranch)` | tree hash | As the top-level export. |
+| `projectPlan(sources, mappings)` | tree hash | As the top-level export. |
+| `commitProjection(options)` | commit hash | Create a projection commit and advance the target ref per `specs/behaviors/projection-commits.md`. `options`: `{ commitRef, holobranch, tree, sourceCommit?, sourceDescription?, workTreePath?, message?, author?, committer? }`. Exactly one of `sourceDescription` (ref mode) / `workTreePath` (working-tree mode) is required (`INVALID_ARGUMENT` otherwise); the description is host-computed, never engine-derived. `author`/`committer` are `{ name, email, timeSeconds?, offsetMinutes? }`; omitted, identity resolves from repo config (incl. `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env). A concurrent ref move surfaces as `REF_CONFLICT`. |
+| `cachedTrees()` | number | `TreeCache` entry count — observability so warmth is provable in tests; metrics only. |
+| `clearCache()` | — | Drop the session's `TreeCache` (never required for correctness; a memory valve for long-lived hosts). |
+
+### Staleness contract
+
+The session caches **only content-addressed state** (parsed trees keyed by
+tree id; the gix object cache keyed by object id) — immutable by
+construction, reusable forever. Everything mutable is read fresh on every
+call:
+
+- **Refs are never cached.** Source heads, spec refs, and commit targets are
+  re-resolved from the repository per call; a ref advanced behind the session
+  is observed by the next call.
+- **Objects written behind the session are visible.** New loose objects and
+  packs (e.g. trees the host hashed from a working tree, commits written by
+  the JS side between calls) are found without reopening the session.
+
+Serving stale state is a correctness bug (`specs/behaviors/watch.md` § Warm
+session and staleness); the binding's test suite writes refs and objects
+behind an open session and asserts the next call observes them.
 
 ## Error contract
 
@@ -56,9 +98,12 @@ matching the holo-tree binding.
   platform packages yet — publication is a follow-up. When it happens, the
   release tag track is prefix-namespaced (`holo-projector-v*`); a bare `v*`
   tag is never acceptable (it collides with the `hologit` release namespace).
-- The binding opens the repository per call; callers batch work per
+- The one-shot exports open the repository per call; callers batch work per
   projection, and tree caching lives inside the engine for the duration of a
-  call.
+  call. `ProjectionSession` is the warm path: repeat projections against the
+  same repository reuse the handle and cache across calls.
+- `Error::RefConflict` forwards as `REF_CONFLICT` via the `Error::Tree`
+  passthrough (relevant to `commitProjection`).
 
 ## Principles
 

--- a/specs/behaviors/engine-selection.md
+++ b/specs/behaviors/engine-selection.md
@@ -5,7 +5,8 @@
 The CLI projects holobranches through a **hybrid pipeline**: pure composition
 runs in the Rust engine (`holo-projector`, via the `holo-projector-napi`
 binding) whenever the projection shape allows, and the JS engine keeps
-ownership of all side effects — fetching, lensing, commits, watch. Any
+ownership of all side effects — fetching, lensing, commits (see § Commit
+dispatch), watch triggers. Any
 projection the Rust path cannot handle falls back to the full JS engine
 **observably** (exactly one logged line stating why), never silently. Both
 paths produce hash-identical output; engine selection is a performance
@@ -49,10 +50,40 @@ falls back to the JS engine with a single logged line naming the condition:
 | --- | --- |
 | Addon not built/loadable | The binding is an optional native artifact; a pure-JS install must behave exactly as before it existed. Degradation is silent-by-default here (debug log), because it is the documented npm-consumer state, not an anomaly. |
 | `fetch` requested | Fetching is a side effect owned by JS; the Rust engine only reads local refs. |
-| Working-tree mode (`repo.workTree` set) | Source heads may be hashed from checked-out sub-worktrees — filesystem state the Rust engine does not read. |
+| Working-tree mode with a checked-out source sub-worktree (`repo.workTree` set **and** any directory exists under `<workTree>/.holo/sources/`) | Source heads may be hashed from checked-out sub-worktrees — filesystem state the Rust engine does not read. Without sub-worktrees the JS oracle resolves source heads from gitlinks and refs exactly as the Rust engine does, so a working-tree projection whose root tree was already hashed (`Repo#hashWorkTree`) is tree-pure and Rust-eligible — the case watch mode's working-tree cycles live on. |
 | `HOLO_SOURCE_*` environment overrides present | The Rust engine reads source config only from the tree. |
 | Phantom (programmatic) branch/source config | In-memory config objects are invisible to an engine that reads config from the tree. `ProjectionPlan` instead uses the binding's `projectPlan` entry point, which accepts structured config directly. |
 | The binding throws (e.g. `SOURCE_RESOLUTION` for an unfetched source, `LENSED_SUBPROJECTION`) | The JS engine can resolve what Rust refused: it fetches on demand and lenses sub-projections. |
+
+### Commit dispatch
+
+`--commit-to` commits are created per `specs/behaviors/projection-commits.md`
+by either engine — both produce byte-identical commits from the same inputs.
+Ownership today:
+
+- **Default (hybrid) and `HOLO_ENGINE=js`**: the JS engine commits (the
+  oracle path). JS remains the default committer until the CI parity gate
+  (below) has demonstrated commit-hash equality in production use; flipping
+  the default is a future spec change.
+- **`HOLO_ENGINE=rust`**: the commit is created through the binding's
+  `commitProjection` (warm session), with the host supplying the
+  `git describe --always --tags` provenance string and identity exactly as
+  the oracle computes them. Any failure is a thrown error, never a silent
+  fallback — this is what lets CI assert the Rust commit path ran.
+
+The CI gate extends the hash-equality conformance to commits: the fixture
+projections run with `--commit-to` under both engines with pinned identity
+(`GIT_AUTHOR_*`/`GIT_COMMITTER_*`) and the resulting **commit hashes** must
+be equal.
+
+### Warm engine context
+
+Rust-path projections run through a per-repository `ProjectionSession`
+(`specs/api/projector-napi.md` § ProjectionSession) owned by the dispatcher
+and keyed to the `Repo` instance, so repeat projections in one process —
+watch cycles above all — reuse the repository handle and content caches.
+Session reuse is invisible in output hashes (warmth is never a behavior
+decision); the staleness contract lives with the session spec.
 
 ### `HOLO_ENGINE` override
 

--- a/specs/behaviors/projection-commits.md
+++ b/specs/behaviors/projection-commits.md
@@ -19,9 +19,12 @@ summarized under [Ported vs. desired state](#ported-vs-desired-state).
 
 - `holo_projector::commit_projection` (Rust engine capability)
 - `lib/Projection.js` `Projection#commit` — the conformance oracle, and the
-  hybrid CLI's `--commit-to` path today (JS owns commits per
-  `specs/behaviors/engine-selection.md`; wiring the Rust capability into the
-  CLI lands with watch-mode's warm-context work)
+  hybrid CLI's default `--commit-to` path (engine choice for commits is
+  specced in `specs/behaviors/engine-selection.md` § Commit dispatch; the
+  Rust path runs via the binding's `commitProjection` under
+  `HOLO_ENGINE=rust`)
+- `specs/behaviors/watch.md` — per-cycle commit inputs and the CAS/
+  `REF_CONFLICT` behavior of committing watch cycles
 
 ## Details
 

--- a/specs/behaviors/watch.md
+++ b/specs/behaviors/watch.md
@@ -37,13 +37,16 @@ A change event that does not change the effective input (same ref target, or
 a tree hash identical to the previous cycle's) publishes nothing — duplicate
 suppression is by hash, not by event.
 
-Ref watching must survive git's rename-based ref updates: a ref advances by
-a lock file renamed over it, which permanently orphans a file-level inotify
-watch (later updates then fire no event at all — observed, not theoretical).
-The watcher monitors each ref's parent directory and filters by path; event
-*coalescing* is harmless because the handler reads the ref's current value
-at processing time, but event *loss* violates "the newest observed state
-always wins".
+Ref watching must survive git's rename-based ref updates. Two observed (not
+theoretical) inotify failure modes: a file-level watch is permanently
+orphaned by the first rename-over (later updates fire no event at all), and
+even a directory-level watch can coalesce a rapid burst into one event
+delivered *before* the burst's final state. Event *coalescing* is harmless —
+the handler reads the ref's current value at processing time — but event
+*loss* violates "the newest observed state always wins". The watcher
+therefore layers a low-latency event path (the ref's parent directory,
+filtered by path) over a stat-polling safety net per watched ref, whose
+interval bounds the worst-case detection delay for a dropped event.
 
 ### The watcher belongs to the host
 

--- a/specs/behaviors/watch.md
+++ b/specs/behaviors/watch.md
@@ -37,6 +37,14 @@ A change event that does not change the effective input (same ref target, or
 a tree hash identical to the previous cycle's) publishes nothing — duplicate
 suppression is by hash, not by event.
 
+Ref watching must survive git's rename-based ref updates: a ref advances by
+a lock file renamed over it, which permanently orphans a file-level inotify
+watch (later updates then fire no event at all — observed, not theoretical).
+The watcher monitors each ref's parent directory and filters by path; event
+*coalescing* is harmless because the handler reads the ref's current value
+at processing time, but event *loss* violates "the newest observed state
+always wins".
+
 ### The watcher belongs to the host
 
 The engine stays pure (`principles.md#composition-is-pure-side-effects-live-at-the-edges`):

--- a/specs/behaviors/watch.md
+++ b/specs/behaviors/watch.md
@@ -1,0 +1,158 @@
+# Behavior: Watch mode (continuous re-projection)
+
+## Rule
+
+Watch mode re-runs a projection whenever its input state changes: the watched
+ref advances (ref mode) or the working tree is edited (working-tree mode).
+Each **cycle** projects exactly the input state it observed and publishes one
+result (an output line, plus a ref advance when committing). Cycles are
+**serialized and latest-wins**: rapid changes coalesce, intermediate states
+may be skipped entirely, and a cycle whose input has been superseded by a
+newer change may be abandoned before publication — the last published result
+always corresponds to the newest observed input.
+
+**The engine does not watch.** Filesystem and ref monitoring is a side effect
+owned by the host (the CLI, or any embedding consumer); the engine's
+contribution is a warm **projection session** that makes repeat projections
+cheap. The engine carries no watcher dependency and no event loop.
+
+## Applies To
+
+- `commands/project.js` (`--watch`) — the projection watch loop
+- `commands/watch.js` — bare watch (publishes input hashes only, no projection)
+- `lib/Repo.js` `Repo#watch` — the trigger source (watchman / chokidar)
+- `holo-projector-napi` `ProjectionSession` (see `specs/api/projector-napi.md`)
+- `specs/behaviors/projection-commits.md` — per-cycle commit behavior
+
+## Details
+
+### Triggers
+
+| Mode | Watched state | Mechanism | Cycle input |
+| --- | --- | --- | --- |
+| Ref mode (default) | The watched ref (`--ref`, default `HEAD`), following symbolic refs — a re-target of `HEAD` re-subscribes to the new branch | Host file-watch on the ref files under the git dir (chokidar today) | The ref's new commit and its root tree |
+| Working-tree mode (`--working`) | The repository's working tree, excluding the git dir and editor droppings (swap/backup files) | Host filesystem watcher (watchman today), VCS-aware deferral enabled | The working tree hashed to a root tree via the holoindex (`Repo#hashWorkTree`) |
+
+A change event that does not change the effective input (same ref target, or
+a tree hash identical to the previous cycle's) publishes nothing — duplicate
+suppression is by hash, not by event.
+
+### The watcher belongs to the host
+
+The engine stays pure (`principles.md#composition-is-pure-side-effects-live-at-the-edges`):
+it never registers filesystem watchers, polls refs, or owns a debounce timer.
+The host observes changes and calls the engine once per cycle. This is a
+deliberate event-boundary decision:
+
+- Embedding consumers (gitsheets watch is tracked demand) already have their
+  own change sources (transactions, HTTP hooks); they need a fast re-project
+  primitive, not a second watcher competing with theirs.
+- Watcher choice stays a host concern: the CLI keeps watchman for working
+  trees (VCS-aware `defer_vcs`, editor-noise filtering proven in production)
+  and chokidar for ref files. Replacing either never touches the engine. An
+  engine-side `notify` dependency was considered and rejected: it would fold
+  platform event semantics into the pure core for zero determinism benefit.
+
+### Debounce and coalescing
+
+Change events are debounced (a short, implementation-defined window; 50ms
+ported from the oracle) and coalesced: however many events arrive while a
+cycle is in flight, **at most one** follow-up cycle runs, using the newest
+input state at the moment it starts. A burst of N saves produces between 1
+and N published results; the final one always reflects the last save.
+
+### Supersession
+
+A cycle whose input is superseded mid-flight (a newer change was observed
+after the cycle started) MAY be abandoned at any checkpoint before
+publication, and MUST NOT publish after a newer cycle has published.
+Composition itself is a synchronous engine call and is not interruptible; the
+mandatory checkpoint sits at the **publication gate** — after the output hash
+exists, before the output line and any commit. A superseded cycle that has
+reached its gate discards its result silently; the pending newer cycle runs
+immediately. (This subsumes the intent of #19 — "cancel" means "never
+publish", not "tear down mid-computation".)
+
+### Per-cycle publication
+
+- Watch start performs an initial projection immediately (before any change)
+  and publishes it — a watch session's first output is always the current
+  state, never silence until an edit.
+- Each published cycle emits exactly one line to stdout: the projected tree
+  hash, or the projection commit hash when committing. Diagnostics go to the
+  log stream, never stdout.
+- A cycle that fails (projection error, lens failure, `REF_CONFLICT`)
+  publishes nothing, reports the error on the log stream, and the watch
+  continues — the next change triggers a normal cycle. Watch only exits on
+  cancellation or a watcher error.
+
+### Committing cycles (`--commit-to`)
+
+Each published cycle that commits does so per
+`specs/behaviors/projection-commits.md`, with per-mode inputs:
+
+- **Ref mode**: source commit = the watched ref's new commit (second parent +
+  `Source-commit` trailer); source description = `git describe --always
+  --tags` of the watched ref, host-computed per cycle.
+- **Working-tree mode**: no source commit for watch cycles (the working tree
+  is not a commit); the `from` clause is the work-tree path. (Oracle quirk,
+  ported: the *initial* projection of a `--working --watch` session still
+  passes the ref's commit as source parent — only change-triggered cycles
+  omit it.)
+- The first parent is the target ref's value observed at cycle start; the
+  advance is compare-and-swap on it. An external writer moving the target ref
+  mid-cycle surfaces as `REF_CONFLICT` (`specs/api/errors.md`) — the cycle
+  fails as above, and the next cycle re-resolves the ref fresh. Watch never
+  clobbers an external write. Successive watch cycles are serialized, so the
+  loop never conflicts with itself.
+
+### Warm session and staleness
+
+Watch cycles run through a persistent engine session
+(`specs/api/projector-napi.md` § ProjectionSession) holding the repository
+handle and content caches across cycles. The staleness contract that makes
+this safe:
+
+| State | Cached across cycles? | Why |
+| --- | --- | --- |
+| Tree/blob/commit content, parsed-tree cache (`TreeCache`), object cache | Yes, indefinitely | Content-addressed: the key fully determines the content (`principles.md#a-content-addressed-key-captures-exactly-what-determines-the-output`); reuse is a performance choice, never a correctness risk |
+| Ref values (source heads, target refs, `HEAD`) | **Never** | Mutable state; every cycle re-resolves refs from the repository |
+| Object presence (packs, loose objects written by other processes between cycles) | Re-checked | New objects — e.g. trees the host hashed from the working tree — must be visible to the session without reopening it |
+
+A session serving a stale ref value or failing to see an externally written
+object is a correctness bug, not a performance trade-off — worse than a cold
+open, because it silently projects the wrong input. Conformance: session
+tests write refs and objects behind an open session and assert the next call
+observes them.
+
+### Re-projection scope
+
+A cycle re-projects the watched holobranch in full from its new root tree.
+There is no incremental/differential projection: warmth comes from
+content-addressed caches making unchanged subtrees cheap, not from diffing.
+(If working-tree hashing cost comes to dominate cycle latency at scale,
+incremental *hashing* is the follow-up — never partial re-projection, which
+would trade hash-identity for speed.)
+
+## Principles
+
+**Inherited** — from [`principles.md`](../principles.md):
+
+- [Composition is pure; side effects live at the edges](../principles.md#composition-is-pure-side-effects-live-at-the-edges) —
+  watching is an edge: the host observes and triggers; the engine only
+  projects.
+- [Determinism is the product](../principles.md#determinism-is-the-product) —
+  a watch cycle's output is hash-identical to a one-shot projection of the
+  same input state; session warmth may never change a result, only its
+  latency.
+- [A content-addressed key captures exactly what determines the output](../principles.md#a-content-addressed-key-captures-exactly-what-determines-the-output) —
+  the staleness table above is this principle applied to session state:
+  immutable-by-key is cached, mutable is re-read.
+
+**Local:**
+
+- **The newest observed state always wins.** When throughput and freshness
+  conflict (bursts, slow cycles), watch drops intermediate results rather
+  than queueing them: never publish two results out of input order, never
+  finish a session on anything but the latest input. A consumer of the watch
+  stream may treat each published line as "current as of publication".

--- a/test/integration/watch.test.js
+++ b/test/integration/watch.test.js
@@ -1,0 +1,139 @@
+/**
+ * Watch Mode Integration Tests (specs/behaviors/watch.md)
+ *
+ * Drives `project --watch` as a real child process against a sandbox repo in
+ * ref mode: the initial publication, re-projection on ref advance, duplicate
+ * suppression, and per-cycle commits. Engine-agnostic — runs identically
+ * under the hybrid dispatcher with or without the Rust addon built.
+ */
+
+const path = require('path');
+const { spawn } = require('child_process');
+
+const GitSandbox = require('../helpers/git-sandbox.js');
+
+const CLI = path.join(__dirname, '../../bin/cli.js');
+
+/** Spawn `project <holobranch> --watch` and collect stdout lines. */
+function spawnWatch (sandbox, args) {
+    const child = spawn('node', [CLI, 'project', ...args], {
+        cwd: sandbox.dir,
+        env: { ...process.env, GIT_DIR: sandbox.gitDir, GIT_WORK_TREE: sandbox.dir },
+        stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    const lines = [];
+    const waiters = [];
+    let stderr = '';
+    let buffered = '';
+
+    child.stdout.on('data', (chunk) => {
+        buffered += chunk;
+        let newlineIndex;
+        while ((newlineIndex = buffered.indexOf('\n')) >= 0) {
+            lines.push(buffered.slice(0, newlineIndex));
+            buffered = buffered.slice(newlineIndex + 1);
+            waiters.splice(0).forEach((check) => check());
+        }
+    });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+
+    const waitForLines = (count, timeoutMs = 20000) => new Promise((resolve, reject) => {
+        const deadline = setTimeout(
+            () => reject(new Error(`timed out waiting for ${count} output lines, have ${lines.length}; stderr:\n${stderr}`)),
+            timeoutMs
+        );
+        const check = () => {
+            if (lines.length >= count) {
+                clearTimeout(deadline);
+                resolve();
+            } else {
+                waiters.push(check);
+            }
+        };
+        check();
+    });
+
+    return { child, lines, waitForLines };
+}
+
+describe('project --watch (ref mode)', () => {
+    let sandbox;
+
+    beforeEach(async () => {
+        sandbox = await GitSandbox.create();
+
+        await sandbox.addFile('src/app.js', 'console.log("v1");\n');
+        await sandbox.initHolo({ name: 'test-repo' });
+        await sandbox.addBranch('dist', {
+            '_test-repo': {
+                files: 'src/**'
+            }
+        });
+        await sandbox.commit('initial setup');
+    });
+
+    afterEach(async () => {
+        await sandbox.cleanup();
+    });
+
+    test('publishes the initial projection, re-projects on ref advance, and commits per cycle', async () => {
+        const { child, lines, waitForLines } = spawnWatch(sandbox, [
+            'dist', '--watch', '--no-lens', '--no-cache-from', '--commit-to=refs/heads/projected'
+        ]);
+
+        try {
+            // initial publication: a watch session's first output is the
+            // current state, and with --commit-to it is a commit hash
+            await waitForLines(1);
+            const initialTree = await sandbox.git.revParse(`${lines[0]}^{tree}`);
+            expect(await sandbox.listTree(initialTree)).toEqual(['src/app.js']);
+            expect(await sandbox.git.revParse('refs/heads/projected')).toEqual(lines[0]);
+
+            // ref advance triggers a re-projection cycle
+            await sandbox.addFile('src/app.js', 'console.log("v2");\n');
+            await sandbox.addFile('src/extra.js', 'module.exports = 2;\n');
+            await sandbox.commit('v2');
+            await waitForLines(2);
+
+            const cycleTree = await sandbox.git.revParse(`${lines[1]}^{tree}`);
+            expect(await sandbox.listTree(cycleTree)).toEqual(['src/app.js', 'src/extra.js']);
+
+            // per-cycle commit: the target ref advanced to the published
+            // commit, whose first parent is the previous projection commit
+            // (specs/behaviors/projection-commits.md)
+            expect(await sandbox.git.revParse('refs/heads/projected')).toEqual(lines[1]);
+            expect(await sandbox.git.revParse(`${lines[1]}^1`)).toEqual(lines[0]);
+
+            // the cycle's source commit rides along as second parent
+            expect(await sandbox.git.revParse(`${lines[1]}^2`)).toEqual(await sandbox.git.revParse('HEAD'));
+        } finally {
+            child.kill('SIGTERM');
+        }
+    });
+
+    test('suppresses cycles whose input tree is unchanged', async () => {
+        const { child, lines, waitForLines } = spawnWatch(sandbox, [
+            'dist', '--watch', '--no-lens', '--no-cache-from'
+        ]);
+
+        try {
+            await waitForLines(1);
+
+            // an empty commit changes the ref but not the input tree —
+            // duplicate suppression is by hash, not by event
+            await sandbox.git.commit({ 'allow-empty': true, m: 'no tree change' });
+
+            // a real change afterward must still publish exactly one line
+            await sandbox.addFile('src/app.js', 'console.log("v3");\n');
+            await sandbox.commit('v3');
+            await waitForLines(2);
+
+            // allow any (wrongly) queued duplicate cycle to flush
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+            expect(lines).toHaveLength(2);
+        } finally {
+            child.kill('SIGTERM');
+        }
+    });
+});

--- a/test/unit/watch-loop.test.js
+++ b/test/unit/watch-loop.test.js
@@ -1,0 +1,145 @@
+/**
+ * Tests for WatchLoop — the serialized, latest-wins cycle runner behind
+ * `project --watch` (specs/behaviors/watch.md): coalescing of rapid inputs,
+ * the publication-gate supersession rule, error isolation, and ordering.
+ */
+
+const WatchLoop = require('../../lib/WatchLoop.js');
+
+/** A manually-resolvable promise. */
+function deferred () {
+    let resolve, reject;
+    const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+    return { promise, resolve, reject };
+}
+
+describe('WatchLoop', () => {
+
+    test('requires cycle and publish handlers', () => {
+        expect(() => new WatchLoop({})).toThrow('cycle and publish handlers required');
+    });
+
+    test('runs a cycle and publishes its result', async () => {
+        const published = [];
+        const loop = new WatchLoop({
+            cycle: async (input) => `projected:${input}`,
+            publish: async (result, input) => published.push([result, input])
+        });
+
+        await loop.push('a');
+        expect(published).toEqual([['projected:a', 'a']]);
+    });
+
+    test('serializes cycles and coalesces a burst to the newest input', async () => {
+        const gates = [];
+        const projected = [];
+        const published = [];
+
+        const loop = new WatchLoop({
+            cycle: async (input) => {
+                projected.push(input);
+                const gate = deferred();
+                gates.push(gate);
+                await gate.promise;
+                return `projected:${input}`;
+            },
+            publish: async (result) => published.push(result)
+        });
+
+        const idle = loop.push('a');
+        // a burst of inputs while cycle 'a' is in flight
+        loop.push('b');
+        loop.push('c');
+        loop.push('d');
+
+        gates[0].resolve(); // finish cycle 'a' — superseded by 'd'
+        while (gates.length < 2) {
+            await new Promise(resolve => setImmediate(resolve)); // let the loop reach the next cycle
+        }
+        gates[1].resolve(); // finish the follow-up cycle
+        await idle;
+
+        // intermediate inputs b and c were never projected at all
+        expect(projected).toEqual(['a', 'd']);
+        // cycle 'a' hit the publication gate superseded and was discarded
+        expect(published).toEqual(['projected:d']);
+    });
+
+    test('publishes every input when cycles keep pace', async () => {
+        const published = [];
+        const loop = new WatchLoop({
+            cycle: async (input) => `projected:${input}`,
+            publish: async (result) => published.push(result)
+        });
+
+        await loop.push('a');
+        await loop.push('b');
+        await loop.push('c');
+
+        expect(published).toEqual(['projected:a', 'projected:b', 'projected:c']);
+    });
+
+    test('a cycle error is reported and does not stop the loop', async () => {
+        const published = [];
+        const errors = [];
+
+        const loop = new WatchLoop({
+            cycle: async (input) => {
+                if (input == 'boom') {
+                    throw new Error('cycle failed');
+                }
+                return `projected:${input}`;
+            },
+            publish: async (result) => published.push(result),
+            onError: (err, input) => errors.push([err.message, input])
+        });
+
+        await loop.push('boom');
+        await loop.push('ok');
+
+        expect(errors).toEqual([['cycle failed', 'boom']]);
+        expect(published).toEqual(['projected:ok']);
+    });
+
+    test('a publish error is reported and does not stop the loop', async () => {
+        const errors = [];
+        let publishes = 0;
+
+        const loop = new WatchLoop({
+            cycle: async (input) => input,
+            publish: async (result) => {
+                publishes++;
+                if (result == 'bad') {
+                    throw new Error('publish failed');
+                }
+            },
+            onError: (err, input) => errors.push([err.message, input])
+        });
+
+        await loop.push('bad');
+        await loop.push('good');
+
+        expect(errors).toEqual([['publish failed', 'bad']]);
+        expect(publishes).toBe(2);
+    });
+
+    test('an input pushed during publish supersedes nothing already published', async () => {
+        const published = [];
+        let loop;
+
+        loop = new WatchLoop({
+            cycle: async (input) => `projected:${input}`,
+            publish: async (result) => {
+                published.push(result);
+                if (result == 'projected:a') {
+                    loop.push('b'); // arrives after 'a' passed its gate
+                }
+            }
+        });
+
+        await loop.push('a');
+
+        // 'a' was already published when 'b' arrived; 'b' publishes after it
+        expect(published).toEqual(['projected:a', 'projected:b']);
+    });
+});


### PR DESCRIPTION
Executes [`plans/watch-mode.md`](https://github.com/JarvusInnovations/hologit/blob/feat/watch-mode/plans/watch-mode.md): continuous re-projection on change, powered by the Rust engine's warm path. Closes #437.

## Spec decisions (`specs/behaviors/watch.md`, new)

- **The engine does not watch.** Filesystem/ref monitoring stays a host-owned side effect (watchman for working trees, chokidar for refs); the engine's contribution is a warm `ProjectionSession`. An engine-side `notify` dependency was considered and rejected — it would fold platform event semantics into the pure core for zero determinism benefit, and embedding consumers (gitsheets watch is tracked demand) bring their own change sources.
- **Cycles are serialized and latest-wins.** Bursts coalesce to at most one follow-up cycle on the newest state; a cycle superseded mid-flight discards its result at the **publication gate** (after the hash exists, before the stdout line and any commit) — this subsumes the intent of #19 for this era.
- **Committing cycles** follow `specs/behaviors/projection-commits.md` per cycle: CAS on the ref value observed at cycle start, external writers surface as `REF_CONFLICT` and the watch continues.
- **Ref watching must survive git's rename-based ref updates.** Two observed (reproduced, not theoretical) inotify failure modes are specced: a file-level watch is permanently orphaned by the first rename-over, and even a directory-level watch can coalesce a burst into one event delivered *before* the final state. The implementation layers directory-level events (low latency) over a per-ref stat-polling safety net (bounded worst-case detection).

## Warm-context staleness design (`specs/api/projector-napi.md` § ProjectionSession)

Explicit consumer-owned session object (post-#490 philosophy): persistent `ThreadSafeRepository` + thread-id-memoized derived handle (holo-tree-napi's `local_repo` pattern from #491) + one `TreeCache`. The staleness contract: **only content-addressed state is cached** (parsed trees by tree id, gix object cache by object id — immutable by construction); **refs are re-resolved on every call**, and **objects written behind the session are visible** without reopening. Proven by tests, not assumed: the binding suite advances a source spec-ref and writes commits behind an open session via the external git CLI and asserts the next call observes them.

## Measured latencies (emergence-site @ CodeForPhilly/codeforphilly.org, this machine)

| Path | Latency |
| --- | --- |
| One-shot binding call (old per-call behavior) | ~123ms, cold every call |
| Warm session, in-process re-projection | first 123–195ms, then **62–82ms** (0 tree reads, 3,380 cache hits) |
| **Watch cycle, commit → publication (e2e, output-changing edit)** | **~90ms** (89.7 / 90.2 / 90.5ms samples) |
| Burst of 5 rapid commits | 2 publications; final matches a one-shot of the final state |
| Working-tree hashing (`hashWorkTree`, warm) | ~40–50ms — does not dominate at this scale |

The sub-100ms warm gate is met end-to-end. The remaining gap to the historical ~27ms engine figure is the write pass — a warm cycle still writes all 3,057 output trees (~60ms of the ~80ms) — filed as #498. Getting under the target required an in-spec **unlensed fast path**: with lensing disabled, the CLI uses the binding's full `projectBranch` (final strip included, spec'd hash-equal with lensing disabled), eliminating all JS tree operations per cycle (was ~150ms with the JS merge/write round-trip).

## Commit-path wiring + parity evidence

`commit_projection` is exposed as `ProjectionSession.commitProjection` (provenance host-supplied per spec; `REF_CONFLICT` passes through). Dispatch per the new `specs/behaviors/engine-selection.md` § Commit dispatch: **JS remains the default committer**; `HOLO_ENGINE=rust` routes commits through the engine. The CI dual-engine gate gains a `--commit-to` step under pinned identity asserting **byte-identical commit hashes** — verified locally (`docs-site`: `4ceee3a4…` from both engines, init-commit parent included). Tree parity re-verified post-rebase (onto #496) on docs-site, github-action-projector, and emergence-site (`de630914…` both engines).

## Also in here

- **Working-tree eligibility refinement** (spec + dispatcher): only a checked-out source sub-worktree under `.holo/sources/` forces the JS engine — a hashed working-tree root with ref-resolved sources is tree-pure and Rust-eligible (this is what makes `--working` watch fast). `--working` parity verified on emergence-site with an uncommitted change (`2e36d5fe…` both engines, change included in output).
- **Watch startup race fixed**: the watcher is established before the initial projection, which now runs through the same loop — a change racing startup supersedes it instead of being lost.
- `WatchLoop` (`lib/WatchLoop.js`) unit tests, `project --watch` child-process integration tests (publication, per-cycle commit parents, duplicate suppression across the exact empty-commit-then-real-commit sequence that dropped events), and binding session tests.

## Deferrals

- Fetch through the binding (lift the `fetch requested` fallback; engine capability landed in #496) — #497. `SOURCE_FETCH` already passes through the binding's generic code mapping.
- Warm-cycle tree-write avoidance — #498.
- Lens-pool integration: lensed branches watch through the existing hybrid path (Rust composite → JS lens per cycle); the warm lens-container pool is `lens-execution`'s scope, seam left at `Projection.projectBranch`'s lens branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01X4KHfjZQG7nS4c6R2pP2DJ>
