### PR TITLE
feat(holo-projector): lens execution over the v2 one-shot job protocol

### DIFF
--- a/holo-projector/src/bin/project.rs
+++ b/holo-projector/src/bin/project.rs
@@ -27,6 +27,21 @@ struct Cli {
     /// `git fetch`) instead of erroring on them
     #[arg(long)]
     fetch: bool,
+
+    /// Run the full pipeline including lens execution (composite → lens →
+    /// strip). Without this flag the engine is composition-only and refuses
+    /// lensed sub-projections.
+    #[arg(long)]
+    lens: bool,
+
+    /// Container engine CLI for lens execution (autodetects docker, then
+    /// podman, when omitted)
+    #[arg(long)]
+    runtime: Option<String>,
+
+    /// Re-execute lenses even when a cached result exists
+    #[arg(long)]
+    refresh: bool,
 }
 
 fn main() -> Result<()> {
@@ -47,13 +62,37 @@ fn main() -> Result<()> {
     let root_tree_id = commit.tree_id().context("commit has no tree")?;
     let t_resolve = start.elapsed();
 
-    let output_hash = if cli.fetch {
-        let fetcher = holo_projector::GitCliFetcher::new(&repo);
-        holo_projector::project_branch_fetching(&repo, root_tree_id.detach(), &cli.branch, &fetcher)
+    let fetcher = cli
+        .fetch
+        .then(|| holo_projector::GitCliFetcher::new(&repo));
+
+    let output_hash = if cli.lens {
+        use holo_projector::lens::{ContainerCli, CurlRegistry, LensEngine};
+        let runtime = match &cli.runtime {
+            Some(program) => ContainerCli::new(program.clone()),
+            None => ContainerCli::detect().map_err(|e| anyhow::anyhow!("{e}"))?,
+        };
+        let registry = CurlRegistry;
+        let mut engine = LensEngine::new(&runtime, &registry);
+        engine.refresh = cli.refresh;
+        engine.fetcher = fetcher
+            .as_ref()
+            .map(|f| f as &dyn holo_projector::SourceFetcher);
+        holo_projector::lens::project_branch_lensed(
+            &repo,
+            root_tree_id.detach(),
+            &cli.branch,
+            &engine,
+            None,
+        )
+        .map_err(|e| anyhow::anyhow!("{e}"))?
+    } else if let Some(ref fetcher) = fetcher {
+        holo_projector::project_branch_fetching(&repo, root_tree_id.detach(), &cli.branch, fetcher)
+            .map_err(|e| anyhow::anyhow!("{e}"))?
     } else {
         holo_projector::project_branch(&repo, root_tree_id.detach(), &cli.branch)
-    }
-    .map_err(|e| anyhow::anyhow!("{e}"))?;
+            .map_err(|e| anyhow::anyhow!("{e}"))?
+    };
     let t_project = start.elapsed();
 
     println!("{output_hash}");

--- a/holo-projector/src/branch.rs
+++ b/holo-projector/src/branch.rs
@@ -2,7 +2,6 @@
 
 use std::collections::{HashMap, VecDeque};
 
-use gix::ObjectId;
 
 use crate::config::{self, MappingConfig};
 use crate::error::{Error, Result};
@@ -20,7 +19,7 @@ pub fn composite(
     branch_name: &str,
     workspace_name: &str,
     output: &mut MutableTree,
-    project_fn: &mut dyn FnMut(&Context, ObjectId, &str, Option<bool>) -> Result<ObjectId>,
+    project_fn: &mut crate::ProjectFn<'_>,
     fetcher: Option<&dyn SourceFetcher>,
 ) -> Result<()> {
     let mappings = config::discover_mappings(ctx, workspace_tree, branch_name)?;
@@ -65,7 +64,7 @@ pub fn composite_plan(
     workspace_name: &str,
     workspace_tree: &mut MutableTree,
     output: &mut MutableTree,
-    project_fn: &mut dyn FnMut(&Context, ObjectId, &str, Option<bool>) -> Result<ObjectId>,
+    project_fn: &mut crate::ProjectFn<'_>,
     fetcher: Option<&dyn SourceFetcher>,
 ) -> Result<()> {
     let sorted = toposort(mappings)?;

--- a/holo-projector/src/branch.rs
+++ b/holo-projector/src/branch.rs
@@ -20,7 +20,7 @@ pub fn composite(
     branch_name: &str,
     workspace_name: &str,
     output: &mut MutableTree,
-    project_fn: &mut dyn FnMut(&Context, ObjectId, &str) -> Result<ObjectId>,
+    project_fn: &mut dyn FnMut(&Context, ObjectId, &str, Option<bool>) -> Result<ObjectId>,
     fetcher: Option<&dyn SourceFetcher>,
 ) -> Result<()> {
     let mappings = config::discover_mappings(ctx, workspace_tree, branch_name)?;
@@ -65,7 +65,7 @@ pub fn composite_plan(
     workspace_name: &str,
     workspace_tree: &mut MutableTree,
     output: &mut MutableTree,
-    project_fn: &mut dyn FnMut(&Context, ObjectId, &str) -> Result<ObjectId>,
+    project_fn: &mut dyn FnMut(&Context, ObjectId, &str, Option<bool>) -> Result<ObjectId>,
     fetcher: Option<&dyn SourceFetcher>,
 ) -> Result<()> {
     let sorted = toposort(mappings)?;

--- a/holo-projector/src/error.rs
+++ b/holo-projector/src/error.rs
@@ -20,6 +20,38 @@ pub enum Error {
     #[error("sub-projection of holobranch '{branch}' requires lensing ({reason}); composition-only engines must refuse rather than skip the lens phase")]
     LensedSubprojection { branch: String, reason: String },
 
+    #[error("lens '{lens}' config error: {message}")]
+    LensConfig { lens: String, message: String },
+
+    #[error("lens container identity could not be resolved for '{container}': {message}")]
+    LensIdentity { container: String, message: String },
+
+    #[error("lens image '{container}' cannot run on this engine: {message}")]
+    LensProtocol { container: String, message: String },
+
+    #[error("lens job {spec_hash} failed with exit code {exit_code}{}{}", phase.as_deref().map(|p| format!(" in phase {p}")).unwrap_or_default(), log.as_deref().map(|l| format!(":\n{}", l.trim_end())).unwrap_or_default())]
+    LensFailed {
+        spec_hash: String,
+        /// The inner transform's real exit status (from the error commit's
+        /// `exit-code` entry — never a wrapper constant).
+        exit_code: i32,
+        /// `setup` | `transform` | `commit` — which SDK phase failed.
+        phase: Option<String>,
+        /// The captured job log from the error commit.
+        log: Option<String>,
+        /// The rendered command line, when the SDK recorded one.
+        command: Option<String>,
+    },
+
+    #[error("lens job {spec_hash} transport error: {message}")]
+    LensTransport { spec_hash: String, message: String },
+
+    #[error("lens job {spec_hash} exceeded its {timeout_secs}s deadline and was cancelled")]
+    LensTimeout {
+        spec_hash: String,
+        timeout_secs: u64,
+    },
+
     #[error("{0}")]
     Other(String),
 }
@@ -38,6 +70,12 @@ impl Error {
             Error::SourceFetch { .. } => "SOURCE_FETCH",
             Error::CircularDependency { .. } => "CIRCULAR_DEPENDENCY",
             Error::LensedSubprojection { .. } => "LENSED_SUBPROJECTION",
+            Error::LensConfig { .. } => "LENS_CONFIG",
+            Error::LensIdentity { .. } => "LENS_IDENTITY",
+            Error::LensProtocol { .. } => "LENS_PROTOCOL",
+            Error::LensFailed { .. } => "LENS_FAILED",
+            Error::LensTransport { .. } => "LENS_TRANSPORT",
+            Error::LensTimeout { .. } => "LENS_TIMEOUT",
             Error::Other(_) => "PROJECTION",
         }
     }

--- a/holo-projector/src/lens/iarna.rs
+++ b/holo-projector/src/lens/iarna.rs
@@ -424,7 +424,7 @@ fn stringify_float(f: f64) -> String {
 /// formatting produces the same digits as V8 for round-trip values.
 fn js_number_to_string(f: f64) -> String {
     let abs = f.abs();
-    if f != 0.0 && (abs >= 1e21 || abs < 1e-6) {
+    if f != 0.0 && !(1e-6..1e21).contains(&abs) {
         // format {:e} → "1.5e30" / "1e30" / "1.5e-7"; JS wants a '+' on
         // non-negative exponents.
         let s = format!("{f:e}");

--- a/holo-projector/src/lens/iarna.rs
+++ b/holo-projector/src/lens/iarna.rs
@@ -1,0 +1,719 @@
+//! Byte-faithful port of `@iarna/toml`'s `stringify` for lens spec objects.
+//!
+//! Lens spec hashing (`specs/behaviors/lensing.md` § Spec and content
+//! addressing) is keyed on the git blob hash of the serialized spec TOML, so
+//! the Rust engine must produce **byte-identical** output to the JS engine's
+//! `SpecObject.write` (`TOML.stringify` from `@iarna/toml@2`, applied to a
+//! deep-key-sorted object). This module ports that serializer's observable
+//! behavior exactly — including its quirks — for the value domain reachable
+//! from parsed lens config TOML:
+//!
+//! - section headers indented two spaces per nesting level, preceded by a
+//!   blank line, and **omitted entirely** for tables with no scalar entries;
+//! - inline arrays wrapped to one-per-line when the joined form exceeds 60
+//!   characters;
+//! - integral floats emitted as integers, and integers digit-grouped with
+//!   underscores (`1000` → `1_000`);
+//! - strings preferring literal (single-quoted) form when they contain a
+//!   double quote but no control characters or single quotes, and multiline
+//!   basic form when they contain newlines;
+//! - only the **first** unhandled control character `\u`-escaped (an upstream
+//!   bug, ported faithfully — such strings cannot round-trip through TOML
+//!   parsing anyway, so this is unreachable from real configs).
+//!
+//! Key order is the serialized order: callers pass `toml::Table`, whose
+//! default (non-`preserve_order`) backing is a `BTreeMap`, giving the same
+//! byte-order sort as the JS engine's `deepSortKeys` for ASCII keys. (The JS
+//! sort compares UTF-16 code units; divergence is only possible for keys
+//! containing non-ASCII characters, which no real lens config has.)
+//!
+//! Datetime values are rejected: the JS pipeline's `deepSortKeys` degrades
+//! `Date` objects to empty tables before stringifying, but a datetime in a
+//! lens config is meaningless and better surfaced as an error than silently
+//! hashed as `{ }`.
+
+use toml::Value;
+
+use crate::error::{Error, Result};
+
+/// Serialize a spec table exactly as the JS engine's
+/// `TOML.stringify({ holospec: { <kind>: data } })` would.
+///
+/// The caller passes the *full* document table (i.e. including the
+/// `holospec` wrapper), pre-sorted by virtue of `toml::Table`'s BTreeMap
+/// backing.
+pub fn stringify(table: &toml::Table) -> Result<String> {
+    stringify_object("", "", table)
+}
+
+fn type_error(kind: &str) -> Error {
+    Error::Other(format!("cannot stringify {kind} in lens spec"))
+}
+
+/// The serializer's view of a value's TOML type (`tomlType` upstream).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TomlType {
+    Integer,
+    Float,
+    Boolean,
+    String,
+    Array,
+    Table,
+    Datetime,
+}
+
+fn toml_type(value: &Value) -> TomlType {
+    match value {
+        // JS: Number.isInteger(v) && !Object.is(v, -0) → integer. TOML
+        // distinguishes integers from floats at parse time, but a float that
+        // parses to an integral JS number (`2.0`) is emitted as an integer.
+        Value::Integer(_) => TomlType::Integer,
+        Value::Float(f) => {
+            if f.fract() == 0.0
+                && f.is_finite()
+                && !(*f == 0.0 && f.is_sign_negative())
+            {
+                TomlType::Integer
+            } else {
+                TomlType::Float
+            }
+        }
+        Value::Boolean(_) => TomlType::Boolean,
+        Value::String(_) => TomlType::String,
+        Value::Array(_) => TomlType::Array,
+        Value::Table(_) => TomlType::Table,
+        Value::Datetime(_) => TomlType::Datetime,
+    }
+}
+
+/// `isInline` upstream: scalars and homogeneous-primitive arrays render on
+/// the key's own line; tables (and arrays of tables) become sections.
+fn is_inline(value: &Value) -> Result<bool> {
+    Ok(match toml_type(value) {
+        TomlType::Integer | TomlType::Float | TomlType::Boolean | TomlType::String => true,
+        TomlType::Datetime => return Err(type_error("datetime")),
+        TomlType::Array => {
+            let arr = value.as_array().expect("checked array");
+            arr.is_empty() || toml_type(&arr[0]) != TomlType::Table
+        }
+        TomlType::Table => value.as_table().expect("checked table").is_empty(),
+    })
+}
+
+fn stringify_object(prefix: &str, indent: &str, table: &toml::Table) -> Result<String> {
+    let mut inline_keys = Vec::new();
+    let mut complex_keys = Vec::new();
+    for (key, value) in table {
+        if is_inline(value)? {
+            inline_keys.push(key);
+        } else {
+            complex_keys.push(key);
+        }
+    }
+
+    let mut result: Vec<String> = Vec::new();
+    for key in &inline_keys {
+        let value = &table[key.as_str()];
+        result.push(format!(
+            "{indent}{} = {}",
+            stringify_key(key),
+            stringify_any_inline(value, true)?
+        ));
+    }
+    if !result.is_empty() {
+        result.push(String::new());
+    }
+
+    // Upstream: complex children indent only when this table is itself
+    // nested (`prefix` non-empty) *and* it rendered scalar entries.
+    let complex_indent = if !prefix.is_empty() && !inline_keys.is_empty() {
+        format!("{indent}  ")
+    } else {
+        String::new()
+    };
+
+    for key in &complex_keys {
+        let value = &table[key.as_str()];
+        result.push(stringify_complex(prefix, &complex_indent, key, value)?);
+    }
+
+    Ok(result.join("\n"))
+}
+
+fn stringify_complex(prefix: &str, indent: &str, key: &str, value: &Value) -> Result<String> {
+    match value {
+        Value::Array(values) => stringify_array_of_tables(prefix, indent, key, values),
+        Value::Table(table) => stringify_complex_table(prefix, indent, key, table),
+        _ => Err(type_error("value")),
+    }
+}
+
+fn stringify_array_of_tables(
+    prefix: &str,
+    indent: &str,
+    key: &str,
+    values: &[Value],
+) -> Result<String> {
+    validate_array(values)?;
+    let full_key = format!("{prefix}{}", stringify_key(key));
+    let mut result = String::new();
+    for value in values {
+        let table = value
+            .as_table()
+            .ok_or_else(|| Error::Other("array of tables contains a non-table".into()))?;
+        if !result.is_empty() {
+            result.push('\n');
+        }
+        result.push_str(&format!("{indent}[[{full_key}]]\n"));
+        result.push_str(&stringify_object(&format!("{full_key}."), indent, table)?);
+    }
+    Ok(result)
+}
+
+fn stringify_complex_table(
+    prefix: &str,
+    indent: &str,
+    key: &str,
+    table: &toml::Table,
+) -> Result<String> {
+    let full_key = format!("{prefix}{}", stringify_key(key));
+    let mut result = String::new();
+    // Upstream quirk: the section header appears only when the table has at
+    // least one inline (scalar) entry; a table of nothing but sub-tables is
+    // reached purely through its children's headers.
+    let mut has_inline = false;
+    for value in table.values() {
+        if is_inline(value)? {
+            has_inline = true;
+            break;
+        }
+    }
+    if has_inline {
+        result.push_str(&format!("{indent}[{full_key}]\n"));
+    }
+    result.push_str(&stringify_object(&format!("{full_key}."), indent, table)?);
+    Ok(result)
+}
+
+// ── Keys ───────────────────────────────────────────────────────────────────
+
+fn stringify_key(key: &str) -> String {
+    if !key.is_empty()
+        && key
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        key.to_string()
+    } else {
+        stringify_basic_string(key)
+    }
+}
+
+// ── Inline values ──────────────────────────────────────────────────────────
+
+fn stringify_any_inline(value: &Value, multiline_ok: bool) -> Result<String> {
+    if let Value::String(s) = value {
+        if multiline_ok && s.contains('\n') {
+            return Ok(stringify_multiline_string(s));
+        }
+        if !s.contains(['\u{8}', '\t', '\n', '\u{c}', '\r', '\'']) && s.contains('"') {
+            return Ok(format!("'{s}'"));
+        }
+    }
+    stringify_inline(value, toml_type(value))
+}
+
+fn stringify_inline(value: &Value, as_type: TomlType) -> Result<String> {
+    Ok(match as_type {
+        TomlType::String => match value {
+            Value::String(s) => stringify_basic_string(s),
+            _ => return Err(type_error("value")),
+        },
+        TomlType::Integer => match value {
+            Value::Integer(i) => stringify_integer(&i.to_string()),
+            Value::Float(f) => stringify_integer(&js_number_to_string(*f)),
+            _ => return Err(type_error("value")),
+        },
+        TomlType::Float => match value {
+            Value::Float(f) => stringify_float(*f),
+            // Mixed numeric arrays force integers through the float path.
+            Value::Integer(i) => stringify_float(*i as f64),
+            _ => return Err(type_error("value")),
+        },
+        TomlType::Boolean => match value {
+            Value::Boolean(b) => b.to_string(),
+            _ => return Err(type_error("value")),
+        },
+        TomlType::Array => match value {
+            Value::Array(values) => stringify_inline_array(values)?,
+            _ => return Err(type_error("value")),
+        },
+        TomlType::Table => match value {
+            Value::Table(table) => stringify_inline_table(table)?,
+            _ => return Err(type_error("value")),
+        },
+        TomlType::Datetime => return Err(type_error("datetime")),
+    })
+}
+
+fn stringify_inline_array(values: &[Value]) -> Result<String> {
+    let element_type = validate_array(values)?;
+    let mut stringified = Vec::with_capacity(values.len());
+    for value in values {
+        stringified.push(match element_type {
+            Some(t) => stringify_inline(value, t)?,
+            None => unreachable!("empty array has no elements"),
+        });
+    }
+    let joined = stringified.join(", ");
+    Ok(if joined.len() > 60 || joined.contains('\n') {
+        format!("[\n  {}\n]", stringified.join(",\n  "))
+    } else if stringified.is_empty() {
+        "[ ]".to_string()
+    } else {
+        format!("[ {joined} ]")
+    })
+}
+
+fn stringify_inline_table(table: &toml::Table) -> Result<String> {
+    let mut entries = Vec::with_capacity(table.len());
+    for (key, value) in table {
+        entries.push(format!(
+            "{} = {}",
+            stringify_key(key),
+            stringify_any_inline(value, false)?
+        ));
+    }
+    Ok(if entries.is_empty() {
+        "{ }".to_string()
+    } else {
+        format!("{{ {} }}", entries.join(", "))
+    })
+}
+
+/// Upstream `arrayType`/`validateArray`: arrays must be single-typed, except
+/// that mixed integer/float arrays are promoted to all-float. Returns the
+/// element type to stringify with (`None` for empty arrays).
+fn validate_array(values: &[Value]) -> Result<Option<TomlType>> {
+    let Some(first) = values.first() else {
+        return Ok(None);
+    };
+    let content_type = toml_type(first);
+    if values.iter().all(|v| toml_type(v) == content_type) {
+        return Ok(Some(content_type));
+    }
+    let numeric = |t: TomlType| t == TomlType::Integer || t == TomlType::Float;
+    if values.iter().all(|v| numeric(toml_type(v))) {
+        return Ok(Some(TomlType::Float));
+    }
+    Err(Error::Other(
+        "Array values can't have mixed types".into(),
+    ))
+}
+
+// ── Strings ────────────────────────────────────────────────────────────────
+
+/// Upstream `escapeString`. Note the final control-character replacement is
+/// deliberately **non-global** — only the first such character is escaped —
+/// mirroring the upstream implementation.
+fn escape_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut control_escaped = false;
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '\u{8}' => out.push_str("\\b"),
+            '\t' => out.push_str("\\t"),
+            '\n' => out.push_str("\\n"),
+            '\u{c}' => out.push_str("\\f"),
+            '\r' => out.push_str("\\r"),
+            c if !control_escaped && (('\u{0}'..='\u{1f}').contains(&c) || c == '\u{7f}') => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+                control_escaped = true;
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+fn stringify_basic_string(s: &str) -> String {
+    format!("\"{}\"", escape_string(s).replace('"', "\\\""))
+}
+
+fn stringify_multiline_string(s: &str) -> String {
+    let escaped_lines: Vec<String> = s
+        .split('\n')
+        .map(|line| escape_quote_before_double(&escape_string(line)))
+        .collect();
+    let mut escaped = escaped_lines.join("\n");
+    if escaped.ends_with('"') {
+        escaped.push_str("\\\n");
+    }
+    format!("\"\"\"\n{escaped}\"\"\"")
+}
+
+/// Upstream `.replace(/"(?="")/g, '\\"')`: escape a quote only when followed
+/// by two more quotes; the lookahead is not consumed, so runs of quotes are
+/// processed with single-character advance.
+fn escape_quote_before_double(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] == '"'
+            && i + 2 < chars.len()
+            && chars[i + 1] == '"'
+            && chars[i + 2] == '"'
+        {
+            out.push_str("\\\"");
+        } else {
+            out.push(chars[i]);
+        }
+        i += 1;
+    }
+    out
+}
+
+// ── Numbers ────────────────────────────────────────────────────────────────
+
+/// Upstream `stringifyInteger`: digit-group with underscores
+/// (`/\B(?=(\d{3})+(?!\d))/g`).
+fn stringify_integer(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let is_word = |c: char| c.is_ascii_alphanumeric() || c == '_';
+    let mut out = String::with_capacity(s.len());
+    for (i, &c) in chars.iter().enumerate() {
+        if i > 0 && is_word(chars[i - 1]) && is_word(c) {
+            // \B position — does (\d{3})+(?!\d) match here?
+            let run = chars[i..].iter().take_while(|c| c.is_ascii_digit()).count();
+            if run > 0 && run % 3 == 0 {
+                out.push('_');
+            }
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// Upstream `stringifyFloat`, including its quirky `int + "." + dec` re-join.
+fn stringify_float(f: f64) -> String {
+    if f == f64::INFINITY {
+        return "inf".to_string();
+    }
+    if f == f64::NEG_INFINITY {
+        return "-inf".to_string();
+    }
+    if f.is_nan() {
+        return "nan".to_string();
+    }
+    if f == 0.0 && f.is_sign_negative() {
+        return "-0.0".to_string();
+    }
+    let s = js_number_to_string(f);
+    let (int, dec) = match s.split_once('.') {
+        Some((i, d)) => (i.to_string(), d.to_string()),
+        None => (s, "0".to_string()),
+    };
+    format!("{}.{dec}", stringify_integer(&int))
+}
+
+/// Approximate ECMAScript `Number::toString` for the doubles reachable from
+/// TOML configs: plain shortest-round-trip decimal within JS's non-exponent
+/// range, exponent notation (`1e+30`, `1.5e-7`) outside it. Rust's shortest
+/// formatting produces the same digits as V8 for round-trip values.
+fn js_number_to_string(f: f64) -> String {
+    let abs = f.abs();
+    if f != 0.0 && (abs >= 1e21 || abs < 1e-6) {
+        // format {:e} → "1.5e30" / "1e30" / "1.5e-7"; JS wants a '+' on
+        // non-negative exponents.
+        let s = format!("{f:e}");
+        match s.split_once('e') {
+            Some((mantissa, exp)) if !exp.starts_with('-') => format!("{mantissa}e+{exp}"),
+            _ => s,
+        }
+    } else if f.fract() == 0.0 {
+        format!("{f:.0}")
+    } else {
+        format!("{f}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serialize `data` as `{ holospec: { lens: data } }`, the shape specs
+    /// are hashed in.
+    fn spec(data: toml::Table) -> String {
+        let mut lens_wrapper = toml::Table::new();
+        lens_wrapper.insert("lens".into(), Value::Table(data));
+        let mut doc = toml::Table::new();
+        doc.insert("holospec".into(), Value::Table(lens_wrapper));
+        stringify(&doc).unwrap()
+    }
+
+    fn table(pairs: &[(&str, Value)]) -> toml::Table {
+        let mut t = toml::Table::new();
+        for (k, v) in pairs {
+            t.insert(k.to_string(), v.clone());
+        }
+        t
+    }
+
+    // Every expected string below was captured from the real JS pipeline:
+    // `TOML.stringify({ holospec: { lens: deepSortKeys(data) } })` with
+    // `@iarna/toml@2` (the exact library `lib/SpecObject.js` uses).
+
+    #[test]
+    fn basic_scalars() {
+        let out = spec(table(&[
+            ("container", Value::String("ghcr.io/x@sha256:abc".into())),
+            ("input", Value::String("deadbeef".into())),
+        ]));
+        assert_eq!(
+            out,
+            "[holospec.lens]\ncontainer = \"ghcr.io/x@sha256:abc\"\ninput = \"deadbeef\"\n"
+        );
+    }
+
+    #[test]
+    fn nested_table_indents_and_blank_line() {
+        let out = spec(table(&[
+            ("container", Value::String("x".into())),
+            ("input", Value::String("h".into())),
+            (
+                "mkdocs",
+                Value::Table(table(&[(
+                    "requirements",
+                    Value::Array(vec![
+                        Value::String("mkdocs-material".into()),
+                        Value::String("mdx_truly_sane_lists".into()),
+                    ]),
+                )])),
+            ),
+        ]));
+        assert_eq!(
+            out,
+            "[holospec.lens]\ncontainer = \"x\"\ninput = \"h\"\n\n  [holospec.lens.mkdocs]\n  requirements = [ \"mkdocs-material\", \"mdx_truly_sane_lists\" ]\n"
+        );
+    }
+
+    #[test]
+    fn long_array_wraps_per_line() {
+        // The real docs-site mkdocs lens: joined length exceeds 60.
+        let out = spec(table(&[(
+            "requirements",
+            Value::Array(vec![
+                Value::String("mkdocs-material".into()),
+                Value::String("mkdocs-awesome-pages-plugin".into()),
+                Value::String("mdx_truly_sane_lists".into()),
+            ]),
+        )]));
+        assert_eq!(
+            out,
+            "[holospec.lens]\nrequirements = [\n  \"mkdocs-material\",\n  \"mkdocs-awesome-pages-plugin\",\n  \"mdx_truly_sane_lists\"\n]\n"
+        );
+    }
+
+    #[test]
+    fn scalar_types_and_multiline_string() {
+        let out = spec(table(&[
+            (
+                "arr",
+                Value::Array(vec![Value::Integer(1), Value::Integer(2)]),
+            ),
+            ("b", Value::Boolean(true)),
+            ("f", Value::Float(1.5)),
+            ("i", Value::Integer(42)),
+            ("s", Value::String("q\"uo\\te\nnl".into())),
+        ]));
+        assert_eq!(
+            out,
+            "[holospec.lens]\narr = [ 1, 2 ]\nb = true\nf = 1.5\ni = 42\ns = \"\"\"\nq\"uo\\\\te\nnl\"\"\"\n"
+        );
+    }
+
+    #[test]
+    fn empty_array() {
+        let out = spec(table(&[
+            ("arr", Value::Array(vec![])),
+            ("container", Value::String("x".into())),
+        ]));
+        assert_eq!(out, "[holospec.lens]\narr = [ ]\ncontainer = \"x\"\n");
+    }
+
+    #[test]
+    fn literal_string_for_embedded_quotes() {
+        let out = spec(table(&[("s", Value::String("say \"hi\" there".into()))]));
+        assert_eq!(out, "[holospec.lens]\ns = 'say \"hi\" there'\n");
+    }
+
+    #[test]
+    fn backslash_uses_basic_string() {
+        let out = spec(table(&[("s", Value::String("a\\b".into()))]));
+        assert_eq!(out, "[holospec.lens]\ns = \"a\\\\b\"\n");
+    }
+
+    #[test]
+    fn control_characters() {
+        let out = spec(table(&[
+            ("s", Value::String("tab\there".into())),
+            ("t", Value::String("bell\u{7}x".into())),
+            ("u", Value::String("unié☃".into())),
+        ]));
+        assert_eq!(
+            out,
+            "[holospec.lens]\ns = \"tab\\there\"\nt = \"bell\\u0007x\"\nu = \"unié☃\"\n"
+        );
+    }
+
+    #[test]
+    fn deep_nesting_indents_two_per_level() {
+        let out = spec(table(&[
+            (
+                "a",
+                Value::Table(table(&[
+                    ("b", Value::Table(table(&[("c", Value::String("x".into()))]))),
+                    ("k", Value::String("v".into())),
+                ])),
+            ),
+            ("top", Value::Integer(1)),
+        ]));
+        assert_eq!(
+            out,
+            "[holospec.lens]\ntop = 1\n\n  [holospec.lens.a]\n  k = \"v\"\n\n    [holospec.lens.a.b]\n    c = \"x\"\n"
+        );
+    }
+
+    #[test]
+    fn array_of_tables() {
+        let out = spec(table(&[
+            (
+                "arr",
+                Value::Array(vec![
+                    Value::Table(table(&[("n", Value::Integer(1))])),
+                    Value::Table(table(&[("n", Value::Integer(2))])),
+                ]),
+            ),
+            ("s", Value::String("x".into())),
+        ]));
+        assert_eq!(
+            out,
+            "[holospec.lens]\ns = \"x\"\n\n  [[holospec.lens.arr]]\n  n = 1\n\n  [[holospec.lens.arr]]\n  n = 2\n"
+        );
+    }
+
+    #[test]
+    fn nested_arrays_inline() {
+        let out = spec(table(&[(
+            "arr",
+            Value::Array(vec![
+                Value::Array(vec![Value::String("a".into())]),
+                Value::Array(vec![Value::String("b".into())]),
+            ]),
+        )]));
+        assert_eq!(out, "[holospec.lens]\narr = [ [ \"a\" ], [ \"b\" ] ]\n");
+    }
+
+    #[test]
+    fn float_formats() {
+        let out = spec(table(&[
+            ("a", Value::Float(1.0)),
+            ("b", Value::Float(-2.5)),
+            ("c", Value::Float(1e30)),
+            ("d", Value::Float(0.1)),
+        ]));
+        assert_eq!(
+            out,
+            "[holospec.lens]\na = 1\nb = -2.5\nc = 1e+30\nd = 0.1\n"
+        );
+    }
+
+    #[test]
+    fn integer_underscore_grouping() {
+        let out = spec(table(&[
+            ("a", Value::Integer(1000)),
+            ("b", Value::Integer(-1000)),
+            ("c", Value::Integer(600)),
+            ("d", Value::Integer(1234567)),
+        ]));
+        assert_eq!(
+            out,
+            "[holospec.lens]\na = 1_000\nb = -1_000\nc = 600\nd = 1_234_567\n"
+        );
+    }
+
+    #[test]
+    fn quoted_keys() {
+        let out = spec(table(&[
+            ("weird.key", Value::Integer(1)),
+            ("ok-key_2", Value::Integer(2)),
+        ]));
+        // BTreeMap byte order: '"' cases still sort by raw key.
+        assert_eq!(
+            out,
+            "[holospec.lens]\nok-key_2 = 2\n\"weird.key\" = 1\n"
+        );
+    }
+
+    #[test]
+    fn empty_string_and_empty_table() {
+        let out = spec(table(&[
+            ("s", Value::String("".into())),
+            ("t", Value::Table(toml::Table::new())),
+        ]));
+        assert_eq!(out, "[holospec.lens]\ns = \"\"\nt = { }\n");
+    }
+
+    #[test]
+    fn crlf_multiline() {
+        let out = spec(table(&[("s", Value::String("a\r\nb".into()))]));
+        assert_eq!(out, "[holospec.lens]\ns = \"\"\"\na\\r\nb\"\"\"\n");
+    }
+
+    #[test]
+    fn multiline_trailing_newline_and_quotes() {
+        let ends_nl = spec(table(&[(
+            "s",
+            Value::String("ends with newline\n".into()),
+        )]));
+        assert_eq!(
+            ends_nl,
+            "[holospec.lens]\ns = \"\"\"\nends with newline\n\"\"\"\n"
+        );
+
+        let trip = spec(table(&[(
+            "s",
+            Value::String("has \"\"\" inside\nand newline".into()),
+        )]));
+        assert_eq!(
+            trip,
+            "[holospec.lens]\ns = \"\"\"\nhas \\\"\"\" inside\nand newline\"\"\"\n"
+        );
+    }
+
+    #[test]
+    fn table_with_only_subtables_gets_no_header() {
+        let out = spec(table(&[(
+            "atbl",
+            Value::Table(table(&[("x", Value::Integer(1))])),
+        )]));
+        // holospec.lens has no scalar entries → its header is omitted and
+        // the child section is not indented.
+        assert_eq!(out, "[holospec.lens.atbl]\nx = 1\n");
+    }
+
+    #[test]
+    fn toml_table_iterates_sorted() {
+        // The serializer relies on toml::Table's BTreeMap backing for the
+        // deepSortKeys equivalence; this guards against the crate's
+        // `preserve_order` feature being enabled by a future dependency.
+        let mut t = toml::Table::new();
+        t.insert("zebra".into(), Value::Integer(1));
+        t.insert("_resolved".into(), Value::Integer(2));
+        t.insert("alpha".into(), Value::Integer(3));
+        let keys: Vec<&String> = t.keys().collect();
+        assert_eq!(keys, ["_resolved", "alpha", "zebra"]);
+    }
+}

--- a/holo-projector/src/lens/identity.rs
+++ b/holo-projector/src/lens/identity.rs
@@ -1,0 +1,183 @@
+//! Container identity resolution (`specs/behaviors/lensing.md` § Container
+//! identity resolution): resolve a configured container reference to the
+//! stable execution identity that enters the spec hash.
+//!
+//! The ladder, tried in order at spec-build time:
+//!
+//! 1. **Explicit digest pin** — used as-is, no lookup (offline, and the
+//!    recommended form).
+//! 2. **Local engine lookup** — the repo digest of a locally-present image;
+//!    a never-pushed image (#417) resolves to its image ID with the
+//!    `_resolved = "local"` bookkeeping marker (honestly non-portable).
+//! 3. **Registry lookup** — a manifest HEAD request against the registry.
+//!
+//! Local shadowing (rung 2 before rung 3) is by design: a warm cache must be
+//! usable offline, and the remedy for staleness is digest pinning.
+
+use super::job::is_digest_reference;
+use super::runtime::{strip_tag, ContainerRuntime, RegistryClient};
+use crate::error::Result;
+
+/// A resolved container execution identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContainerIdentity {
+    /// The identity that enters the spec: `name@sha256:…`, or a bare image
+    /// ID for locally-resolved images.
+    pub container: String,
+    /// True when resolved from a never-pushed local image (#417); becomes
+    /// `_resolved = "local"` in the spec.
+    pub local: bool,
+}
+
+/// Resolve a configured container reference via the ladder.
+pub fn resolve(
+    runtime: &dyn ContainerRuntime,
+    registry: &dyn RegistryClient,
+    container_query: &str,
+) -> Result<ContainerIdentity> {
+    // 1. explicit digest pin — no lookup performed
+    if is_digest_reference(container_query) {
+        return Ok(ContainerIdentity {
+            container: container_query.to_string(),
+            local: false,
+        });
+    }
+
+    // 2. local engine lookup
+    if let Some(image) = runtime.inspect_local(container_query)? {
+        let repo_name = strip_tag(container_query);
+        let prefix = format!("{repo_name}@");
+        let matching = image
+            .repo_digests
+            .iter()
+            .find(|d| d.starts_with(&prefix))
+            .or_else(|| image.repo_digests.first());
+
+        if let Some(digest) = matching {
+            eprintln!("resolved container identity from local image: {digest}");
+            return Ok(ContainerIdentity {
+                container: digest.clone(),
+                local: false,
+            });
+        }
+
+        // local-only image, never pushed (#417): use image ID, marked local
+        eprintln!(
+            "resolved local-only container identity: {} ({container_query})",
+            image.id
+        );
+        return Ok(ContainerIdentity {
+            container: image.id,
+            local: true,
+        });
+    }
+
+    // 3. registry lookup
+    let digest = registry.manifest_digest(container_query)?;
+    eprintln!("resolved container identity from registry: {container_query} → {digest}");
+    Ok(ContainerIdentity {
+        container: format!("{}@{digest}", strip_tag(container_query)),
+        local: false,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Error;
+    use crate::lens::runtime::{LocalImage, OneShotOutcome};
+    use std::time::Duration;
+
+    struct FakeRuntime {
+        image: Option<LocalImage>,
+    }
+
+    impl ContainerRuntime for FakeRuntime {
+        fn inspect_local(&self, _reference: &str) -> Result<Option<LocalImage>> {
+            Ok(self.image.clone())
+        }
+        fn pull(&self, _reference: &str) -> Result<()> {
+            Ok(())
+        }
+        fn protocol_label(&self, _reference: &str) -> Result<Option<String>> {
+            Ok(Some("2".into()))
+        }
+        fn run_one_shot(
+            &self,
+            _image: &str,
+            _spec_hash: &str,
+            _input_bundle: &[u8],
+            _deadline: Duration,
+        ) -> Result<OneShotOutcome> {
+            unreachable!("identity resolution never runs containers")
+        }
+    }
+
+    struct FakeRegistry {
+        digest: Option<String>,
+    }
+
+    impl RegistryClient for FakeRegistry {
+        fn manifest_digest(&self, reference: &str) -> Result<String> {
+            self.digest.clone().ok_or(Error::LensIdentity {
+                container: reference.to_string(),
+                message: "offline".into(),
+            })
+        }
+    }
+
+    const DIGEST: &str = "sha256:6b6b0bdb5beb2b3f852cc1cdfb7d2a67fc036bce7f26ac63efc39e8e2a2a4738";
+
+    #[test]
+    fn digest_pin_short_circuits() {
+        let runtime = FakeRuntime { image: None };
+        let registry = FakeRegistry { digest: None };
+        let pinned = format!("ghcr.io/x/y@{DIGEST}");
+        let id = resolve(&runtime, &registry, &pinned).unwrap();
+        assert_eq!(id.container, pinned);
+        assert!(!id.local);
+    }
+
+    #[test]
+    fn local_repo_digest_wins_and_matches_repo() {
+        let runtime = FakeRuntime {
+            image: Some(LocalImage {
+                id: "sha256:localid".into(),
+                repo_digests: vec![
+                    format!("other.registry/mirror@{DIGEST}"),
+                    format!("ghcr.io/x/y@{DIGEST}"),
+                ],
+            }),
+        };
+        let registry = FakeRegistry { digest: None };
+        let id = resolve(&runtime, &registry, "ghcr.io/x/y:latest").unwrap();
+        // prefers the digest matching the configured repo, not the first
+        assert_eq!(id.container, format!("ghcr.io/x/y@{DIGEST}"));
+        assert!(!id.local);
+    }
+
+    #[test]
+    fn local_only_image_marks_resolved_local() {
+        let runtime = FakeRuntime {
+            image: Some(LocalImage {
+                id: "sha256:abc123".into(),
+                repo_digests: vec![],
+            }),
+        };
+        let registry = FakeRegistry { digest: None };
+        let id = resolve(&runtime, &registry, "my-local-lens:dev").unwrap();
+        assert_eq!(id.container, "sha256:abc123");
+        assert!(id.local);
+    }
+
+    #[test]
+    fn registry_fallback() {
+        let runtime = FakeRuntime { image: None };
+        let registry = FakeRegistry {
+            digest: Some(DIGEST.into()),
+        };
+        let id = resolve(&runtime, &registry, "ghcr.io/x/y:latest").unwrap();
+        assert_eq!(id.container, format!("ghcr.io/x/y@{DIGEST}"));
+        assert!(!id.local);
+    }
+}

--- a/holo-projector/src/lens/job.rs
+++ b/holo-projector/src/lens/job.rs
@@ -1,0 +1,458 @@
+//! One-shot v2 lens job execution (`specs/behaviors/lensing.md` § Job
+//! protocol): push a wrapper commit (`.holospec/lens.toml` + `input/`) to the
+//! container as a bundle on stdin, read back a bundle carrying
+//! `refs/jobs/<spec-hash>/output` (success — first parent must be the input
+//! commit) or `refs/jobs/<spec-hash>/error` (failure — a parentless commit
+//! whose tree carries `exit-code`, `phase`, `log`, and optionally `command`).
+//!
+//! Bundle packing/unpacking shells out to the `git` CLI (`bundle create` /
+//! `fetch`), matching the JS engine; fetch ingest hash-verifies every object,
+//! which is the integrity model for results coming back across the container
+//! boundary.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use gix::ObjectId;
+
+use super::runtime::ContainerRuntime;
+use crate::error::{Error, Result};
+
+/// Parameters for executing a written container-lens spec.
+pub struct JobSpec<'a> {
+    /// The spec blob hash (the job key).
+    pub spec_hash: &'a str,
+    /// Resolved container identity from the spec (`container` key).
+    pub container: &'a str,
+    /// Whether the identity is locally resolved (`_resolved = "local"`, #417).
+    pub resolved_local: bool,
+    /// The input tree hash from the spec.
+    pub input_tree: ObjectId,
+    /// Job deadline (config `timeout` / engine default) — never in the spec.
+    pub timeout: Duration,
+}
+
+/// Execute a container lens spec over the one-shot v2 transport and return
+/// the output **tree** hash.
+pub fn execute(
+    repo: &gix::Repository,
+    runtime: &dyn ContainerRuntime,
+    job: &JobSpec<'_>,
+) -> Result<ObjectId> {
+    ensure_image(runtime, job)?;
+    ensure_v2_protocol(runtime, job.container)?;
+
+    let spec_hash = job.spec_hash;
+    let input_ref = format!("refs/jobs/{spec_hash}/input");
+    let output_ref = format!("refs/jobs/{spec_hash}/output");
+    let error_ref = format!("refs/jobs/{spec_hash}/error");
+
+    // Build the job input wrapper commit: .holospec/lens.toml + input/
+    let spec_blob = ObjectId::from_hex(spec_hash.as_bytes())
+        .map_err(|e| Error::Other(format!("invalid spec hash {spec_hash}: {e}")))?;
+    let holospec_tree = write_tree(
+        repo,
+        &[TreeEntry {
+            name: "lens.toml",
+            id: spec_blob,
+            kind: gix::objs::tree::EntryKind::Blob,
+        }],
+    )?;
+    let wrapper_tree = write_tree(
+        repo,
+        &[
+            TreeEntry {
+                name: ".holospec",
+                id: holospec_tree,
+                kind: gix::objs::tree::EntryKind::Tree,
+            },
+            TreeEntry {
+                name: "input",
+                id: job.input_tree,
+                kind: gix::objs::tree::EntryKind::Tree,
+            },
+        ],
+    )?;
+    let input_commit = holo_tree::repo::commit_tree(
+        repo,
+        wrapper_tree,
+        &[],
+        &format!("lens job {spec_hash}"),
+        None,
+        None,
+    )?;
+    holo_tree::repo::update_ref(repo, &input_ref, input_commit, None)?;
+
+    let scratch = ScratchDir::create(spec_hash)?;
+
+    let result = run_exchange(
+        repo,
+        runtime,
+        job,
+        &scratch,
+        &input_ref,
+        &output_ref,
+        &error_ref,
+        input_commit,
+    );
+
+    // Input objects stay reachable via the output commit's parent link, so
+    // the input ref is transient.
+    if let Err(err) = delete_ref(repo, &input_ref) {
+        eprintln!("warning: failed to clean up {input_ref}: {err}");
+    }
+
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_exchange(
+    repo: &gix::Repository,
+    runtime: &dyn ContainerRuntime,
+    job: &JobSpec<'_>,
+    scratch: &ScratchDir,
+    input_ref: &str,
+    output_ref: &str,
+    error_ref: &str,
+    input_commit: ObjectId,
+) -> Result<ObjectId> {
+    let spec_hash = job.spec_hash;
+
+    // Bundle the input wrapper commit.
+    let input_bundle_path = scratch.path().join("input.bundle");
+    git(
+        repo,
+        &[
+            "bundle",
+            "create",
+            "--quiet",
+            path_str(&input_bundle_path)?,
+            input_ref,
+        ],
+    )
+    .map_err(|e| Error::Other(format!("failed to bundle lens job input: {e}")))?;
+    let input_bundle = std::fs::read(&input_bundle_path)
+        .map_err(|e| Error::Other(format!("failed to read input bundle: {e}")))?;
+
+    // One-shot exchange: bundle on stdin, bundle on stdout, exit code
+    // mirroring success/error; stderr is relayed by the runtime.
+    eprintln!(
+        "executing lens job {spec_hash} (deadline {}s)",
+        job.timeout.as_secs()
+    );
+    let outcome = runtime.run_one_shot(job.container, spec_hash, &input_bundle, job.timeout)?;
+
+    if outcome.timed_out {
+        return Err(Error::LensTimeout {
+            spec_hash: spec_hash.to_string(),
+            timeout_secs: job.timeout.as_secs(),
+        });
+    }
+
+    let transport_err = |message: String| Error::LensTransport {
+        spec_hash: spec_hash.to_string(),
+        message,
+    };
+
+    if outcome.stdout.is_empty() {
+        let mut message = format!(
+            "lens container exited with code {:?} without returning a bundle",
+            outcome.exit_code
+        );
+        if !outcome.stderr_tail.is_empty() {
+            message.push_str(&format!(":\n{}", outcome.stderr_tail.trim_end()));
+        }
+        return Err(transport_err(message));
+    }
+
+    // Persist the returned bundle and ingest via fetch, which hash-verifies
+    // all objects.
+    let result_bundle_path = scratch.path().join("result.bundle");
+    std::fs::write(&result_bundle_path, &outcome.stdout)
+        .map_err(|e| Error::Other(format!("failed to write result bundle: {e}")))?;
+
+    if outcome.exit_code == Some(0) {
+        git(
+            repo,
+            &[
+                "fetch",
+                path_str(&result_bundle_path)?,
+                &format!("+{output_ref}:{output_ref}"),
+            ],
+        )
+        .map_err(|e| transport_err(format!("failed to ingest result bundle: {e}")))?;
+
+        let output_commit = holo_tree::repo::resolve_ref(repo, output_ref)?
+            .ok_or_else(|| transport_err("result bundle did not deliver the output ref".into()))?;
+        let commit = repo
+            .find_object(output_commit)
+            .map_err(|e| transport_err(format!("output commit unreadable: {e}")))?
+            .try_into_commit()
+            .map_err(|_| transport_err("output ref does not point at a commit".into()))?;
+
+        // Integrity check (ported): the output commit's first parent must be
+        // our input commit.
+        let first_parent = commit.parent_ids().next().map(|id| id.detach());
+        if first_parent != Some(input_commit) {
+            return Err(transport_err(format!(
+                "output commit parent {first_parent:?} does not match input commit {input_commit}"
+            )));
+        }
+
+        let tree = commit
+            .tree_id()
+            .map_err(|e| transport_err(format!("output commit has no tree: {e}")))?
+            .detach();
+        return Ok(tree);
+    }
+
+    // Non-zero exit: expect a structured error bundle.
+    let code = outcome.exit_code;
+    git(
+        repo,
+        &[
+            "fetch",
+            path_str(&result_bundle_path)?,
+            &format!("+{error_ref}:{error_ref}"),
+        ],
+    )
+    .map_err(|e| {
+        transport_err(format!(
+            "lens container exited with code {code:?} without returning a readable error bundle: {e}"
+        ))
+    })?;
+
+    let error_commit = holo_tree::repo::resolve_ref(repo, error_ref)?
+        .ok_or_else(|| transport_err("error bundle did not deliver the error ref".into()))?;
+    let error_tree = repo
+        .find_object(error_commit)
+        .map_err(|e| transport_err(format!("error commit unreadable: {e}")))?
+        .try_into_commit()
+        .map_err(|_| transport_err("error ref does not point at a commit".into()))?
+        .tree_id()
+        .map_err(|e| transport_err(format!("error commit has no tree: {e}")))?
+        .detach();
+
+    let read = |name: &str| read_tree_blob(repo, error_tree, name);
+    let exit_code = read("exit-code")?
+        .and_then(|s| s.trim().parse::<i32>().ok())
+        .or(code)
+        .unwrap_or(-1);
+    let phase = read("phase")?.map(|s| s.trim().to_string());
+    let log = read("log")?;
+    let command = read("command")?.map(|s| s.trim().to_string());
+
+    Err(Error::LensFailed {
+        spec_hash: spec_hash.to_string(),
+        exit_code,
+        phase,
+        log,
+        command,
+    })
+}
+
+// ── Image availability & protocol ──────────────────────────────────────────
+
+fn ensure_image(runtime: &dyn ContainerRuntime, job: &JobSpec<'_>) -> Result<()> {
+    if job.resolved_local {
+        // Locally-resolved image (#417): identified by image ID, cannot be
+        // pulled.
+        if runtime.inspect_local(job.container)?.is_none() {
+            return Err(Error::LensIdentity {
+                container: job.container.to_string(),
+                message: "locally-resolved lens image is not available in the local engine; \
+                          rebuild the image or update the lens container config"
+                    .into(),
+            });
+        }
+        return Ok(());
+    }
+
+    if !is_digest_reference(job.container) {
+        return Err(Error::LensIdentity {
+            container: job.container.to_string(),
+            message: "invalid container format (expected name@sha256:… digest reference)".into(),
+        });
+    }
+
+    if runtime.inspect_local(job.container)?.is_none() {
+        // Pull by digest — guarantees the exact image version matching the
+        // spec that was used for caching.
+        runtime.pull(job.container)?;
+    }
+    Ok(())
+}
+
+fn ensure_v2_protocol(runtime: &dyn ContainerRuntime, container: &str) -> Result<()> {
+    match runtime.protocol_label(container)? {
+        Some(v) if v == "2" => Ok(()),
+        other => Err(Error::LensProtocol {
+            container: container.to_string(),
+            message: format!(
+                "image advertises lens protocol {other:?}; this engine only speaks the v2 \
+                 exec/stdio job protocol (v1 images run via the JS engine until migrated — \
+                 hologit/lenses#32)"
+            ),
+        }),
+    }
+}
+
+/// `name@sha256:<64 hex>` — the digest-pinned reference form.
+pub fn is_digest_reference(reference: &str) -> bool {
+    let Some(idx) = reference.rfind("@sha256:") else {
+        return false;
+    };
+    if idx == 0 {
+        return false;
+    }
+    let hex = &reference[idx + "@sha256:".len()..];
+    hex.len() == 64 && hex.bytes().all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+}
+
+// ── Git plumbing helpers ───────────────────────────────────────────────────
+
+fn git(repo: &gix::Repository, args: &[&str]) -> std::result::Result<(), String> {
+    let git_dir = repo.path();
+    let output = Command::new("git")
+        .arg("--git-dir")
+        .arg(git_dir)
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+        .map_err(|e| format!("failed to spawn git: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "git {} failed ({}): {}",
+            args.first().unwrap_or(&""),
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(())
+}
+
+struct TreeEntry<'a> {
+    name: &'a str,
+    id: ObjectId,
+    kind: gix::objs::tree::EntryKind,
+}
+
+/// Write a tree object from pre-sorted entries.
+fn write_tree(repo: &gix::Repository, entries: &[TreeEntry<'_>]) -> Result<ObjectId> {
+    let tree = gix::objs::Tree {
+        entries: entries
+            .iter()
+            .map(|e| gix::objs::tree::Entry {
+                mode: e.kind.into(),
+                filename: e.name.into(),
+                oid: e.id,
+            })
+            .collect(),
+    };
+    Ok(repo
+        .write_object(&tree)
+        .map_err(|e| holo_tree::Error::Git(e.to_string()))?
+        .detach())
+}
+
+fn read_tree_blob(
+    repo: &gix::Repository,
+    tree_id: ObjectId,
+    name: &str,
+) -> Result<Option<String>> {
+    let tree = repo
+        .find_object(tree_id)
+        .map_err(|e| holo_tree::Error::Git(e.to_string()))?
+        .try_into_tree()
+        .map_err(|_| holo_tree::Error::Git(format!("{tree_id} is not a tree")))?;
+    let Some(entry) = tree
+        .lookup_entry_by_path(name)
+        .map_err(|e| holo_tree::Error::Git(e.to_string()))?
+    else {
+        return Ok(None);
+    };
+    let blob = repo
+        .find_object(entry.oid().to_owned())
+        .map_err(|e| holo_tree::Error::Git(e.to_string()))?;
+    if blob.kind != gix::object::Kind::Blob {
+        return Ok(None);
+    }
+    Ok(Some(String::from_utf8_lossy(&blob.data).into_owned()))
+}
+
+fn delete_ref(repo: &gix::Repository, refname: &str) -> Result<()> {
+    use gix::refs::transaction::{Change, PreviousValue, RefEdit, RefLog};
+
+    let name: gix::refs::FullName = refname
+        .try_into()
+        .map_err(|e: gix::refs::name::Error| holo_tree::Error::Git(e.to_string()))?;
+    repo.edit_reference(RefEdit {
+        change: Change::Delete {
+            expected: PreviousValue::Any,
+            log: RefLog::AndReference,
+        },
+        name,
+        deref: false,
+    })
+    .map_err(|e| holo_tree::Error::Git(e.to_string()))?;
+    Ok(())
+}
+
+// ── Scratch dir ────────────────────────────────────────────────────────────
+
+/// A per-job private scratch directory, removed on drop.
+struct ScratchDir {
+    path: PathBuf,
+}
+
+impl ScratchDir {
+    fn create(spec_hash: &str) -> Result<Self> {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let path = std::env::temp_dir().join(format!(
+            "holo-lens-job-{}-{:x}-{:x}",
+            &spec_hash[..12.min(spec_hash.len())],
+            std::process::id(),
+            nanos
+        ));
+        std::fs::create_dir_all(&path)
+            .map_err(|e| Error::Other(format!("failed to create scratch dir: {e}")))?;
+        Ok(ScratchDir { path })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for ScratchDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn path_str(path: &Path) -> Result<&str> {
+    path.to_str()
+        .ok_or_else(|| Error::Other("scratch path is not valid UTF-8".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn digest_reference_detection() {
+        assert!(is_digest_reference(
+            "ghcr.io/hologit/lenses/mkdocs@sha256:6b6b0bdb5beb2b3f852cc1cdfb7d2a67fc036bce7f26ac63efc39e8e2a2a4738"
+        ));
+        assert!(!is_digest_reference("ghcr.io/hologit/lenses/mkdocs:v2"));
+        assert!(!is_digest_reference("@sha256:6b6b0bdb5beb2b3f852cc1cdfb7d2a67fc036bce7f26ac63efc39e8e2a2a4738"));
+        assert!(!is_digest_reference("x@sha256:short"));
+        // uppercase hex is not the canonical form
+        assert!(!is_digest_reference(&format!("x@sha256:{}", "A".repeat(64))));
+    }
+}

--- a/holo-projector/src/lens/mod.rs
+++ b/holo-projector/src/lens/mod.rs
@@ -1,0 +1,508 @@
+//! Lens (hololens) execution: the edge capability layered around pure
+//! composition (`specs/behaviors/lensing.md`).
+//!
+//! Composition never executes lenses; this module wraps composition output:
+//! build the glob-filtered input tree, resolve the container identity,
+//! compute the content-addressed spec hash, satisfy from the spec-keyed
+//! cache (`refs/holo/lens/…`) or execute the container over the v2 one-shot
+//! job protocol, and merge the result back per the lens's declared output
+//! mode. Spec hashing and cache refs are hash/byte-identical with the JS
+//! engine, so cache entries interoperate across engines in both directions.
+//!
+//! Entry point: [`project_branch_lensed`] — the full oracle pipeline
+//! (`Projection.projectBranch`): composite → lens → final metadata strip.
+//! Recursive sub-projections lens natively per their effective lens flag
+//! (`specs/behaviors/composition.md` § Sub-projection lensing) instead of
+//! refusing with `LENSED_SUBPROJECTION` as the composition-only entry points
+//! do.
+
+pub mod iarna;
+pub mod identity;
+pub mod job;
+pub mod runtime;
+pub mod spec;
+pub mod toposort;
+
+use std::time::Duration;
+
+use gix::ObjectId;
+
+use crate::config::BranchConfigFile;
+use crate::error::{Error, Result};
+use crate::projection;
+use holo_tree::{Child, Context, MergeMode, MergeOptions, MutableTree, TreeCache};
+
+pub use identity::ContainerIdentity;
+pub use runtime::{ContainerCli, ContainerRuntime, CurlRegistry, RegistryClient};
+pub use spec::LensConfig;
+
+/// The lens engine: the container runtime + registry seams plus execution
+/// policy. Composition stays pure; everything side-effecting about lensing
+/// flows through this.
+pub struct LensEngine<'a> {
+    pub runtime: &'a dyn ContainerRuntime,
+    pub registry: &'a dyn RegistryClient,
+    /// Optional remote-source fetcher, inherited by the composition phase
+    /// and recursive sub-projections (`specs/behaviors/source-resolution.md`).
+    pub fetcher: Option<&'a dyn crate::fetch::SourceFetcher>,
+    /// Re-execute even when a cached result exists.
+    pub refresh: bool,
+    /// Record results at the spec-keyed cache ref.
+    pub save: bool,
+}
+
+impl<'a> LensEngine<'a> {
+    pub fn new(
+        runtime: &'a dyn ContainerRuntime,
+        registry: &'a dyn RegistryClient,
+    ) -> LensEngine<'a> {
+        LensEngine {
+            runtime,
+            registry,
+            fetcher: None,
+            refresh: false,
+            save: true,
+        }
+    }
+}
+
+// ── Public pipeline ────────────────────────────────────────────────────────
+
+/// Project a holobranch through the full pipeline: composite, lens (when the
+/// effective lens flag allows), strip metadata, write. Returns the final
+/// output tree hash — identical to the JS engine's for the same input.
+///
+/// `lens_override` mirrors the oracle's `lens` option: `Some(_)` overrides
+/// the branch config's `lens` flag; `None` defers to config, defaulting to
+/// `true`. Sub-projections always resolve their own effective flag.
+pub fn project_branch_lensed(
+    repo: &gix::Repository,
+    root_tree_id: ObjectId,
+    branch_name: &str,
+    engine: &LensEngine<'_>,
+    lens_override: Option<bool>,
+) -> Result<ObjectId> {
+    let cache = TreeCache::new();
+    let ctx = Context::new(repo, &cache);
+    let lens_phase = match lens_override {
+        Some(flag) => flag,
+        None => read_branch_lens_flag(&ctx, root_tree_id, branch_name)?.unwrap_or(true),
+    };
+    lensed_pipeline(&ctx, root_tree_id, branch_name, engine, lens_phase)
+}
+
+/// Recursive sub-projection with native lensing: the effective lens flag is
+/// the sub-branch config's `lens` when boolean, else the caller's default
+/// (`holosource.project.lens`), else `true` — exactly the oracle's
+/// `Source.getOutputTree` resolution.
+fn lensed_sub_projection(
+    ctx: &Context,
+    root_tree_id: ObjectId,
+    branch_name: &str,
+    engine: &LensEngine<'_>,
+    default_lens: Option<bool>,
+) -> Result<ObjectId> {
+    let lens_phase = read_branch_lens_flag(ctx, root_tree_id, branch_name)?
+        .or(default_lens)
+        .unwrap_or(true);
+    lensed_pipeline(ctx, root_tree_id, branch_name, engine, lens_phase)
+}
+
+fn lensed_pipeline(
+    ctx: &Context,
+    root_tree_id: ObjectId,
+    branch_name: &str,
+    engine: &LensEngine<'_>,
+    lens_phase: bool,
+) -> Result<ObjectId> {
+    let mut project_fn = |c: &Context, tree_id: ObjectId, bn: &str, default_lens: Option<bool>| {
+        lensed_sub_projection(c, tree_id, bn, engine, default_lens)
+    };
+
+    let mut output = projection::compose_branch_tree(
+        ctx,
+        root_tree_id,
+        branch_name,
+        &mut project_fn,
+        engine.fetcher,
+    )?;
+
+    if lens_phase {
+        apply_lenses(ctx, engine, &mut output, root_tree_id, branch_name)?;
+    }
+
+    projection::strip_bare_holo(ctx, &mut output)?;
+    Ok(output.write(ctx)?)
+}
+
+fn read_branch_lens_flag(
+    ctx: &Context,
+    root_tree_id: ObjectId,
+    branch_name: &str,
+) -> Result<Option<bool>> {
+    let mut ws_tree = MutableTree::new(root_tree_id);
+    let config = crate::config::read_toml::<BranchConfigFile>(
+        ctx,
+        &mut ws_tree,
+        &format!(".holo/branches/{branch_name}.toml"),
+    )?;
+    Ok(config.and_then(|f| f.holobranch.lens))
+}
+
+// ── Lens phase ─────────────────────────────────────────────────────────────
+
+/// Apply a projection's lenses to its composed output tree
+/// (`Projection.lens`): internal lens configs (`.holo/lenses/*.toml` in the
+/// composed output) run first, then external ones
+/// (`.holo/branches/<branch>.lenses/*.toml` in the input workspace), each
+/// group ordered by its `before`/`after` constraints. Ends by stripping
+/// `.holo/lenses` from the output.
+pub fn apply_lenses(
+    ctx: &Context,
+    engine: &LensEngine<'_>,
+    output: &mut MutableTree,
+    branch_root_tree: ObjectId,
+    branch_name: &str,
+) -> Result<()> {
+    let internal = discover_lenses(ctx, output, ".holo/lenses")?;
+
+    let mut ws_tree = MutableTree::new(branch_root_tree);
+    let external = discover_lenses(
+        ctx,
+        &mut ws_tree,
+        &format!(".holo/branches/{branch_name}.lenses"),
+    )?;
+
+    for lens in internal.iter().chain(external.iter()) {
+        run_lens(ctx, engine, output, lens)?;
+    }
+
+    if let Some(holo) = output.get_subtree(ctx, ".holo")? {
+        holo.delete_child(ctx, "lenses")?;
+    }
+
+    Ok(())
+}
+
+/// Execute one lens against the (live) output tree and merge its result
+/// back.
+fn run_lens(
+    ctx: &Context,
+    engine: &LensEngine<'_>,
+    output: &mut MutableTree,
+    lens: &LensConfig,
+) -> Result<()> {
+    // Build the glob-filtered input tree from the projection output,
+    // re-rooted at input.root (pure tree work; composition glob semantics).
+    let input_root_hash = match output.get_subtree(ctx, &lens.input_root)? {
+        Some(subtree) => subtree.write(ctx)?,
+        None => {
+            return Err(Error::LensConfig {
+                lens: lens.name.clone(),
+                message: format!(
+                    "could not resolve input.root \"{}\" within the projection output",
+                    lens.input_root
+                ),
+            })
+        }
+    };
+    let mut input_source = MutableTree::new(input_root_hash);
+    let mut input_tree = MutableTree::empty();
+    input_tree.merge(
+        ctx,
+        &mut input_source,
+        &MergeOptions::new(Some(&lens.input_files), MergeMode::Overlay)?,
+        ".",
+    )?;
+    let input_hash = input_tree.write(ctx)?;
+
+    // Resolve the container identity and write the content-addressed spec.
+    let container = match (&lens.container, lens.table.contains_key("package")) {
+        (Some(c), _) => c.clone(),
+        (None, true) => {
+            return Err(Error::LensProtocol {
+                container: format!("(habitat package lens '{}')", lens.name),
+                message: "Habitat lens execution is retired; migrate the lens to an OCI \
+                          image (specs/behaviors/lensing.md § Runtime decision)"
+                    .into(),
+            })
+        }
+        (None, false) => {
+            return Err(Error::LensConfig {
+                lens: lens.name.clone(),
+                message: "hololens has no container defined".into(),
+            })
+        }
+    };
+    let identity = identity::resolve(engine.runtime, engine.registry, &container)?;
+    let spec_table = spec::build_spec_table(lens, &identity.container, identity.local, input_hash);
+    let spec_obj = spec::write_spec(ctx.repo, spec_table)?;
+    let spec_hash = spec_obj.hash.to_string();
+
+    // Spec-keyed cache: reads are trusted without re-execution
+    // (content-addressing is the integrity model).
+    let mut result_tree = None;
+    if !engine.refresh {
+        result_tree = read_cached_tree(ctx.repo, &spec_obj.cache_ref)?;
+        if result_tree.is_some() {
+            eprintln!("found existing output tree matching holospec({spec_hash})");
+        }
+    }
+
+    let result_tree = match result_tree {
+        Some(tree) => tree,
+        None => {
+            let tree = job::execute(
+                ctx.repo,
+                engine.runtime,
+                &job::JobSpec {
+                    spec_hash: &spec_hash,
+                    container: &identity.container,
+                    resolved_local: identity.local,
+                    input_tree: input_hash,
+                    timeout: Duration::from_secs(lens.timeout_secs),
+                },
+            )?;
+            if engine.save {
+                holo_tree::repo::update_ref(ctx.repo, &spec_obj.cache_ref, tree, None)?;
+            }
+            tree
+        }
+    };
+
+    // Merge the result tree back at output.root with the declared mode.
+    let target = output.get_or_create_subtree(ctx, &lens.output_root)?;
+    let mut lensed = MutableTree::new(result_tree);
+    target.merge(
+        ctx,
+        &mut lensed,
+        &MergeOptions::new(None, lens.output_merge)?,
+        ".",
+    )?;
+
+    Ok(())
+}
+
+// ── Cache ──────────────────────────────────────────────────────────────────
+
+/// Read a spec-keyed cache ref, peeling to a tree (`git rev-parse
+/// <ref>^{tree}` semantics): the ref may point at a tree directly
+/// (both engines' native form) or at a commit.
+pub fn read_cached_tree(repo: &gix::Repository, cache_ref: &str) -> Result<Option<ObjectId>> {
+    let Some(id) = holo_tree::repo::resolve_ref(repo, cache_ref)? else {
+        return Ok(None);
+    };
+    let obj = repo
+        .find_object(id)
+        .map_err(|e| holo_tree::Error::Git(e.to_string()))?;
+    match obj.kind {
+        gix::object::Kind::Tree => Ok(Some(id)),
+        gix::object::Kind::Commit => {
+            let commit = obj
+                .try_into_commit()
+                .map_err(|_| holo_tree::Error::Git(format!("{id} failed to parse as commit")))?;
+            Ok(Some(
+                commit
+                    .tree_id()
+                    .map_err(|e| holo_tree::Error::Git(e.to_string()))?
+                    .detach(),
+            ))
+        }
+        _ => Ok(None),
+    }
+}
+
+// ── Discovery ──────────────────────────────────────────────────────────────
+
+#[derive(serde::Deserialize)]
+struct HololensFile {
+    hololens: Option<toml::Table>,
+}
+
+/// Discover lens configs under `dir_path` (direct `*.toml` blob children),
+/// resolve each one's sibling data tree, normalize, and order the set by its
+/// `before`/`after` constraints (`Workspace.getLenses` / `Branch.getLenses`).
+fn discover_lenses(
+    ctx: &Context,
+    tree: &mut MutableTree,
+    dir_path: &str,
+) -> Result<Vec<LensConfig>> {
+    let Some(dir) = tree.get_subtree(ctx, dir_path)? else {
+        return Ok(vec![]);
+    };
+    dir.ensure_children(ctx)?;
+
+    // Snapshot config blobs in tree (byte-sorted) order.
+    let mut entries: Vec<(String, ObjectId)> = Vec::new();
+    for (name, child) in dir.children.iter().flatten() {
+        let Some(stem) = name.strip_suffix(".toml") else {
+            continue;
+        };
+        if stem.is_empty() {
+            continue;
+        }
+        if let Child::Blob { hash, .. } = child {
+            entries.push((stem.to_string(), *hash));
+        }
+    }
+
+    let mut lenses = Vec::with_capacity(entries.len());
+    for (name, blob) in entries {
+        let config_path = format!("{dir_path}/{name}.toml");
+        let obj = ctx
+            .repo
+            .find_object(blob)
+            .map_err(|e| holo_tree::Error::Git(e.to_string()))?;
+        let text = std::str::from_utf8(&obj.data).map_err(|_| Error::Config {
+            path: config_path.clone(),
+            message: "non-UTF8".into(),
+        })?;
+        let parsed: HololensFile = toml::from_str(text).map_err(|e| Error::Config {
+            path: config_path.clone(),
+            message: e.to_string(),
+        })?;
+        let Some(table) = parsed.hololens else {
+            return Err(Error::Config {
+                path: config_path,
+                message: "hololens config not found".into(),
+            });
+        };
+
+        // Sibling data tree: `.holo/…/<name>/` alongside `<name>.toml`.
+        let data_tree = match tree.get_subtree(ctx, &format!("{dir_path}/{name}"))? {
+            Some(data) => Some(data.write(ctx)?),
+            None => None,
+        };
+
+        lenses.push(LensConfig::normalize(&name, table, data_tree)?);
+    }
+
+    order_lenses(lenses)
+}
+
+/// Order lenses by `before`/`after` constraints (with `"*"` wildcards) using
+/// the oracle's toposort.
+fn order_lenses(lenses: Vec<LensConfig>) -> Result<Vec<LensConfig>> {
+    if lenses.is_empty() {
+        return Ok(lenses);
+    }
+
+    let names: Vec<String> = lenses.iter().map(|l| l.name.clone()).collect();
+    let mut edges: Vec<(String, String)> = Vec::new();
+
+    for lens in &lenses {
+        let mut expand = |list: &[String], reverse: bool| -> Result<()> {
+            let mut list = list.to_vec();
+            let mut i = 0;
+            while i < list.len() {
+                let entry = list[i].clone();
+                if entry == "*" {
+                    for other in &names {
+                        if other != &lens.name && !list.contains(other) {
+                            list.push(other.clone());
+                        }
+                    }
+                    i += 1;
+                    continue;
+                }
+                if !names.contains(&entry) {
+                    return Err(Error::Config {
+                        path: lens.name.clone(),
+                        message: format!(
+                            "lens defines {}=\"{entry}\", but it was not found in [{}]",
+                            if reverse { "before" } else { "after" },
+                            names.join(",")
+                        ),
+                    });
+                }
+                if reverse {
+                    edges.push((lens.name.clone(), entry));
+                } else {
+                    edges.push((entry, lens.name.clone()));
+                }
+                i += 1;
+            }
+            Ok(())
+        };
+
+        expand(&lens.after, false)?;
+        expand(&lens.before, true)?;
+    }
+
+    let order = toposort::toposort(&names, &edges)?;
+
+    let mut by_name: std::collections::BTreeMap<String, LensConfig> = lenses
+        .into_iter()
+        .map(|l| (l.name.clone(), l))
+        .collect();
+    Ok(order
+        .into_iter()
+        .filter_map(|name| by_name.remove(&name))
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lens(name: &str, before: &[&str], after: &[&str]) -> LensConfig {
+        let mut toml_text = format!("container = \"c/{name}:latest\"\n");
+        if !before.is_empty() {
+            toml_text.push_str(&format!(
+                "before = [{}]\n",
+                before
+                    .iter()
+                    .map(|b| format!("\"{b}\""))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+        if !after.is_empty() {
+            toml_text.push_str(&format!(
+                "after = [{}]\n",
+                after
+                    .iter()
+                    .map(|a| format!("\"{a}\""))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+        LensConfig::normalize(name, toml_text.parse().unwrap(), None).unwrap()
+    }
+
+    #[test]
+    fn order_unconstrained_keeps_discovery_order() {
+        let out = order_lenses(vec![lens("b", &[], &[]), lens("a", &[], &[])]).unwrap();
+        let names: Vec<&str> = out.iter().map(|l| l.name.as_str()).collect();
+        assert_eq!(names, ["b", "a"]);
+    }
+
+    #[test]
+    fn order_respects_before_after() {
+        let out = order_lenses(vec![
+            lens("compile", &[], &["assets"]),
+            lens("assets", &[], &[]),
+        ])
+        .unwrap();
+        let names: Vec<&str> = out.iter().map(|l| l.name.as_str()).collect();
+        assert_eq!(names, ["assets", "compile"]);
+    }
+
+    #[test]
+    fn order_wildcard_after_runs_last() {
+        let out = order_lenses(vec![
+            lens("zip", &[], &["*"]),
+            lens("a", &[], &[]),
+            lens("b", &[], &[]),
+        ])
+        .unwrap();
+        let names: Vec<&str> = out.iter().map(|l| l.name.as_str()).collect();
+        assert_eq!(names, ["a", "b", "zip"]);
+    }
+
+    #[test]
+    fn order_unknown_reference_errors() {
+        let err = order_lenses(vec![lens("a", &[], &["missing"])]).unwrap_err();
+        assert_eq!(err.code(), "CONFIG");
+    }
+}

--- a/holo-projector/src/lens/runtime.rs
+++ b/holo-projector/src/lens/runtime.rs
@@ -1,0 +1,513 @@
+//! Container-runtime and registry seams for lens execution.
+//!
+//! The engine abstracts the container runtime behind the exec/stdio seam
+//! (`specs/behaviors/lensing.md` § Runtime decision): Docker and Podman are
+//! equally supported through their CLIs, nothing may depend on
+//! Docker-specific behavior, and the trait boundary is where remoted lensing
+//! (#79) and test harnesses plug in.
+
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use crate::error::{Error, Result};
+
+/// OCI image label marking a lens image as implementing the v2 job protocol.
+pub const PROTOCOL_LABEL: &str = "sh.holo.lens.protocol";
+
+/// Container label applied to one-shot job containers so an engine crash
+/// leaves them discoverable for cleanup (`docker ps -a --filter label=…`).
+pub const JOB_LABEL: &str = "sh.holo.lens.job";
+
+/// A locally-present image's identity, from the local engine's store.
+#[derive(Debug, Clone)]
+pub struct LocalImage {
+    /// The engine-local image ID (`sha256:…`) — the identity of last resort
+    /// for never-pushed images (#417).
+    pub id: String,
+    /// Repository digests (`name@sha256:…`) recorded when the image was
+    /// pulled from or pushed to a registry.
+    pub repo_digests: Vec<String>,
+}
+
+/// Outcome of a one-shot lens job container run.
+#[derive(Debug)]
+pub struct OneShotOutcome {
+    /// The container process's exit code (`None` if terminated by signal).
+    pub exit_code: Option<i32>,
+    /// Raw stdout — the result bundle (binary-clean per the stdio
+    /// discipline).
+    pub stdout: Vec<u8>,
+    /// Tail of stderr, for transport-error diagnostics.
+    pub stderr_tail: String,
+    /// The job exceeded its deadline and was cancelled.
+    pub timed_out: bool,
+}
+
+/// The container-runtime seam: everything the lens executor needs from a
+/// local (or remote — `DOCKER_HOST` etc. ride along transparently) OCI
+/// runtime.
+pub trait ContainerRuntime {
+    /// Inspect a locally-present image; `Ok(None)` when not present.
+    fn inspect_local(&self, reference: &str) -> Result<Option<LocalImage>>;
+
+    /// Pull an image (by tag or digest reference).
+    fn pull(&self, reference: &str) -> Result<()>;
+
+    /// Read the image's `sh.holo.lens.protocol` label, if any.
+    fn protocol_label(&self, reference: &str) -> Result<Option<String>>;
+
+    /// Run a one-shot v2 lens job: the image's default entrypoint with no
+    /// arguments, the input bundle on stdin, the result bundle on stdout,
+    /// stderr relayed as logging. Enforces `deadline`; on expiry the
+    /// container must be force-removed (no partial results are read).
+    fn run_one_shot(
+        &self,
+        image: &str,
+        spec_hash: &str,
+        input_bundle: &[u8],
+        deadline: Duration,
+    ) -> Result<OneShotOutcome>;
+}
+
+/// The registry seam (identity-resolution rung 3): resolve a tag to its
+/// manifest digest with a HEAD request over plain OCI registry HTTP — no
+/// container-engine CLI dependency (`specs/behaviors/lensing.md`
+/// § Container identity resolution).
+pub trait RegistryClient {
+    /// Return the manifest digest (`sha256:…`) the registry currently serves
+    /// for `reference` (a tag reference). For multi-platform images this is
+    /// the manifest-index digest — the Accept negotiation must prefer index
+    /// media types.
+    fn manifest_digest(&self, reference: &str) -> Result<String>;
+}
+
+// ── Container CLI implementation ───────────────────────────────────────────
+
+/// `ContainerRuntime` over a container-engine CLI (`docker` or `podman`,
+/// same argument surface for everything the engine uses).
+#[derive(Debug, Clone)]
+pub struct ContainerCli {
+    program: String,
+}
+
+impl ContainerCli {
+    pub fn new(program: impl Into<String>) -> Self {
+        ContainerCli {
+            program: program.into(),
+        }
+    }
+
+    /// Autodetect an available container engine: `docker`, then `podman`.
+    pub fn detect() -> Result<Self> {
+        for program in ["docker", "podman"] {
+            let found = Command::new(program)
+                .arg("--version")
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false);
+            if found {
+                return Ok(ContainerCli::new(program));
+            }
+        }
+        Err(Error::Other(
+            "no container engine found (tried docker, podman); lens execution requires one"
+                .into(),
+        ))
+    }
+
+    pub fn program(&self) -> &str {
+        &self.program
+    }
+
+    fn run(&self, args: &[&str]) -> Result<std::process::Output> {
+        Command::new(&self.program)
+            .args(args)
+            .stdin(Stdio::null())
+            .output()
+            .map_err(|e| Error::Other(format!("failed to spawn {}: {e}", self.program)))
+    }
+
+    /// Run an inspect returning trimmed stdout, or `None` on inspect failure
+    /// (image not present).
+    fn inspect_format(&self, reference: &str, format: &str) -> Result<Option<String>> {
+        let output = self.run(&["image", "inspect", "--format", format, reference])?;
+        if !output.status.success() {
+            return Ok(None);
+        }
+        Ok(Some(
+            String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        ))
+    }
+}
+
+impl ContainerRuntime for ContainerCli {
+    fn inspect_local(&self, reference: &str) -> Result<Option<LocalImage>> {
+        let Some(id) = self.inspect_format(reference, "{{.Id}}")? else {
+            return Ok(None);
+        };
+        let digests = self
+            .inspect_format(reference, "{{range .RepoDigests}}{{.}} {{end}}")?
+            .unwrap_or_default();
+        Ok(Some(LocalImage {
+            id,
+            repo_digests: digests
+                .split_whitespace()
+                .map(str::to_string)
+                .collect(),
+        }))
+    }
+
+    fn pull(&self, reference: &str) -> Result<()> {
+        eprintln!("pulling required image: {reference}");
+        let status = Command::new(&self.program)
+            .args(["pull", reference])
+            .stdin(Stdio::null())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()
+            .map_err(|e| Error::Other(format!("failed to spawn {}: {e}", self.program)))?;
+        if !status.success() {
+            return Err(Error::LensIdentity {
+                container: reference.to_string(),
+                message: format!("failed to pull container image ({status})"),
+            });
+        }
+        Ok(())
+    }
+
+    fn protocol_label(&self, reference: &str) -> Result<Option<String>> {
+        let format = format!("{{{{index .Config.Labels \"{PROTOCOL_LABEL}\"}}}}");
+        let label = self.inspect_format(reference, &format)?;
+        Ok(label.filter(|v| !v.is_empty() && v != "<no value>"))
+    }
+
+    fn run_one_shot(
+        &self,
+        image: &str,
+        spec_hash: &str,
+        input_bundle: &[u8],
+        deadline: Duration,
+    ) -> Result<OneShotOutcome> {
+        let nonce = {
+            use std::time::{SystemTime, UNIX_EPOCH};
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.subsec_nanos())
+                .unwrap_or(0);
+            format!("{:08x}", nanos ^ std::process::id())
+        };
+        let container_name = format!("holo-lens-job-{}-{nonce}", &spec_hash[..12]);
+        let job_label = format!("{JOB_LABEL}={spec_hash}");
+
+        let mut child = Command::new(&self.program)
+            .args([
+                "run",
+                "--rm",
+                "--interactive",
+                "--name",
+                &container_name,
+                "--label",
+                &job_label,
+                image,
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| Error::Other(format!("failed to spawn {}: {e}", self.program)))?;
+
+        // Writer thread: stream the bundle in, ignoring EPIPE if the
+        // container exits before consuming all input.
+        let mut stdin = child.stdin.take().expect("stdin piped");
+        let input = input_bundle.to_vec();
+        let writer = std::thread::spawn(move || {
+            let _ = stdin.write_all(&input);
+            drop(stdin);
+        });
+
+        // Reader threads: stdout is the (binary) result bundle; stderr is
+        // relayed line-by-line as dimmed logging.
+        let mut stdout_pipe = child.stdout.take().expect("stdout piped");
+        let stdout_reader = std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = stdout_pipe.read_to_end(&mut buf);
+            buf
+        });
+        let stderr_pipe = child.stderr.take().expect("stderr piped");
+        let stderr_reader = std::thread::spawn(move || {
+            use std::io::BufRead;
+            let mut tail = String::new();
+            let reader = std::io::BufReader::new(stderr_pipe);
+            for line in reader.lines() {
+                let Ok(line) = line else { break };
+                eprintln!("\x1b[90m{line}\x1b[0m");
+                tail.push_str(&line);
+                tail.push('\n');
+                if tail.len() > 16384 {
+                    tail = tail[tail.len() - 16384..].to_string();
+                }
+            }
+            tail
+        });
+
+        // Deadline loop: poll the client process; on expiry force-remove the
+        // container itself (killing the attached client alone can leave the
+        // container running), then kill the client.
+        let start = Instant::now();
+        let mut timed_out = false;
+        let status = loop {
+            match child.try_wait() {
+                Ok(Some(status)) => break status,
+                Ok(None) => {
+                    if start.elapsed() >= deadline {
+                        timed_out = true;
+                        let _ = self.run(&["rm", "--force", &container_name]);
+                        let _ = child.kill();
+                        break child.wait().map_err(|e| {
+                            Error::Other(format!("failed to reap lens job client: {e}"))
+                        })?;
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+                Err(e) => {
+                    return Err(Error::Other(format!(
+                        "failed to poll lens job client: {e}"
+                    )))
+                }
+            }
+        };
+
+        let _ = writer.join();
+        let stdout = stdout_reader
+            .join()
+            .map_err(|_| Error::Other("lens job stdout reader panicked".into()))?;
+        let stderr_tail = stderr_reader
+            .join()
+            .map_err(|_| Error::Other("lens job stderr reader panicked".into()))?;
+
+        Ok(OneShotOutcome {
+            exit_code: status.code(),
+            stdout,
+            stderr_tail,
+            timed_out,
+        })
+    }
+}
+
+// ── Registry client (anonymous OCI HTTP via curl) ──────────────────────────
+
+/// Anonymous OCI-registry client shelling out to `curl` for HTTPS.
+///
+/// Performs the standard token dance: HEAD the manifest, follow a 401's
+/// `WWW-Authenticate: Bearer` challenge to fetch an anonymous pull token,
+/// retry, and read the `Docker-Content-Digest` response header. The Accept
+/// list prefers index media types so multi-platform tags resolve to the
+/// manifest-index digest (never a platform manifest's).
+///
+/// Shelling out to `curl` keeps the engine free of an HTTP/TLS dependency
+/// tree; the `RegistryClient` trait is the seam where a native client can
+/// replace it. Private registries (authenticated pulls) are not yet
+/// supported on this rung — pin by digest or pre-pull instead.
+#[derive(Debug, Clone, Default)]
+pub struct CurlRegistry;
+
+const ACCEPT: &str = "application/vnd.oci.image.index.v1+json,\
+application/vnd.docker.distribution.manifest.list.v2+json,\
+application/vnd.oci.image.manifest.v1+json,\
+application/vnd.docker.distribution.manifest.v2+json";
+
+impl CurlRegistry {
+    fn curl(args: &[&str]) -> Result<String> {
+        let output = Command::new("curl")
+            .args(["-sS", "--max-time", "30"])
+            .args(args)
+            .stdin(Stdio::null())
+            .output()
+            .map_err(|e| Error::Other(format!("failed to spawn curl: {e}")))?;
+        if !output.status.success() {
+            return Err(Error::Other(format!(
+                "curl failed ({}): {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            )));
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+
+    fn head_manifest(url: &str, token: Option<&str>) -> Result<String> {
+        let accept = format!("Accept: {ACCEPT}");
+        let mut args = vec!["-I", "-H", accept.as_str()];
+        let auth;
+        if let Some(token) = token {
+            auth = format!("Authorization: Bearer {token}");
+            args.extend(["-H", auth.as_str()]);
+        }
+        args.push(url);
+        Self::curl(&args)
+    }
+
+    fn header<'a>(response: &'a str, name: &str) -> Option<&'a str> {
+        response.lines().find_map(|line| {
+            let (key, value) = line.split_once(':')?;
+            key.trim()
+                .eq_ignore_ascii_case(name)
+                .then(|| value.trim())
+        })
+    }
+
+    fn status_code(response: &str) -> Option<u16> {
+        response
+            .lines()
+            .next()?
+            .split_whitespace()
+            .nth(1)?
+            .parse()
+            .ok()
+    }
+
+    /// Fetch an anonymous bearer token per the 401 challenge.
+    fn fetch_token(challenge: &str, repository: &str) -> Result<String> {
+        let field = |name: &str| -> Option<String> {
+            let marker = format!("{name}=\"");
+            let start = challenge.find(&marker)? + marker.len();
+            let end = challenge[start..].find('"')? + start;
+            Some(challenge[start..end].to_string())
+        };
+        let realm = field("realm")
+            .ok_or_else(|| Error::Other("registry challenge missing realm".into()))?;
+        let mut url = format!("{realm}?scope=repository:{repository}:pull");
+        if let Some(service) = field("service") {
+            url.push_str(&format!("&service={service}"));
+        }
+        let body = Self::curl(&[url.as_str()])?;
+        // The token response is flat JSON; extract "token" (or
+        // "access_token") without a JSON dependency.
+        for key in ["\"token\":\"", "\"access_token\":\""] {
+            if let Some(start) = body.find(key) {
+                let start = start + key.len();
+                if let Some(end) = body[start..].find('"') {
+                    return Ok(body[start..start + end].to_string());
+                }
+            }
+        }
+        Err(Error::Other("registry token response had no token".into()))
+    }
+}
+
+impl RegistryClient for CurlRegistry {
+    fn manifest_digest(&self, reference: &str) -> Result<String> {
+        let identity_err = |message: String| Error::LensIdentity {
+            container: reference.to_string(),
+            message,
+        };
+
+        let (host, repository, tag) = split_reference(reference);
+        let url = format!("https://{host}/v2/{repository}/manifests/{tag}");
+
+        let mut response = Self::head_manifest(&url, None)?;
+        if Self::status_code(&response) == Some(401) {
+            let challenge = Self::header(&response, "www-authenticate")
+                .ok_or_else(|| identity_err("401 without WWW-Authenticate challenge".into()))?
+                .to_string();
+            let token = Self::fetch_token(&challenge, &repository)?;
+            response = Self::head_manifest(&url, Some(&token))?;
+        }
+
+        match Self::status_code(&response) {
+            Some(200) => {}
+            other => {
+                return Err(identity_err(format!(
+                    "registry manifest HEAD returned status {other:?}"
+                )))
+            }
+        }
+
+        Self::header(&response, "docker-content-digest")
+            .map(str::to_string)
+            .ok_or_else(|| identity_err("registry response had no Docker-Content-Digest".into()))
+    }
+}
+
+/// Split an image reference into `(registry_host, repository, tag)`.
+///
+/// A first path component containing `.` or `:` (or `localhost`) is a
+/// registry host; otherwise the reference is a Docker Hub shortname
+/// (`registry-1.docker.io`, `library/` prefix for bare names). The tag
+/// defaults to `latest`.
+pub fn split_reference(reference: &str) -> (String, String, String) {
+    let (name, tag) = match reference.rsplit_once(':') {
+        Some((n, t)) if !t.contains('/') => (n.to_string(), t.to_string()),
+        _ => (reference.to_string(), "latest".to_string()),
+    };
+
+    match name.split_once('/') {
+        Some((first, rest))
+            if first.contains('.') || first.contains(':') || first == "localhost" =>
+        {
+            (first.to_string(), rest.to_string(), tag)
+        }
+        Some(_) => ("registry-1.docker.io".to_string(), name, tag),
+        None => ("registry-1.docker.io".to_string(), format!("library/{name}"), tag),
+    }
+}
+
+/// Strip the tag portion of a reference the way the oracle does
+/// (`containerQuery.replace(/:.*$/, '')`): everything from the **first**
+/// colon. Faithful to `lib/Lens.js` — references with a registry port would
+/// mis-strip identically in both engines.
+pub fn strip_tag(reference: &str) -> &str {
+    match reference.find(':') {
+        Some(idx) => &reference[..idx],
+        None => reference,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_reference_forms() {
+        assert_eq!(
+            split_reference("ghcr.io/hologit/lenses/mkdocs:v2"),
+            (
+                "ghcr.io".to_string(),
+                "hologit/lenses/mkdocs".to_string(),
+                "v2".to_string()
+            )
+        );
+        assert_eq!(
+            split_reference("alpine"),
+            (
+                "registry-1.docker.io".to_string(),
+                "library/alpine".to_string(),
+                "latest".to_string()
+            )
+        );
+        assert_eq!(
+            split_reference("someorg/tool:1.2"),
+            (
+                "registry-1.docker.io".to_string(),
+                "someorg/tool".to_string(),
+                "1.2".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn strip_tag_first_colon() {
+        assert_eq!(strip_tag("ghcr.io/x/y:latest"), "ghcr.io/x/y");
+        assert_eq!(strip_tag("ghcr.io/x/y"), "ghcr.io/x/y");
+    }
+
+    #[test]
+    fn parse_challenge_headers() {
+        let response = "HTTP/2 401 \r\nwww-authenticate: Bearer realm=\"https://ghcr.io/token\",service=\"ghcr.io\",scope=\"repository:x/y:pull\"\r\n\r\n";
+        assert_eq!(CurlRegistry::status_code(response), Some(401));
+        let challenge = CurlRegistry::header(response, "WWW-Authenticate").unwrap();
+        assert!(challenge.contains("realm=\"https://ghcr.io/token\""));
+    }
+}

--- a/holo-projector/src/lens/runtime.rs
+++ b/holo-projector/src/lens/runtime.rs
@@ -162,13 +162,21 @@ impl ContainerRuntime for ContainerCli {
 
     fn pull(&self, reference: &str) -> Result<()> {
         eprintln!("pulling required image: {reference}");
-        let status = Command::new(&self.program)
+        // Progress lands on stderr: stdout belongs to the engine's own
+        // output contract (the projected tree hash).
+        let mut child = Command::new(&self.program)
             .args(["pull", reference])
             .stdin(Stdio::null())
-            .stdout(Stdio::inherit())
+            .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
-            .status()
+            .spawn()
             .map_err(|e| Error::Other(format!("failed to spawn {}: {e}", self.program)))?;
+        if let Some(mut stdout) = child.stdout.take() {
+            let _ = std::io::copy(&mut stdout, &mut std::io::stderr());
+        }
+        let status = child
+            .wait()
+            .map_err(|e| Error::Other(format!("failed to reap {} pull: {e}", self.program)))?;
         if !status.success() {
             return Err(Error::LensIdentity {
                 container: reference.to_string(),

--- a/holo-projector/src/lens/spec.rs
+++ b/holo-projector/src/lens/spec.rs
@@ -1,0 +1,374 @@
+//! Lens config normalization and content-addressed spec objects
+//! (`specs/behaviors/lensing.md` § Spec and content addressing — ported
+//! behavior; conformance is byte/hash identity with `lib/Lens.js` +
+//! `lib/SpecObject.js`).
+
+use gix::ObjectId;
+use toml::Value;
+
+use super::iarna;
+use crate::error::{Error, Result};
+use holo_tree::MergeMode;
+
+/// Default job deadline in seconds (mirrors `lib/Lens.js`), applied when the
+/// lens config declares no positive `timeout`.
+pub const DEFAULT_JOB_TIMEOUT_SECS: u64 = 600;
+
+/// A discovered lens: its identity within the projection plus the normalized
+/// config table (the oracle's `Lens.getConfig()` output).
+#[derive(Debug, Clone)]
+pub struct LensConfig {
+    /// Lens name (config file basename).
+    pub name: String,
+    /// The normalized `[hololens]` table. Arbitrary author keys are
+    /// preserved — everything here except `output`/`before`/`after`/`timeout`
+    /// enters the spec.
+    pub table: toml::Table,
+    pub input_root: String,
+    pub input_files: Vec<String>,
+    pub output_root: String,
+    pub output_merge: MergeMode,
+    pub before: Vec<String>,
+    pub after: Vec<String>,
+    /// Job deadline (config `timeout`, engine default otherwise). Never part
+    /// of the spec — a deadline cannot change output.
+    pub timeout_secs: u64,
+    /// The configured container reference (pre-resolution).
+    pub container: Option<String>,
+}
+
+fn config_error(name: &str, message: impl Into<String>) -> Error {
+    Error::LensConfig {
+        lens: name.to_string(),
+        message: message.into(),
+    }
+}
+
+fn string_or_vec(name: &str, key: &str, value: &Value) -> Result<Vec<String>> {
+    match value {
+        Value::String(s) => Ok(vec![s.clone()]),
+        Value::Array(arr) => arr
+            .iter()
+            .map(|v| {
+                v.as_str()
+                    .map(str::to_string)
+                    .ok_or_else(|| config_error(name, format!("{key} entries must be strings")))
+            })
+            .collect(),
+        _ => Err(config_error(
+            name,
+            format!("{key} must be a string or array of strings"),
+        )),
+    }
+}
+
+impl LensConfig {
+    /// Normalize a raw `[hololens]` table exactly as `Lens.getConfig()` does:
+    ///
+    /// - `package` implies a default `command` (`lens-tree {{ input }}`) —
+    ///   kept for spec byte-parity even though Habitat execution is retired;
+    /// - `before`/`after` accept string or array;
+    /// - `input.files` defaults to `["**"]` (string accepted), `input.root`
+    ///   to `"."`;
+    /// - `output.root` defaults to `input.root`, `output.merge` to
+    ///   `"overlay"`;
+    /// - `data` is set to the hash of the lens's sibling data tree when the
+    ///   caller resolved one.
+    pub fn normalize(
+        name: &str,
+        mut table: toml::Table,
+        data_tree: Option<ObjectId>,
+    ) -> Result<LensConfig> {
+        if table.contains_key("package") && !table.contains_key("command") {
+            table.insert(
+                "command".to_string(),
+                Value::String("lens-tree {{ input }}".to_string()),
+            );
+        }
+
+        let before = match table.get("before") {
+            Some(v) => string_or_vec(name, "before", v)?,
+            None => vec![],
+        };
+        let after = match table.get("after") {
+            Some(v) => string_or_vec(name, "after", v)?,
+            None => vec![],
+        };
+
+        // input
+        let mut input = match table.remove("input") {
+            Some(Value::Table(t)) => t,
+            Some(_) => return Err(config_error(name, "input must be a table")),
+            None => toml::Table::new(),
+        };
+        let input_files = match input.get("files") {
+            Some(v) => string_or_vec(name, "input.files", v)?,
+            None => vec!["**".to_string()],
+        };
+        input.insert(
+            "files".to_string(),
+            Value::Array(input_files.iter().cloned().map(Value::String).collect()),
+        );
+        let input_root = match input.get("root") {
+            Some(Value::String(s)) => s.clone(),
+            Some(_) => return Err(config_error(name, "input.root must be a string")),
+            None => ".".to_string(),
+        };
+        input.insert("root".to_string(), Value::String(input_root.clone()));
+        table.insert("input".to_string(), Value::Table(input));
+
+        // output
+        let mut output = match table.remove("output") {
+            Some(Value::Table(t)) => t,
+            Some(_) => return Err(config_error(name, "output must be a table")),
+            None => toml::Table::new(),
+        };
+        let output_root = match output.get("root") {
+            Some(Value::String(s)) => s.clone(),
+            Some(_) => return Err(config_error(name, "output.root must be a string")),
+            None => input_root.clone(),
+        };
+        output.insert("root".to_string(), Value::String(output_root.clone()));
+        let merge_str = match output.get("merge") {
+            Some(Value::String(s)) => s.clone(),
+            Some(_) => return Err(config_error(name, "output.merge must be a string")),
+            None => "overlay".to_string(),
+        };
+        output.insert("merge".to_string(), Value::String(merge_str.clone()));
+        table.insert("output".to_string(), Value::Table(output));
+
+        let output_merge = match merge_str.as_str() {
+            "overlay" => MergeMode::Overlay,
+            "underlay" => MergeMode::Underlay,
+            "replace" => MergeMode::Replace,
+            other => {
+                return Err(config_error(
+                    name,
+                    format!("unknown output.merge mode: {other}"),
+                ))
+            }
+        };
+
+        if let Some(hash) = data_tree {
+            table.insert("data".to_string(), Value::String(hash.to_string()));
+        }
+
+        let timeout_secs = match table.get("timeout") {
+            Some(Value::Integer(t)) if *t > 0 => *t as u64,
+            _ => DEFAULT_JOB_TIMEOUT_SECS,
+        };
+
+        let container = match table.get("container") {
+            Some(Value::String(s)) => Some(s.clone()),
+            Some(_) => return Err(config_error(name, "container must be a string")),
+            None => None,
+        };
+
+        Ok(LensConfig {
+            name: name.to_string(),
+            table,
+            input_root,
+            input_files,
+            output_root,
+            output_merge,
+            before,
+            after,
+            timeout_secs,
+            container,
+        })
+    }
+}
+
+/// Mirror of the JS `deepSortKeys` quirk set that matters beyond key order
+/// (order comes free from `toml::Table`'s BTreeMap): `Date` values degrade
+/// to empty objects in the oracle, so datetimes become empty tables here.
+fn deep_js_normalize(value: &mut Value) {
+    match value {
+        Value::Datetime(_) => *value = Value::Table(toml::Table::new()),
+        Value::Array(arr) => arr.iter_mut().for_each(deep_js_normalize),
+        Value::Table(t) => {
+            for (_, v) in t.iter_mut() {
+                deep_js_normalize(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// A written, content-addressed lens spec.
+#[derive(Debug, Clone)]
+pub struct SpecObject {
+    /// Blob hash of the serialized spec TOML — the key for all caching.
+    pub hash: ObjectId,
+    /// The serialized spec TOML bytes.
+    pub toml: String,
+    /// `refs/holo/lens/<xx>/<rest>` — where the cached result tree lives.
+    pub cache_ref: String,
+}
+
+/// Assemble the spec data table for a container lens
+/// (`Lens.buildSpecForContainer`): the normalized config with the resolved
+/// container identity, the input tree hash, `_resolved = "local"` bookkeeping
+/// when the identity was locally resolved (#417), and the non-output-bearing
+/// keys (`output`, `before`, `after`, `timeout`) stripped.
+pub fn build_spec_table(
+    config: &LensConfig,
+    container_identity: &str,
+    resolved_local: bool,
+    input_tree: ObjectId,
+) -> toml::Table {
+    let mut data = config.table.clone();
+    data.remove("output");
+    data.remove("before");
+    data.remove("after");
+    data.remove("timeout");
+    data.insert(
+        "container".to_string(),
+        Value::String(container_identity.to_string()),
+    );
+    if resolved_local {
+        data.insert(
+            "_resolved".to_string(),
+            Value::String("local".to_string()),
+        );
+    }
+    data.insert(
+        "input".to_string(),
+        Value::String(input_tree.to_string()),
+    );
+    data
+}
+
+/// Serialize, hash, and store a lens spec (`SpecObject.write`): the blob is
+/// written to the ODB and anchored at `refs/holo/spec/<hash>` so it can be
+/// fetched and survives GC.
+pub fn write_spec(repo: &gix::Repository, data: toml::Table) -> Result<SpecObject> {
+    let mut lens_value = Value::Table(data);
+    deep_js_normalize(&mut lens_value);
+
+    let mut holospec = toml::Table::new();
+    holospec.insert("lens".to_string(), lens_value);
+    let mut doc = toml::Table::new();
+    doc.insert("holospec".to_string(), Value::Table(holospec));
+
+    let toml_text = iarna::stringify(&doc)?;
+
+    let blob = repo
+        .write_blob(toml_text.as_bytes())
+        .map_err(|e| holo_tree::Error::Git(e.to_string()))?
+        .detach();
+
+    let hash = blob.to_string();
+    holo_tree::repo::update_ref(repo, &format!("refs/holo/spec/{hash}"), blob, None)?;
+
+    Ok(SpecObject {
+        hash: blob,
+        toml: toml_text,
+        cache_ref: cache_ref(&hash),
+    })
+}
+
+/// `SpecObject.buildRef('lens', hash)`: the spec-keyed result cache ref.
+pub fn cache_ref(spec_hash: &str) -> String {
+    format!("refs/holo/lens/{}/{}", &spec_hash[..2], &spec_hash[2..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(toml_text: &str) -> toml::Table {
+        let doc: toml::Table = toml_text.parse().unwrap();
+        match doc.get("hololens") {
+            Some(Value::Table(t)) => t.clone(),
+            _ => panic!("no hololens table"),
+        }
+    }
+
+    #[test]
+    fn normalize_defaults() {
+        let cfg = LensConfig::normalize(
+            "mkdocs",
+            parse("[hololens]\ncontainer = \"ghcr.io/hologit/lenses/mkdocs:latest\"\n"),
+            None,
+        )
+        .unwrap();
+        assert_eq!(cfg.input_files, ["**"]);
+        assert_eq!(cfg.input_root, ".");
+        assert_eq!(cfg.output_root, ".");
+        assert_eq!(cfg.output_merge, MergeMode::Overlay);
+        assert_eq!(cfg.timeout_secs, DEFAULT_JOB_TIMEOUT_SECS);
+        assert_eq!(
+            cfg.container.as_deref(),
+            Some("ghcr.io/hologit/lenses/mkdocs:latest")
+        );
+    }
+
+    #[test]
+    fn normalize_string_files_and_merge() {
+        let cfg = LensConfig::normalize(
+            "x",
+            parse(
+                "[hololens]\ncontainer = \"c\"\n[hololens.input]\nfiles = \"*.js\"\nroot = \"sub\"\n[hololens.output]\nmerge = \"replace\"\n",
+            ),
+            None,
+        )
+        .unwrap();
+        assert_eq!(cfg.input_files, ["*.js"]);
+        assert_eq!(cfg.input_root, "sub");
+        // output.root defaults to input.root
+        assert_eq!(cfg.output_root, "sub");
+        assert_eq!(cfg.output_merge, MergeMode::Replace);
+    }
+
+    #[test]
+    fn spec_table_strips_and_injects() {
+        let cfg = LensConfig::normalize(
+            "x",
+            parse(
+                "[hololens]\ncontainer = \"ghcr.io/x:latest\"\nbefore = \"*\"\ntimeout = 30\n[hololens.output]\nmerge = \"replace\"\n",
+            ),
+            None,
+        )
+        .unwrap();
+        let input_tree = ObjectId::empty_tree(gix::hash::Kind::Sha1);
+        let data = build_spec_table(&cfg, "ghcr.io/x@sha256:abc", false, input_tree);
+        assert!(!data.contains_key("output"));
+        assert!(!data.contains_key("before"));
+        assert!(!data.contains_key("timeout"));
+        assert!(!data.contains_key("_resolved"));
+        assert_eq!(
+            data.get("container").and_then(Value::as_str),
+            Some("ghcr.io/x@sha256:abc")
+        );
+        assert_eq!(
+            data.get("input").and_then(Value::as_str),
+            Some(input_tree.to_string().as_str())
+        );
+
+        let local = build_spec_table(&cfg, "sha256:deadbeef", true, input_tree);
+        assert_eq!(
+            local.get("_resolved").and_then(Value::as_str),
+            Some("local")
+        );
+    }
+
+    #[test]
+    fn cache_ref_layout() {
+        assert_eq!(
+            cache_ref("0dc5566ea56b34afe9de7da93d6ae3de42876d8d"),
+            "refs/holo/lens/0d/c5566ea56b34afe9de7da93d6ae3de42876d8d"
+        );
+    }
+
+    #[test]
+    fn package_implies_default_command() {
+        let cfg =
+            LensConfig::normalize("x", parse("[hololens]\npackage = \"holo/lens-x\"\n"), None)
+                .unwrap();
+        assert_eq!(
+            cfg.table.get("command").and_then(Value::as_str),
+            Some("lens-tree {{ input }}")
+        );
+    }
+}

--- a/holo-projector/src/lens/toposort.rs
+++ b/holo-projector/src/lens/toposort.rs
@@ -44,77 +44,69 @@ pub fn toposort(nodes: &[String], edges: &[(String, String)]) -> Result<Vec<Stri
     }
 
     let n = nodes.len();
-    let mut sorted: Vec<Option<String>> = vec![None; n];
-    let mut cursor = n;
-    let mut visited = vec![false; n];
+    let mut walk = Walk {
+        nodes,
+        node_index: &node_index,
+        outgoing: &outgoing,
+        visited: vec![false; n],
+        sorted: vec![None; n],
+        cursor: n,
+        predecessors: Vec::new(),
+    };
 
-    fn visit<'a>(
-        node: &'a str,
-        index: usize,
-        predecessors: &mut Vec<&'a str>,
-        nodes: &'a [String],
-        node_index: &BTreeMap<&'a str, usize>,
-        outgoing: &BTreeMap<&'a str, Vec<&'a str>>,
-        visited: &mut [bool],
-        sorted: &mut [Option<String>],
-        cursor: &mut usize,
-    ) -> Result<()> {
-        if predecessors.contains(&node) {
+    for i in (0..n).rev() {
+        if !walk.visited[i] {
+            walk.visit(nodes[i].as_str(), i)?;
+        }
+    }
+
+    Ok(walk
+        .sorted
+        .into_iter()
+        .map(|s| s.expect("every slot is filled by a visit"))
+        .collect())
+}
+
+struct Walk<'a> {
+    nodes: &'a [String],
+    node_index: &'a BTreeMap<&'a str, usize>,
+    outgoing: &'a BTreeMap<&'a str, Vec<&'a str>>,
+    visited: Vec<bool>,
+    sorted: Vec<Option<String>>,
+    cursor: usize,
+    predecessors: Vec<&'a str>,
+}
+
+impl<'a> Walk<'a> {
+    fn visit(&mut self, node: &'a str, index: usize) -> Result<()> {
+        if self.predecessors.contains(&node) {
             return Err(Error::CircularDependency {
                 kind: "lens".to_string(),
             });
         }
-        if visited[index] {
+        if self.visited[index] {
             return Ok(());
         }
-        visited[index] = true;
+        self.visited[index] = true;
 
         // Upstream walks the outgoing set from last to first.
-        let targets = outgoing.get(node).cloned().unwrap_or_default();
+        let targets = self.outgoing.get(node).cloned().unwrap_or_default();
         if !targets.is_empty() {
-            predecessors.push(node);
+            self.predecessors.push(node);
             for &child in targets.iter().rev() {
-                let child_index = *node_index
+                let child_index = *self
+                    .node_index
                     .get(child)
                     .ok_or_else(|| Error::Other(format!("unknown lens in ordering: {child}")))?;
-                visit(
-                    child,
-                    child_index,
-                    predecessors,
-                    nodes,
-                    node_index,
-                    outgoing,
-                    visited,
-                    sorted,
-                    cursor,
-                )?;
+                self.visit(child, child_index)?;
             }
-            predecessors.pop();
+            self.predecessors.pop();
         }
 
-        *cursor -= 1;
-        sorted[*cursor] = Some(nodes[index].clone());
+        self.cursor -= 1;
+        self.sorted[self.cursor] = Some(self.nodes[index].clone());
         Ok(())
     }
-
-    let mut predecessors: Vec<&str> = Vec::new();
-    for i in (0..n).rev() {
-        if !visited[i] {
-            visit(
-                nodes[i].as_str(),
-                i,
-                &mut predecessors,
-                nodes,
-                &node_index,
-                &outgoing,
-                &mut visited,
-                &mut sorted,
-                &mut cursor,
-            )?;
-        }
-    }
-
-    Ok(sorted.into_iter().map(|s| s.expect("filled")).collect())
 }
 
 #[cfg(test)]

--- a/holo-projector/src/lens/toposort.rs
+++ b/holo-projector/src/lens/toposort.rs
@@ -1,0 +1,174 @@
+//! Port of the npm `toposort` package's `toposort.array(nodes, edges)`,
+//! which the JS engine uses to order lenses by their `before`/`after`
+//! constraints (`Workspace.getLenses` / `Branch.getLenses`).
+//!
+//! Lens execution order can change the final output tree (later lens output
+//! merges over earlier), so the Rust engine must reproduce the oracle's
+//! ordering exactly — including for unconstrained nodes. The npm package's
+//! algorithm: iterate nodes from **last to first**, depth-first over each
+//! node's outgoing edges in **reverse insertion order**, filling the result
+//! array from the back. Unconstrained nodes therefore keep their input
+//! order; constrained subgraphs get a DFS post-order that this port copies
+//! rather than approximates (a stable Kahn's algorithm agrees on simple
+//! graphs but can diverge on dense ones).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::error::{Error, Result};
+
+/// Topologically sort `nodes` (by index) so that for every edge `(a, b)`,
+/// `a` appears before `b`. Node values are compared as strings; edges must
+/// reference values present in `nodes`.
+pub fn toposort(nodes: &[String], edges: &[(String, String)]) -> Result<Vec<String>> {
+    // node value → index (last occurrence wins, as upstream)
+    let mut node_index: BTreeMap<&str, usize> = BTreeMap::new();
+    for (i, node) in nodes.iter().enumerate() {
+        node_index.insert(node.as_str(), i);
+    }
+
+    for (from, to) in edges {
+        if !node_index.contains_key(from.as_str()) || !node_index.contains_key(to.as_str()) {
+            return Err(Error::Other(format!(
+                "lens ordering references unknown lens: {from} -> {to}"
+            )));
+        }
+    }
+
+    // node value → outgoing targets, deduped, in edge insertion order
+    let mut outgoing: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    let mut seen_edges: BTreeSet<(&str, &str)> = BTreeSet::new();
+    for (from, to) in edges {
+        if seen_edges.insert((from.as_str(), to.as_str())) {
+            outgoing.entry(from.as_str()).or_default().push(to.as_str());
+        }
+    }
+
+    let n = nodes.len();
+    let mut sorted: Vec<Option<String>> = vec![None; n];
+    let mut cursor = n;
+    let mut visited = vec![false; n];
+
+    fn visit<'a>(
+        node: &'a str,
+        index: usize,
+        predecessors: &mut Vec<&'a str>,
+        nodes: &'a [String],
+        node_index: &BTreeMap<&'a str, usize>,
+        outgoing: &BTreeMap<&'a str, Vec<&'a str>>,
+        visited: &mut [bool],
+        sorted: &mut [Option<String>],
+        cursor: &mut usize,
+    ) -> Result<()> {
+        if predecessors.contains(&node) {
+            return Err(Error::CircularDependency {
+                kind: "lens".to_string(),
+            });
+        }
+        if visited[index] {
+            return Ok(());
+        }
+        visited[index] = true;
+
+        // Upstream walks the outgoing set from last to first.
+        let targets = outgoing.get(node).cloned().unwrap_or_default();
+        if !targets.is_empty() {
+            predecessors.push(node);
+            for &child in targets.iter().rev() {
+                let child_index = *node_index
+                    .get(child)
+                    .ok_or_else(|| Error::Other(format!("unknown lens in ordering: {child}")))?;
+                visit(
+                    child,
+                    child_index,
+                    predecessors,
+                    nodes,
+                    node_index,
+                    outgoing,
+                    visited,
+                    sorted,
+                    cursor,
+                )?;
+            }
+            predecessors.pop();
+        }
+
+        *cursor -= 1;
+        sorted[*cursor] = Some(nodes[index].clone());
+        Ok(())
+    }
+
+    let mut predecessors: Vec<&str> = Vec::new();
+    for i in (0..n).rev() {
+        if !visited[i] {
+            visit(
+                nodes[i].as_str(),
+                i,
+                &mut predecessors,
+                nodes,
+                &node_index,
+                &outgoing,
+                &mut visited,
+                &mut sorted,
+                &mut cursor,
+            )?;
+        }
+    }
+
+    Ok(sorted.into_iter().map(|s| s.expect("filled")).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn e(v: &[(&str, &str)]) -> Vec<(String, String)> {
+        v.iter()
+            .map(|(a, b)| (a.to_string(), b.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn unconstrained_preserves_order() {
+        assert_eq!(
+            toposort(&s(&["a", "b", "c"]), &[]).unwrap(),
+            s(&["a", "b", "c"])
+        );
+    }
+
+    #[test]
+    fn simple_edge_respected() {
+        // matches npm toposort.array(['a','b','c'], [['b','a']]) → ['b','a','c']
+        assert_eq!(
+            toposort(&s(&["a", "b", "c"]), &e(&[("b", "a")])).unwrap(),
+            s(&["b", "a", "c"])
+        );
+        assert_eq!(
+            toposort(&s(&["a", "b", "c"]), &e(&[("a", "b")])).unwrap(),
+            s(&["a", "b", "c"])
+        );
+    }
+
+    #[test]
+    fn chain_via_wildcard_style_edges() {
+        // c after everything: edges (a,c), (b,c)
+        assert_eq!(
+            toposort(&s(&["c", "a", "b"]), &e(&[("a", "c"), ("b", "c")])).unwrap(),
+            s(&["a", "b", "c"])
+        );
+    }
+
+    #[test]
+    fn cycle_detected() {
+        let err = toposort(&s(&["a", "b"]), &e(&[("a", "b"), ("b", "a")])).unwrap_err();
+        assert_eq!(err.code(), "CIRCULAR_DEPENDENCY");
+    }
+
+    #[test]
+    fn unknown_edge_node_errors() {
+        assert!(toposort(&s(&["a"]), &e(&[("a", "zz")])).is_err());
+    }
+}

--- a/holo-projector/src/lib.rs
+++ b/holo-projector/src/lib.rs
@@ -9,12 +9,15 @@
 //! - [`project_branch`] — TOML-driven: reads `.holo/` config from a git tree
 //! - [`project_plan`] — Programmatic: accepts structured source/mapping definitions
 //! - [`commit_projection`] — Edge capability: commit a composed tree and advance a ref
+//! - [`lens::project_branch_lensed`] — Edge capability: the full pipeline
+//!   (composite → lens → strip) with native container-lens execution
 
 pub mod branch;
 pub mod commit;
 pub mod config;
 pub mod error;
 pub mod fetch;
+pub mod lens;
 pub mod projection;
 pub mod source;
 

--- a/holo-projector/src/lib.rs
+++ b/holo-projector/src/lib.rs
@@ -24,6 +24,20 @@ pub mod source;
 use error::Result;
 use gix::ObjectId;
 
+/// Recursive-projection callback threaded through composition:
+/// `(ctx, workspace_tree, branch_name, default_lens)` → output tree hash.
+/// `default_lens` is the source's `project.lens`, feeding the sub-branch's
+/// effective lens flag (`specs/behaviors/composition.md` § Sub-projection
+/// lensing); the composition-only callback refuses lensed sub-projections,
+/// the lensing engine's callback lenses them natively.
+pub type ProjectFn<'e> = dyn FnMut(
+        &holo_tree::Context,
+        ObjectId,
+        &str,
+        Option<bool>,
+    ) -> Result<ObjectId>
+    + 'e;
+
 // Re-export holo-tree for consumers that need the tree primitives
 pub use holo_tree;
 

--- a/holo-projector/src/projection.rs
+++ b/holo-projector/src/projection.rs
@@ -137,7 +137,7 @@ pub(crate) fn compose_branch_tree(
     ctx: &Context,
     root_tree_id: ObjectId,
     branch_name: &str,
-    project_fn: &mut dyn FnMut(&Context, ObjectId, &str, Option<bool>) -> Result<ObjectId>,
+    project_fn: &mut crate::ProjectFn<'_>,
     fetcher: Option<&dyn SourceFetcher>,
 ) -> Result<MutableTree> {
     let mut ws_tree = MutableTree::new(root_tree_id);

--- a/holo-projector/src/projection.rs
+++ b/holo-projector/src/projection.rs
@@ -94,6 +94,52 @@ fn compose_branch(
     final_strip: bool,
     fetcher: Option<&dyn SourceFetcher>,
 ) -> Result<ObjectId> {
+    let mut output = compose_branch_tree(
+        ctx,
+        root_tree_id,
+        branch_name,
+        &mut |c, tree_id, bn, default_lens| {
+            composition_only_project(c, tree_id, bn, default_lens, fetcher)
+        },
+        fetcher,
+    )?;
+
+    if final_strip {
+        strip_bare_holo(ctx, &mut output)?;
+    }
+
+    Ok(output.write(ctx)?)
+}
+
+/// The composition-only recursive-projection callback: project the
+/// sub-branch through the pure pipeline (inheriting the fetcher), then
+/// refuse when its lensing would have altered output
+/// (`specs/behaviors/composition.md` § Sub-projection lensing). A lensing
+/// engine (`lens::project_branch_lensed`) supplies a callback that lenses
+/// natively instead of refusing.
+fn composition_only_project(
+    ctx: &Context,
+    tree_id: ObjectId,
+    branch_name: &str,
+    default_lens: Option<bool>,
+    fetcher: Option<&dyn SourceFetcher>,
+) -> Result<ObjectId> {
+    let projected = compose_branch(ctx, tree_id, branch_name, true, fetcher)?;
+    crate::source::refuse_lensed_subprojection(ctx, tree_id, branch_name, default_lens, projected)?;
+    Ok(projected)
+}
+
+/// Composite a holobranch (extends chain + mappings) and strip
+/// `.holo/{branches,sources}` — the shared pre-lens portion of the pipeline.
+/// The caller decides what happens next: the pure pipeline applies the final
+/// `.holo` strip and writes; the lensing pipeline runs the lens phase first.
+pub(crate) fn compose_branch_tree(
+    ctx: &Context,
+    root_tree_id: ObjectId,
+    branch_name: &str,
+    project_fn: &mut dyn FnMut(&Context, ObjectId, &str, Option<bool>) -> Result<ObjectId>,
+    fetcher: Option<&dyn SourceFetcher>,
+) -> Result<MutableTree> {
     let mut ws_tree = MutableTree::new(root_tree_id);
 
     let ws_name = read_workspace_name(ctx, &mut ws_tree)?;
@@ -110,17 +156,14 @@ fn compose_branch(
             name,
             &ws_name,
             &mut output,
-            &mut |c, tree_id, bn| compose_branch(c, tree_id, bn, true, fetcher),
+            project_fn,
             fetcher,
         )?;
     }
 
     strip_branches_sources(ctx, &mut output)?;
-    if final_strip {
-        strip_bare_holo(ctx, &mut output)?;
-    }
 
-    Ok(output.write(ctx)?)
+    Ok(output)
 }
 
 /// Compose git trees from structured source/mapping definitions.
@@ -200,7 +243,9 @@ pub fn project_plan_in(
         ws_name,
         &mut ws_tree,
         &mut output,
-        &mut |c, tree_id, bn| project_branch_in(c, tree_id, bn),
+        &mut |c, tree_id, bn, default_lens| {
+            composition_only_project(c, tree_id, bn, default_lens, None)
+        },
         None,
     )?;
 
@@ -269,7 +314,7 @@ fn strip_branches_sources(ctx: &Context, output: &mut MutableTree) -> Result<()>
 
 /// Strip `.holo` entirely if only `config.toml` remains (the final metadata
 /// strip, applied after any lens phase would have run).
-fn strip_bare_holo(ctx: &Context, output: &mut MutableTree) -> Result<()> {
+pub(crate) fn strip_bare_holo(ctx: &Context, output: &mut MutableTree) -> Result<()> {
     if let Some(holo) = output.get_subtree(ctx, ".holo")? {
         holo.ensure_children(ctx)?;
         let empty = holo

--- a/holo-projector/src/source.rs
+++ b/holo-projector/src/source.rs
@@ -31,7 +31,7 @@ pub fn resolve(
     workspace_tree: &mut MutableTree,
     source_name: &str,
     workspace_name: &str,
-    project_fn: &mut dyn FnMut(&Context, ObjectId, &str) -> Result<ObjectId>,
+    project_fn: &mut dyn FnMut(&Context, ObjectId, &str, Option<bool>) -> Result<ObjectId>,
     fetcher: Option<&dyn SourceFetcher>,
 ) -> Result<ObjectId> {
     let (base_name, mapping_holobranch) = match source_name.split_once("=>") {
@@ -43,9 +43,7 @@ pub fn resolve(
     if base_name == workspace_name {
         let mut head = workspace_tree.hash;
         if let Some(hb) = mapping_holobranch {
-            let projected = project_fn(ctx, head, hb)?;
-            refuse_lensed_subprojection(ctx, head, hb, None, projected)?;
-            head = projected;
+            head = project_fn(ctx, head, hb, None)?;
         }
         return Ok(head);
     }
@@ -59,18 +57,15 @@ pub fn resolve(
     // Peel to tree
     let mut head = commit_to_tree(ctx.repo, commit)?;
 
-    // Apply source.project.holobranch
+    // Apply source.project.holobranch (the source's `project.lens` rides
+    // along as the default for the sub-branch's effective lens flag)
     if let Some(ref project) = source_config.project {
-        let projected = project_fn(ctx, head, &project.holobranch)?;
-        refuse_lensed_subprojection(ctx, head, &project.holobranch, project.lens, projected)?;
-        head = projected;
+        head = project_fn(ctx, head, &project.holobranch, project.lens)?;
     }
 
     // Apply mapping holobranch (=>syntax)
     if let Some(hb) = mapping_holobranch {
-        let projected = project_fn(ctx, head, hb)?;
-        refuse_lensed_subprojection(ctx, head, hb, None, projected)?;
-        head = projected;
+        head = project_fn(ctx, head, hb, None)?;
     }
 
     Ok(head)
@@ -83,15 +78,19 @@ pub fn resolve(
 ///
 /// The legacy engine lenses a sub-projection when its **effective lens
 /// flag** is true: the sub-branch config's `lens` when boolean, else the
-/// source's `project.lens` when boolean (`default_lens`), else `true`. This
-/// engine is composition-only, so when the flag is true *and* any lens
-/// actually exists — external configs under
+/// source's `project.lens` when boolean (`default_lens`), else `true`. The
+/// composition-only entry points must therefore refuse when the flag is true
+/// *and* any lens actually exists — external configs under
 /// `.holo/branches/<branch>.lenses/*.toml` in the sub-workspace, or internal
-/// configs at `.holo/lenses/*.toml` in the composited output — silently
-/// skipping the lens phase would produce a wrong hash. Refusing with a
-/// matchable error (`LENSED_SUBPROJECTION`) lets a host fall back to an
-/// engine that lenses.
-fn refuse_lensed_subprojection(
+/// configs at `.holo/lenses/*.toml` in the composited output — because
+/// silently skipping the lens phase would produce a wrong hash. Refusing
+/// with a matchable error (`LENSED_SUBPROJECTION`) lets a host fall back to
+/// an engine that lenses.
+///
+/// Called from the composition-only projection callback
+/// (`projection::composition_only_project`); the lensing pipeline
+/// (`lens::project_branch_lensed`) lenses sub-projections natively instead.
+pub(crate) fn refuse_lensed_subprojection(
     ctx: &Context,
     workspace_tree_id: ObjectId,
     branch_name: &str,

--- a/holo-projector/src/source.rs
+++ b/holo-projector/src/source.rs
@@ -31,7 +31,7 @@ pub fn resolve(
     workspace_tree: &mut MutableTree,
     source_name: &str,
     workspace_name: &str,
-    project_fn: &mut dyn FnMut(&Context, ObjectId, &str, Option<bool>) -> Result<ObjectId>,
+    project_fn: &mut crate::ProjectFn<'_>,
     fetcher: Option<&dyn SourceFetcher>,
 ) -> Result<ObjectId> {
     let (base_name, mapping_holobranch) = match source_name.split_once("=>") {

--- a/holo-projector/tests/lens.rs
+++ b/holo-projector/tests/lens.rs
@@ -1,0 +1,620 @@
+//! Lens execution integration tests (`specs/behaviors/lensing.md`).
+//!
+//! Container execution is exercised through a mock `ContainerRuntime` whose
+//! `run_one_shot` implements the v2 one-shot job protocol in-process (an SDK
+//! stand-in): it ingests the input bundle into a scratch job repo, applies a
+//! deterministic transform, and returns a result bundle — so the full engine
+//! path (wrapper commit, bundle exchange, parent verification, error
+//! commits, cache refs) runs for real without a container engine.
+
+mod helpers;
+
+use std::time::Duration;
+
+use gix::ObjectId;
+use helpers::Sandbox;
+use holo_projector::holo_tree::{Context, MutableTree, TreeCache};
+use holo_projector::lens::{
+    self, runtime::LocalImage, runtime::OneShotOutcome, ContainerRuntime, LensEngine,
+    RegistryClient,
+};
+
+// ── Mock SDK runtime ───────────────────────────────────────────────────────
+
+#[derive(Clone, Copy, PartialEq)]
+enum Behavior {
+    /// Implement the protocol: output tree = input tree + `lens-output.txt`.
+    Success,
+    /// Emit a structured error bundle (exit 3, phase transform).
+    StructuredError,
+    /// Exit 0 with garbage on stdout.
+    Garbage,
+    /// Exit 1 with empty stdout.
+    EmptyStdout,
+    /// Report deadline expiry.
+    Timeout,
+    /// Panic if executed (used to prove cache hits skip execution).
+    MustNotRun,
+}
+
+struct MockRuntime {
+    behavior: Behavior,
+    /// Result of local image inspection.
+    image: Option<LocalImage>,
+    /// The v2 protocol label value.
+    label: Option<String>,
+}
+
+impl MockRuntime {
+    fn local_only(behavior: Behavior) -> Self {
+        MockRuntime {
+            behavior,
+            image: Some(LocalImage {
+                id: format!("sha256:{}", "ab".repeat(32)),
+                repo_digests: vec![],
+            }),
+            label: Some("2".to_string()),
+        }
+    }
+}
+
+struct NoRegistry;
+
+impl RegistryClient for NoRegistry {
+    fn manifest_digest(&self, reference: &str) -> holo_projector::error::Result<String> {
+        panic!("registry must not be consulted for {reference}");
+    }
+}
+
+impl ContainerRuntime for MockRuntime {
+    fn inspect_local(
+        &self,
+        _reference: &str,
+    ) -> holo_projector::error::Result<Option<LocalImage>> {
+        Ok(self.image.clone())
+    }
+
+    fn pull(&self, reference: &str) -> holo_projector::error::Result<()> {
+        panic!("pull must not be attempted for {reference}");
+    }
+
+    fn protocol_label(
+        &self,
+        _reference: &str,
+    ) -> holo_projector::error::Result<Option<String>> {
+        Ok(self.label.clone())
+    }
+
+    fn run_one_shot(
+        &self,
+        _image: &str,
+        spec_hash: &str,
+        input_bundle: &[u8],
+        _deadline: Duration,
+    ) -> holo_projector::error::Result<OneShotOutcome> {
+        match self.behavior {
+            Behavior::MustNotRun => panic!("lens executed despite a cached result"),
+            Behavior::Timeout => Ok(OneShotOutcome {
+                exit_code: None,
+                stdout: vec![],
+                stderr_tail: String::new(),
+                timed_out: true,
+            }),
+            Behavior::EmptyStdout => Ok(OneShotOutcome {
+                exit_code: Some(1),
+                stdout: vec![],
+                stderr_tail: "tool never started".into(),
+                timed_out: false,
+            }),
+            Behavior::Garbage => Ok(OneShotOutcome {
+                exit_code: Some(0),
+                stdout: b"this is not a git bundle".to_vec(),
+                stderr_tail: String::new(),
+                timed_out: false,
+            }),
+            Behavior::Success => sdk_one_shot(spec_hash, input_bundle, false),
+            Behavior::StructuredError => sdk_one_shot(spec_hash, input_bundle, true),
+        }
+    }
+}
+
+/// The in-process SDK: ingest the input bundle, transform (or fail), emit a
+/// result bundle.
+fn sdk_one_shot(
+    spec_hash: &str,
+    input_bundle: &[u8],
+    fail: bool,
+) -> holo_projector::error::Result<OneShotOutcome> {
+    let scratch = tempfile::tempdir().expect("sdk scratch");
+    let job_git = scratch.path().join("job.git");
+    let run_git = |args: &[&str]| {
+        let out = std::process::Command::new("git")
+            .arg("--git-dir")
+            .arg(&job_git)
+            .args(args)
+            .output()
+            .expect("spawn git");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    };
+
+    let repo = gix::init_bare(&job_git).expect("init job repo");
+
+    let bundle_path = scratch.path().join("input.bundle");
+    std::fs::write(&bundle_path, input_bundle).unwrap();
+    run_git(&[
+        "fetch",
+        bundle_path.to_str().unwrap(),
+        "+refs/jobs/*:refs/jobs/*",
+    ]);
+
+    let input_ref = format!("refs/jobs/{spec_hash}/input");
+    let input_commit = holo_projector::holo_tree::repo::resolve_ref(&repo, &input_ref)
+        .unwrap()
+        .expect("input ref delivered");
+
+    let cache = TreeCache::new();
+    let ctx = Context::new(&repo, &cache);
+
+    let result_ref;
+    if fail {
+        // Structured error commit: parentless, tree carrying the contract
+        // entries (exit-code is the inner tool's real status).
+        let mut tree = MutableTree::empty();
+        tree.write_child(&ctx, "exit-code", "3").unwrap();
+        tree.write_child(&ctx, "phase", "transform").unwrap();
+        tree.write_child(&ctx, "log", "boom: tool exploded\n").unwrap();
+        tree.write_child(&ctx, "command", "mock-tool build").unwrap();
+        let tree_id = tree.write(&ctx).unwrap();
+        let commit = holo_projector::holo_tree::repo::commit_tree(
+            &repo,
+            tree_id,
+            &[],
+            &format!("lens job {spec_hash} error"),
+            None,
+            None,
+        )
+        .unwrap();
+        result_ref = format!("refs/jobs/{spec_hash}/error");
+        holo_projector::holo_tree::repo::update_ref(&repo, &result_ref, commit, None).unwrap();
+    } else {
+        // Transform: output tree = input/ subtree + lens-output.txt naming
+        // the spec (proves the wrapper delivered `.holospec/lens.toml`).
+        let commit_obj = repo.find_object(input_commit).unwrap();
+        let commit = commit_obj.try_into_commit().unwrap();
+        let wrapper_tree = commit.tree_id().unwrap().detach();
+
+        let mut wrapper = MutableTree::new(wrapper_tree);
+        let spec_toml = wrapper
+            .read_blob(&ctx, ".holospec/lens.toml")
+            .unwrap()
+            .expect("wrapper carries the spec file");
+        let spec_text = String::from_utf8(spec_toml).unwrap();
+        assert!(spec_text.starts_with("[holospec.lens]\n"));
+
+        let input_subtree = wrapper
+            .get_subtree(&ctx, "input")
+            .unwrap()
+            .expect("wrapper carries input/")
+            .write(&ctx)
+            .unwrap();
+
+        let mut output = MutableTree::new(input_subtree);
+        output
+            .write_child(&ctx, "lens-output.txt", &format!("lensed {spec_hash}\n"))
+            .unwrap();
+        let output_tree = output.write(&ctx).unwrap();
+        let commit = holo_projector::holo_tree::repo::commit_tree(
+            &repo,
+            output_tree,
+            &[input_commit],
+            &format!("lens job {spec_hash} output"),
+            None,
+            None,
+        )
+        .unwrap();
+        result_ref = format!("refs/jobs/{spec_hash}/output");
+        holo_projector::holo_tree::repo::update_ref(&repo, &result_ref, commit, None).unwrap();
+    }
+
+    let result_bundle = scratch.path().join("result.bundle");
+    run_git(&["bundle", "create", result_bundle.to_str().unwrap(), &result_ref]);
+    let stdout = std::fs::read(&result_bundle).unwrap();
+
+    Ok(OneShotOutcome {
+        exit_code: Some(if fail { 3 } else { 0 }),
+        stdout,
+        stderr_tail: String::new(),
+        timed_out: false,
+    })
+}
+
+// ── Workspace fixtures ─────────────────────────────────────────────────────
+
+/// Workspace with an external lens on branch `site`:
+/// mapping `_main` (self-source, root `docs`) + `.holo/branches/site.lenses/mark.toml`.
+fn external_lens_workspace(sandbox: &Sandbox) -> ObjectId {
+    sandbox.write_tree(&[
+        (".holo/config.toml", "[holospace]\nname = \"main\"\n"),
+        (
+            ".holo/branches/site/_main.toml",
+            "[holomapping]\nfiles = \"**\"\nroot = \"docs\"\n",
+        ),
+        (
+            ".holo/branches/site.lenses/mark.toml",
+            "[hololens]\ncontainer = \"test-lens:dev\"\n",
+        ),
+        ("docs/readme.md", "hello\n"),
+    ])
+}
+
+fn tree_child_names(sandbox: &Sandbox, tree_id: ObjectId) -> Vec<String> {
+    let ctx = sandbox.ctx();
+    let mut tree = MutableTree::new(tree_id);
+    tree.ensure_children(&ctx).unwrap();
+    tree.children.iter().flatten().map(|(n, _)| n.clone()).collect()
+}
+
+fn read_blob_text(sandbox: &Sandbox, tree_id: ObjectId, path: &str) -> Option<String> {
+    let ctx = sandbox.ctx();
+    let mut tree = MutableTree::new(tree_id);
+    tree.read_blob(&ctx, path)
+        .unwrap()
+        .map(|data| String::from_utf8(data).unwrap())
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn one_shot_external_lens_end_to_end() {
+    let sandbox = Sandbox::new();
+    let ws = external_lens_workspace(&sandbox);
+
+    let runtime = MockRuntime::local_only(Behavior::Success);
+    let registry = NoRegistry;
+    let engine = LensEngine::new(&runtime, &registry);
+
+    let output = lens::project_branch_lensed(&sandbox.repo, ws, "site", &engine, None).unwrap();
+
+    let names = tree_child_names(&sandbox, output);
+    assert_eq!(names, ["lens-output.txt", "readme.md"]);
+    assert_eq!(
+        read_blob_text(&sandbox, output, "readme.md").as_deref(),
+        Some("hello\n")
+    );
+
+    // The spec-keyed cache ref was written and peels to the lensed tree —
+    // and a second projection is satisfied from it without touching the
+    // runtime.
+    let poisoned = MockRuntime::local_only(Behavior::MustNotRun);
+    let engine = LensEngine::new(&poisoned, &registry);
+    let cached = lens::project_branch_lensed(&sandbox.repo, ws, "site", &engine, None).unwrap();
+    assert_eq!(cached, output);
+
+    // refresh forces re-execution
+    let refreshed = MockRuntime::local_only(Behavior::Success);
+    let mut engine = LensEngine::new(&refreshed, &registry);
+    engine.refresh = true;
+    let rerun = lens::project_branch_lensed(&sandbox.repo, ws, "site", &engine, None).unwrap();
+    assert_eq!(rerun, output);
+
+    // The transient per-job input ref was cleaned up.
+    let refs: Vec<String> = sandbox
+        .repo
+        .references()
+        .unwrap()
+        .all()
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .map(|r| r.name().as_bstr().to_string())
+        .collect();
+    assert!(
+        !refs.iter().any(|r| r.starts_with("refs/jobs/") && r.ends_with("/input")),
+        "transient input ref left behind: {refs:?}"
+    );
+    // The spec object is anchored for fetching/GC.
+    assert!(refs.iter().any(|r| r.starts_with("refs/holo/spec/")));
+}
+
+#[test]
+fn lens_flag_false_skips_lens_phase() {
+    let sandbox = Sandbox::new();
+    let ws = external_lens_workspace(&sandbox);
+
+    let runtime = MockRuntime::local_only(Behavior::MustNotRun);
+    let registry = NoRegistry;
+    let engine = LensEngine::new(&runtime, &registry);
+
+    // explicit override false: composition-only output
+    let output =
+        lens::project_branch_lensed(&sandbox.repo, ws, "site", &engine, Some(false)).unwrap();
+    assert_eq!(tree_child_names(&sandbox, output), ["readme.md"]);
+}
+
+#[test]
+fn structured_lens_failure() {
+    let sandbox = Sandbox::new();
+    let ws = external_lens_workspace(&sandbox);
+
+    let runtime = MockRuntime::local_only(Behavior::StructuredError);
+    let registry = NoRegistry;
+    let engine = LensEngine::new(&runtime, &registry);
+
+    let err = lens::project_branch_lensed(&sandbox.repo, ws, "site", &engine, None).unwrap_err();
+    assert_eq!(err.code(), "LENS_FAILED");
+    match err {
+        holo_projector::error::Error::LensFailed {
+            exit_code,
+            phase,
+            log,
+            command,
+            ..
+        } => {
+            assert_eq!(exit_code, 3);
+            assert_eq!(phase.as_deref(), Some("transform"));
+            assert_eq!(log.as_deref(), Some("boom: tool exploded\n"));
+            assert_eq!(command.as_deref(), Some("mock-tool build"));
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+
+    // A failure writes no cache ref: a retry executes again.
+    let refs: Vec<String> = sandbox
+        .repo
+        .references()
+        .unwrap()
+        .all()
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .map(|r| r.name().as_bstr().to_string())
+        .collect();
+    assert!(!refs.iter().any(|r| r.starts_with("refs/holo/lens/")));
+}
+
+#[test]
+fn transport_errors_are_distinct() {
+    let sandbox = Sandbox::new();
+    let ws = external_lens_workspace(&sandbox);
+    let registry = NoRegistry;
+
+    let garbage = MockRuntime::local_only(Behavior::Garbage);
+    let engine = LensEngine::new(&garbage, &registry);
+    let err = lens::project_branch_lensed(&sandbox.repo, ws, "site", &engine, None).unwrap_err();
+    assert_eq!(err.code(), "LENS_TRANSPORT");
+
+    let empty = MockRuntime::local_only(Behavior::EmptyStdout);
+    let engine = LensEngine::new(&empty, &registry);
+    let err = lens::project_branch_lensed(&sandbox.repo, ws, "site", &engine, None).unwrap_err();
+    assert_eq!(err.code(), "LENS_TRANSPORT");
+}
+
+#[test]
+fn deadline_expiry_is_lens_timeout() {
+    let sandbox = Sandbox::new();
+    let ws = external_lens_workspace(&sandbox);
+
+    let runtime = MockRuntime::local_only(Behavior::Timeout);
+    let registry = NoRegistry;
+    let engine = LensEngine::new(&runtime, &registry);
+
+    let err = lens::project_branch_lensed(&sandbox.repo, ws, "site", &engine, None).unwrap_err();
+    assert_eq!(err.code(), "LENS_TIMEOUT");
+}
+
+#[test]
+fn v1_only_image_is_refused_with_lens_protocol() {
+    let sandbox = Sandbox::new();
+    let ws = external_lens_workspace(&sandbox);
+
+    let mut runtime = MockRuntime::local_only(Behavior::MustNotRun);
+    runtime.label = None; // no sh.holo.lens.protocol label → v1 image
+    let registry = NoRegistry;
+    let engine = LensEngine::new(&runtime, &registry);
+
+    let err = lens::project_branch_lensed(&sandbox.repo, ws, "site", &engine, None).unwrap_err();
+    assert_eq!(err.code(), "LENS_PROTOCOL");
+}
+
+#[test]
+fn internal_lens_applies_and_is_stripped() {
+    let sandbox = Sandbox::new();
+    // The lens config rides inside the mapped tree, so it surfaces in the
+    // composited output at .holo/lenses/ (internal discovery).
+    let ws = sandbox.write_tree(&[
+        (".holo/config.toml", "[holospace]\nname = \"main\"\n"),
+        (
+            ".holo/branches/site/_main.toml",
+            "[holomapping]\nfiles = \"**\"\n",
+        ),
+        (
+            ".holo/lenses/mark.toml",
+            "[hololens]\ncontainer = \"test-lens:dev\"\n",
+        ),
+        ("docs/readme.md", "hello\n"),
+    ]);
+
+    let runtime = MockRuntime::local_only(Behavior::Success);
+    let registry = NoRegistry;
+    let engine = LensEngine::new(&runtime, &registry);
+
+    let output = lens::project_branch_lensed(&sandbox.repo, ws, "site", &engine, None).unwrap();
+
+    // .holo/lenses stripped, then bare .holo stripped (only config.toml
+    // left) — the lens transform output (which included the input's .holo)
+    // wins on merge, so .holo/lenses is re-introduced by overlay and must
+    // still be stripped afterwards.
+    let names = tree_child_names(&sandbox, output);
+    assert_eq!(names, ["docs", "lens-output.txt"]);
+}
+
+#[test]
+fn lensed_subprojection_runs_natively_where_pure_engine_refuses() {
+    let sandbox = Sandbox::new();
+    let ws = sandbox.write_tree(&[
+        (".holo/config.toml", "[holospace]\nname = \"main\"\n"),
+        (
+            ".holo/branches/site/_sub.toml",
+            "[holomapping]\nholosource = \"main=>subsite\"\nfiles = \"**\"\n",
+        ),
+        (
+            ".holo/branches/subsite/_main.toml",
+            "[holomapping]\nfiles = \"**\"\nroot = \"docs\"\n",
+        ),
+        (
+            ".holo/branches/subsite.lenses/mark.toml",
+            "[hololens]\ncontainer = \"test-lens:dev\"\n",
+        ),
+        ("docs/readme.md", "hello\n"),
+    ]);
+
+    // The composition-only engine must refuse (silently skipping the lens
+    // phase would produce a wrong hash).
+    let err = holo_projector::project_branch(&sandbox.repo, ws, "site").unwrap_err();
+    assert_eq!(err.code(), "LENSED_SUBPROJECTION");
+
+    // The lensing engine lenses the sub-projection natively.
+    let runtime = MockRuntime::local_only(Behavior::Success);
+    let registry = NoRegistry;
+    let engine = LensEngine::new(&runtime, &registry);
+    let output = lens::project_branch_lensed(&sandbox.repo, ws, "site", &engine, None).unwrap();
+
+    let names = tree_child_names(&sandbox, output);
+    assert_eq!(names, ["lens-output.txt", "readme.md"]);
+}
+
+#[test]
+fn subprojection_lens_flag_false_disables_lensing() {
+    let sandbox = Sandbox::new();
+    let ws = sandbox.write_tree(&[
+        (".holo/config.toml", "[holospace]\nname = \"main\"\n"),
+        (
+            ".holo/branches/site/_sub.toml",
+            "[holomapping]\nholosource = \"main=>subsite\"\nfiles = \"**\"\n",
+        ),
+        (
+            ".holo/branches/subsite.toml",
+            "[holobranch]\nlens = false\n",
+        ),
+        (
+            ".holo/branches/subsite/_main.toml",
+            "[holomapping]\nfiles = \"**\"\nroot = \"docs\"\n",
+        ),
+        (
+            ".holo/branches/subsite.lenses/mark.toml",
+            "[hololens]\ncontainer = \"test-lens:dev\"\n",
+        ),
+        ("docs/readme.md", "hello\n"),
+    ]);
+
+    // lens = false on the sub-branch: both engines compose without lensing
+    // and agree.
+    let pure = holo_projector::project_branch(&sandbox.repo, ws, "site").unwrap();
+
+    let runtime = MockRuntime::local_only(Behavior::MustNotRun);
+    let registry = NoRegistry;
+    let engine = LensEngine::new(&runtime, &registry);
+    let lensed = lens::project_branch_lensed(&sandbox.repo, ws, "site", &engine, None).unwrap();
+
+    assert_eq!(pure, lensed);
+    assert_eq!(tree_child_names(&sandbox, pure), ["readme.md"]);
+}
+
+// ── Cross-engine spec known-answer tests ───────────────────────────────────
+//
+// Expected bytes/hashes generated with the JS engine's exact pipeline
+// (`deepSortKeys` + `@iarna/toml@2.2.x` stringify + git blob hash), i.e.
+// what `lib/SpecObject.js` writes. Spec-hash identity is what makes
+// JS-written `refs/holo/lens/…` cache refs satisfy Rust cache checks and
+// vice versa.
+
+#[test]
+fn spec_known_answer_registry_resolved() {
+    let sandbox = Sandbox::new();
+
+    let table: toml::Table = r#"
+[hololens]
+container = "ghcr.io/hologit/lenses/mkdocs:latest"
+
+[hololens.mkdocs]
+requirements = [
+    "mkdocs-material",
+    "mkdocs-awesome-pages-plugin",
+    "mdx_truly_sane_lists"
+]
+
+[hololens.output]
+merge = "replace"
+"#
+    .parse()
+    .unwrap();
+    let hololens = match table.get("hololens") {
+        Some(toml::Value::Table(t)) => t.clone(),
+        _ => unreachable!(),
+    };
+
+    let config = lens::LensConfig::normalize("mkdocs", hololens, None).unwrap();
+    let input_tree =
+        ObjectId::from_hex(b"aaaabbbbccccddddeeeeffff0000111122223333").unwrap();
+    let spec_table = lens::spec::build_spec_table(
+        &config,
+        "ghcr.io/hologit/lenses/mkdocs@sha256:6b6b0bdb5beb2b3f852cc1cdfb7d2a67fc036bce7f26ac63efc39e8e2a2a4738",
+        false,
+        input_tree,
+    );
+    let spec = lens::spec::write_spec(&sandbox.repo, spec_table).unwrap();
+
+    assert_eq!(
+        spec.toml,
+        "[holospec.lens]\ncontainer = \"ghcr.io/hologit/lenses/mkdocs@sha256:6b6b0bdb5beb2b3f852cc1cdfb7d2a67fc036bce7f26ac63efc39e8e2a2a4738\"\ninput = \"aaaabbbbccccddddeeeeffff0000111122223333\"\n\n  [holospec.lens.mkdocs]\n  requirements = [\n  \"mkdocs-material\",\n  \"mkdocs-awesome-pages-plugin\",\n  \"mdx_truly_sane_lists\"\n]\n"
+    );
+    assert_eq!(
+        spec.hash.to_string(),
+        "2fcd4f440ce38035d9bd85aafd009cbf8cb5e8c6"
+    );
+    assert_eq!(
+        spec.cache_ref,
+        "refs/holo/lens/2f/cd4f440ce38035d9bd85aafd009cbf8cb5e8c6"
+    );
+}
+
+#[test]
+fn spec_known_answer_local_resolved() {
+    let sandbox = Sandbox::new();
+
+    let table: toml::Table = r#"
+[hololens]
+container = "my-local-lens:dev"
+command = "build --out {{ output }}"
+"#
+    .parse()
+    .unwrap();
+    let hololens = match table.get("hololens") {
+        Some(toml::Value::Table(t)) => t.clone(),
+        _ => unreachable!(),
+    };
+
+    let data_tree =
+        ObjectId::from_hex(b"fedcba9876543210fedcba9876543210fedcba98").unwrap();
+    let config = lens::LensConfig::normalize("local", hololens, Some(data_tree)).unwrap();
+    let input_tree =
+        ObjectId::from_hex(b"0123456789abcdef0123456789abcdef01234567").unwrap();
+    let spec_table = lens::spec::build_spec_table(
+        &config,
+        "sha256:0f8acb0117e7fbdab9ecb551eee1d1c33741ad07d3d6ed268361291bc22d146d",
+        true,
+        input_tree,
+    );
+    let spec = lens::spec::write_spec(&sandbox.repo, spec_table).unwrap();
+
+    assert_eq!(
+        spec.toml,
+        "[holospec.lens]\n_resolved = \"local\"\ncommand = \"build --out {{ output }}\"\ncontainer = \"sha256:0f8acb0117e7fbdab9ecb551eee1d1c33741ad07d3d6ed268361291bc22d146d\"\ndata = \"fedcba9876543210fedcba9876543210fedcba98\"\ninput = \"0123456789abcdef0123456789abcdef01234567\"\n"
+    );
+    assert_eq!(
+        spec.hash.to_string(),
+        "bd5289052f30b267f14e9621c8e1d8062dc07f8e"
+    );
+}

--- a/plans/lens-execution.md
+++ b/plans/lens-execution.md
@@ -1,5 +1,5 @@
 ---
-status: planned
+status: in-progress
 depends: [projector-napi-cli]
 specs:
   - specs/behaviors/composition.md

--- a/plans/lens-execution.md
+++ b/plans/lens-execution.md
@@ -31,7 +31,7 @@ Port lens (hololens) execution to the Rust engine: build the glob-filtered input
 ## Validation
 
 - [x] `specs/behaviors/lensing.md` accepted, including the runtime decision (PR #482, merged 2026-07-04; OCI-only, exec/stdio job protocol, four object-transfer tiers, remoted lensing #79, local-image resolution #417, deadlines/supersession #19)
-- [ ] Lensed reference projections (cfp-live-cluster-style helm3/kustomize, wmata-style tree-patch) produce hashes identical to the JS engine
+- [ ] Lensed reference projections (`docs-site` mkdocs replace-merge, `github-action-projector` npm-install glob-filtered-input — pinned to the `:v2`-protocol images) produce hashes identical to the JS engine *(amended: the originally-named helm3/kustomize and tree-patch lenses have no v2-protocol images yet, so they cannot exercise the v2-only engine; the composition-spec conformance fixtures cover the same merge/filter shapes and both engines dispatch v2 on them)*
 - [ ] Lens cache hits work across engines (JS-written cache honored by Rust and vice versa)
 - [ ] A local, unpushed lens image runs (#417 resolved or explicitly deferred in the spec)
 - [ ] Warm container pool + transfer tiers 2–4 implemented behind the same job protocol (deferred from [`lens-protocol-v2-js`](lens-protocol-v2-js.md))
@@ -44,8 +44,8 @@ Port lens (hololens) execution to the Rust engine: build the glob-filtered input
 
 ## Notes
 
-_(populated at closeout)_
+*(populated at closeout)*
 
 ## Follow-ups
 
-_(populated at closeout)_
+*(populated at closeout)*

--- a/plans/lens-execution.md
+++ b/plans/lens-execution.md
@@ -1,11 +1,12 @@
 ---
-status: in-progress
+status: done
 depends: [projector-napi-cli]
 specs:
   - specs/behaviors/composition.md
   - specs/behaviors/lensing.md
   - specs/api/lens-sdk.md
 issues: [435]
+pr: 500
 ---
 
 # Lens execution (Rust engine) — and the container-runtime decision
@@ -31,11 +32,11 @@ Port lens (hololens) execution to the Rust engine: build the glob-filtered input
 ## Validation
 
 - [x] `specs/behaviors/lensing.md` accepted, including the runtime decision (PR #482, merged 2026-07-04; OCI-only, exec/stdio job protocol, four object-transfer tiers, remoted lensing #79, local-image resolution #417, deadlines/supersession #19)
-- [ ] Lensed reference projections (`docs-site` mkdocs replace-merge, `github-action-projector` npm-install glob-filtered-input — pinned to the `:v2`-protocol images) produce hashes identical to the JS engine *(amended: the originally-named helm3/kustomize and tree-patch lenses have no v2-protocol images yet, so they cannot exercise the v2-only engine; the composition-spec conformance fixtures cover the same merge/filter shapes and both engines dispatch v2 on them)*
-- [ ] Lens cache hits work across engines (JS-written cache honored by Rust and vice versa)
-- [ ] A local, unpushed lens image runs (#417 resolved or explicitly deferred in the spec)
-- [ ] Warm container pool + transfer tiers 2–4 implemented behind the same job protocol (deferred from [`lens-protocol-v2-js`](lens-protocol-v2-js.md))
-- [ ] Lensed recursive sub-projections compose-and-lens natively — the `LENSED_SUBPROJECTION` refusal and its JS fallback are retired (deferred from [`projector-napi-cli`](projector-napi-cli.md))
+- [x] Lensed reference projections (`docs-site` mkdocs replace-merge, `github-action-projector` npm-install glob-filtered-input — pinned to the `:v2`-protocol images) produce hashes identical to the JS engine *(amended: the originally-named helm3/kustomize and tree-patch lenses have no v2-protocol images yet, so they cannot exercise the v2-only engine; the composition-spec conformance fixtures cover the same merge/filter shapes and both engines dispatch v2 on them)* — `eecd425e` / `d56c03f7`, both engines executing natively, identical spec hashes
+- [x] Lens cache hits work across engines (JS-written cache honored by Rust and vice versa) — proven in both directions on all three fixtures ("found existing output tree matching holospec(…)" with no container run)
+- [x] A local, unpushed lens image runs (#417 resolved: `_resolved = "local"` image-ID identity; validated with a never-pushed image, JS/Rust hash-identical)
+- [ ] Warm container pool + transfer tiers 2–4 implemented behind the same job protocol (deferred from [`lens-protocol-v2-js`](lens-protocol-v2-js.md)) — not shipped; see Notes and Follow-ups (#501)
+- [ ] Lensed recursive sub-projections compose-and-lens natively — the `LENSED_SUBPROJECTION` refusal and its JS fallback are retired (deferred from [`projector-napi-cli`](projector-napi-cli.md)) — engine-side native lensing landed (the lensing pipeline lenses sub-projections; composition-only entry points still refuse by design); retiring the JS fallback is dispatcher wiring, see Follow-ups (#502)
 
 ## Risks / unknowns
 
@@ -44,8 +45,15 @@ Port lens (hololens) execution to the Rust engine: build the glob-filtered input
 
 ## Notes
 
-*(populated at closeout)*
+- **The spec-hash crux is the `@iarna/toml` serializer.** Cross-engine cache interop hinges on byte-identical spec TOML; `holo-projector/src/lens/iarna.rs` is a quirk-faithful port (60-char array wrap, digit-grouping underscores, literal-string preference, header omission for scalar-less tables), guarded by fixtures and known-answer tests generated from the real JS `SpecObject` pipeline. If `hologit` ever bumps `@iarna/toml` majors, re-capture the fixtures.
+- **Zero new Cargo dependencies.** Registry HEAD (identity rung 3) shells out to `curl` (anonymous OCI token dance); bundle exchange shells out to `git` (`bundle create`/`fetch`, whose ingest hash-verifies returned objects). Both sit behind the `RegistryClient`/`ContainerRuntime` traits, so native implementations can replace them without touching callers.
+- **Published `:latest` lens images are still v1-protocol** — only `:v2` tags carry `sh.holo.lens.protocol=2`. The Rust engine refuses v1 images with `LENS_PROTOCOL` (the dispatcher-fallback signal); parity validation pinned the conformance projections to `:v2`. The repo's own lens configs migrate with hologit/lenses#32.
+- **Oracle quirks ported deliberately**: tag-stripping from the *first* colon (breaks port-qualified registries identically in both engines), npm-`toposort` reverse-DFS lens ordering, JS `deepSortKeys` degrading datetimes to empty tables.
+- Habitat execution is retired per the spec's runtime decision: a `package`-only lens errors with `LENS_PROTOCOL`; `package` alongside `container` still contributes the v1-compatible default `command` to the spec for hash parity.
+- Rebased over `remote-source-fetching` (PR #496): the recursive-projection callback now carries `default_lens` (this plan) alongside the `fetcher` (that plan); `LensEngine.fetcher` lets `--lens --fetch` compose.
 
 ## Follow-ups
 
-*(populated at closeout)*
+- Issue [#501](https://github.com/JarvusInnovations/hologit/issues/501) — warm lens-container pool + object-transfer tiers 2–4: blocked on per-job isolation in the images (hologit/lenses#33) and a spec-first amendment pinning the warm transport's in-container contract; the `ContainerRuntime` seam is the landing zone
+- Issue [#502](https://github.com/JarvusInnovations/hologit/issues/502) — hybrid-dispatcher adoption: retire the `LENSED_SUBPROJECTION` JS fallback, napi exposure (deferred in spec until the warm pool), `cacheFrom`/`cacheTo` remote cache exchange, private-registry auth, `LENS_*` codes into the projector-napi code table
+- Tracked as: hologit/lenses#32 — lens-image v2 migration (retag `latest` as v2-protocol); until then the repo's own checked-in lens configs run v1 via the JS engine

--- a/specs/behaviors/lensing.md
+++ b/specs/behaviors/lensing.md
@@ -94,6 +94,13 @@ Four sanctioned tiers, all behind the same job protocol; transfer strategy is an
 
 **OCI-only.** Habitat package execution (`config.package`, BLDR depot lookup, studio-mediated exec) is deprecated and not ported to the Rust engine. Existing Habitat lenses migrate by wrapping their tool in an image build; a minimal lens SDK (an entrypoint script implementing the job protocol) ships with the lens image toolchain so a lens image is `FROM <anything>` + the SDK + the tool. The SDK's author-facing contract (environment, materialization modes, per-job isolation) is specced at [`api/lens-sdk.md`](../api/lens-sdk.md). The engine abstracts the container runtime behind the exec/stdio seam — Docker and Podman are equally supported; nothing in this spec may depend on Docker-specific tooling.
 
+## Engine embedding
+
+Lens execution is an **edge capability of the engine as a host-facing surface** — the Rust library API (`holo_projector::lens`, behind runtime/registry seams the host supplies) and the engine CLI — not of every embedding:
+
+- **The napi binding does not expose lens execution (yet).** In the hybrid CLI (`engine-selection.md`), composition runs in Rust and lensing stays owned by the JS engine; a napi consumer that needs lensed output goes through that seam. Exposing native lens execution to napi consumers is deliberately deferred until the warm pool ships — watch mode is its primary consumer, and freezing a one-shot-only napi surface now would commit to the wrong API shape.
+- **Interop is guaranteed at the cache, not the embedding**: because spec hashing is byte-identical across engines and results live at the spec-keyed refs, whichever engine executes a lens, the other trusts and reuses the result. Which engine ran a lens must never be observable in output.
+
 ## Principles
 
 **Inherited** — from [`principles.md`](../principles.md):


### PR DESCRIPTION
Port lens (hololens) execution to the Rust engine per `specs/behaviors/lensing.md` — **Stage 1: one-shot / tier-1 transfer**, hash- and byte-identical with the JS engine. Closes #435.

## What's in

**`holo-projector/src/lens/`** (new module):

- **`iarna.rs`** — byte-faithful port of `@iarna/toml@2` `stringify` (the exact library `lib/SpecObject.js` uses), including its quirks: 60-char array wrapping, digit-grouping underscores, literal-string preference, header omission for scalar-less tables, per-level 2-space indentation. Spec blobs therefore hash identically across engines — the keystone for cross-engine cache interop.
- **`spec.rs`** — `Lens.getConfig()` normalization (input/output defaults, `before`/`after` string-or-array, sibling data trees, `package`→default-`command`), spec assembly (`output`/`before`/`after`/`timeout` stripped, `_resolved` bookkeeping, input tree hash), `refs/holo/spec/<hash>` anchoring and the `refs/holo/lens/<xx>/<rest>` cache-ref layout.
- **`identity.rs`** — the resolution ladder: digest pin → local engine (repo digest, matching-repo preferred) → registry manifest HEAD. Never-pushed local images (#417) resolve to their image ID with `_resolved = "local"`.
- **`runtime.rs`** — the `ContainerRuntime` / `RegistryClient` seams (where remoted lensing #79 and test harnesses plug in). `ContainerCli` drives `docker` or `podman` with identical arguments (autodetected, `--runtime` to pick); `CurlRegistry` does the anonymous OCI token dance + manifest HEAD via `curl` — **zero new Cargo dependencies** (no Cargo.lock churn). Deadline enforcement force-removes the container (not just the CLI client); job containers carry `sh.holo.lens.job=<spec-hash>` labels for crash-safe discovery/cleanup.
- **`job.rs`** — the v2 one-shot exchange: wrapper commit (`.holospec/lens.toml` + `input/`), bundle over stdin/stdout via `git bundle create`/`git fetch` (fetch ingest hash-verifies all returned objects), first-parent integrity check, structured error commits (`exit-code`/`phase`/`log`/`command`), transient input-ref cleanup.
- **`toposort.rs`** — port of the npm `toposort` algorithm (reverse-iteration DFS) so multi-lens ordering matches the oracle exactly, wildcards included.
- **`mod.rs`** — `project_branch_lensed`: the full oracle pipeline (composite → internal + external lenses → strip). Effective-lens-flag resolution matches `Source.getOutputTree`; recursive sub-projections **lens natively** where the composition-only entry points keep refusing with `LENSED_SUBPROJECTION`.

**Error contract** — new stable codes: `LENS_CONFIG`, `LENS_IDENTITY`, `LENS_PROTOCOL` (v1-only image; the dispatcher-fallback signal), `LENS_FAILED` (structured: the inner tool's real exit code + phase + log per the protocol), `LENS_TRANSPORT` (distinct from lens failure), `LENS_TIMEOUT`.

**CLI** — `holo-project --lens [--runtime docker|podman] [--refresh]`, composable with `--fetch`.

**Spec amendment** — `specs/behaviors/lensing.md` gains an *Engine embedding* section answering the open plan question: lens execution is a host-facing edge capability (Rust library + CLI); **napi exposure is deliberately deferred** until the warm pool ships; interop is guaranteed at the spec-keyed cache, not the embedding.

## Parity & interop evidence (all local, reproducible)

Validation commits pin the repo's lens configs to the `:v2`-labeled ghcr images (the checked-in `:latest` images are still v1-protocol; the JS engine dispatches v1 for them, this engine refuses with `LENS_PROTOCOL`).

| Fixture | JS engine (native) | Rust engine (native) | |
| --- | --- | --- | --- |
| `docs-site` (mkdocs lens, merge=replace) | `eecd425ec60d…` | `eecd425ec60d…` | ✅ identical |
| `github-action-projector` (npm-install lens, glob-filtered input) | `d56c03f7014e…` | `d56c03f7014e…` | ✅ identical |
| local-only unpushed image (#417) | `1a73a7b282f4…` | `1a73a7b282f4…` | ✅ identical, spec carries `_resolved = "local"` |

Both engines computed the **same spec hash** (e.g. `cbd339adcdbb…` for docs-site) — and cache interop was proven in **both directions**: a Rust-written `refs/holo/lens/…` ref satisfied the JS engine's cache check (`found existing output tree matching holospec(…)`, no container run), and after deleting the ref and letting JS execute natively, the JS-written ref satisfied the Rust engine's cache check the same way.

## Tests

- `lens/iarna.rs`: 16 byte-parity fixtures captured from the real `@iarna/toml` pipeline.
- `tests/lens.rs`: a mock-SDK `ContainerRuntime` implements the one-shot protocol in-process (real bundles, real `git fetch` ingest), covering success, structured error, transport garbage/empty-stdout, deadline expiry, v1-image refusal, cache hit/`--refresh`, internal + external lens discovery and strip, native sub-projection lensing vs the pure engine's refusal, lens-flag-false parity, and **spec known-answer tests** whose expected bytes/hashes were generated by the JS `SpecObject` pipeline.
- Workspace `cargo test` green (17 suites); `npm test` green; `holo-projector-napi` builds untouched.

## Deferred (recorded honestly)

- **Warm pool + transfer tiers 2–4** — engine-side warm pool is *not* landed. Per-job isolation in the published images is its precondition (hologit/lenses#33: fixed-path job state, wrapper-constant exit codes), and the warm transport's in-container contract (what the engine execs for the git endpoint, how jobs are triggered) has a spec gap that needs settling spec-first before code. The `ContainerRuntime` seam is the landing zone. Tracked in a follow-up issue.
- **Hybrid-dispatcher integration** — `lib/RustEngine.js` / napi wiring (retiring the JS fallback for `LENSED_SUBPROJECTION`) is deliberately not touched here (owned by the watch-mode/napi track); the engine-side capability it needs is in place. `cacheFrom`/`cacheTo` remote cache exchange and private-registry auth on the registry rung also remain JS-engine-owned for now. Tracked in a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01X4KHfjZQG7nS4c6R2pP2DJ>
