### PR TITLE
Establish the @hologit/holo-projector publication track (holo-projector-v* tags)

### DIFF
--- a/.github/workflows/holo-projector-napi.yml
+++ b/.github/workflows/holo-projector-napi.yml
@@ -1,0 +1,164 @@
+# Build + publish the @hologit/holo-projector napi binding with per-platform
+# prebuilds. Mirrors holo-tree-napi.yml.
+#
+# Each target builds NATIVELY on its matching runner (no cross-compilation):
+#   x86_64-unknown-linux-gnu → ubuntu-latest
+#   aarch64-apple-darwin     → macos-latest   (Apple Silicon runner)
+#   x86_64-pc-windows-msvc   → windows-latest
+#
+# Triggers:
+#   - pull_request touching the binding/crates    → build + smoke-test (no publish)
+#   - push of a `holo-projector-v*` tag           → build, then publish to npm
+#   - workflow_dispatch                           → manual build
+#
+# Publish auth: npm TRUSTED PUBLISHING (OIDC) — no token, matching hologit's
+# publish-npm.yml. Each of the 7 packages (@hologit/holo-projector + the 6
+# platform packages) must already exist on npm AND have a trusted publisher
+# configured for this repo + this workflow. One-time bootstrap (the package
+# can't get a trusted publisher until it exists): publish an early version of
+# all 7 manually, then add the trusted publishers. See
+# holo-projector-napi/README "Publishing".
+#
+# The release marker is the `holo-projector-v*` git tag itself; napi prepublish
+# runs with --skip-gh-release so it does NOT create a bare `v<version>` GitHub
+# release + tag. NEVER tag this binding with a bare `v*` — that namespace
+# belongs to the hologit JS package (it matches publish-npm.yml's trigger and
+# the develop→master Release-PR flow) and a collision would double-publish.
+name: holo-projector-napi
+
+on:
+  pull_request:
+    paths:
+      - 'holo-projector-napi/**'
+      - 'holo-projector/**'
+      - 'holo-tree/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+  push:
+    tags:
+      - 'holo-projector-v*'
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: holo-projector-napi
+
+jobs:
+  build:
+    name: build ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Native — build + smoke-test on a matching runner.
+          - target: x86_64-unknown-linux-gnu
+            host: ubuntu-latest
+            test: true
+          - target: aarch64-unknown-linux-gnu
+            host: ubuntu-24.04-arm
+            test: true
+          - target: aarch64-apple-darwin
+            host: macos-latest
+            test: true
+          - target: x86_64-pc-windows-msvc
+            host: windows-latest
+            test: true
+          # Cross — build only; the .node can't run on the host arch/libc, so
+          # the smoke test is skipped (the logic is covered by the native runs).
+          - target: x86_64-unknown-linux-musl
+            host: ubuntu-latest
+            zig: true
+            test: false
+          - target: x86_64-apple-darwin
+            host: macos-latest
+            test: false
+    runs-on: ${{ matrix.host }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+
+      # zig cc bundles libc/libgcc and links musl cleanly — napi-rs's
+      # recommended cross path. (musl-gcc fails on `libgcc_s.so.1`.)
+      - name: Setup zig (musl cross-link)
+        if: ${{ matrix.zig }}
+        working-directory: ${{ runner.temp }}
+        run: |
+          ZIG=zig-linux-x86_64-0.13.0
+          curl -fsSL "https://ziglang.org/download/0.13.0/${ZIG}.tar.xz" | tar -xJ
+          echo "${{ runner.temp }}/${ZIG}" >> "$GITHUB_PATH"
+
+      - name: Configure git identity (the smoke test commits to scratch repos)
+        if: ${{ matrix.test }}
+        run: |
+          git config --global user.name "holo-projector CI"
+          git config --global user.email "ci@hologit.local"
+
+      - run: npm install
+
+      - name: Build (release)
+        run: npm run build -- --target ${{ matrix.target }}${{ matrix.zig && ' --zig' || '' }}
+
+      - name: Smoke test
+        if: ${{ matrix.test }}
+        run: npm test
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: bindings-${{ matrix.target }}
+          path: holo-projector-napi/*.node
+          if-no-files-found: error
+
+  publish:
+    name: publish @hologit/holo-projector
+    if: ${{ startsWith(github.ref, 'refs/tags/holo-projector-v') }}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read    # no GitHub release is created (see --skip-gh-release)
+      id-token: write   # npm provenance attestation
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24' # recent npm for OIDC trusted publishing
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm install
+
+      - name: Set version from tag (e.g. holo-projector-v0.2.0 → 0.2.0)
+        run: |
+          VERSION="${GITHUB_REF_NAME#holo-projector-v}"
+          export VERSION
+          npm version --no-git-tag-version "$VERSION"
+          npx napi version
+          # `napi version` updates the npm/<triple> package versions but NOT the
+          # root optionalDependencies — pin those to the release version too, or
+          # the main package would resolve stale platform packages.
+          node -e "const fs=require('fs'),p=require('./package.json');for(const k in p.optionalDependencies)p.optionalDependencies[k]=process.env.VERSION;fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+
+      - name: Collect prebuilt .node artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: holo-projector-napi/artifacts
+          pattern: bindings-*
+          merge-multiple: true
+
+      - name: Distribute artifacts into npm/<triple>/
+        run: npx napi artifacts --dir artifacts
+
+      - name: Publish (platform packages via prepublishOnly hook, then main)
+        # Tokenless: OIDC trusted publishing. Requires all 7 packages to exist
+        # with a trusted publisher configured (see the bootstrap note up top).
+        # prepublishOnly runs `napi prepublish ... --skip-gh-release`, so no
+        # GitHub release/tag is created and no GITHUB_TOKEN is needed.
+        run: npm publish --provenance --access public

--- a/holo-projector-napi/.gitignore
+++ b/holo-projector-napi/.gitignore
@@ -4,7 +4,8 @@ target/
 # npm
 node_modules/
 
-# Compiled native addons — built per-platform, never committed.
-# (The generated index.js / index.d.ts loader+types ARE committed; only the
-# .node binaries are ignored.)
+# Compiled native addons — built per-platform in CI, never committed.
+# (The generated index.js / index.d.ts loader+types ARE committed, and the
+# npm/<triple>/ platform package manifests ARE committed; only the .node
+# binaries that land in them are ignored.)
 *.node

--- a/holo-projector-napi/README.md
+++ b/holo-projector-napi/README.md
@@ -1,18 +1,48 @@
-# holo-projector-napi
+# @hologit/holo-projector
 
-Node.js native binding for [`holo-projector`](../holo-projector) — the Rust
-holobranch composition engine, via [gitoxide](https://github.com/GitoxideLabs/gitoxide),
-with no `git` subprocess.
+Holobranch projection and composition for Node.js — a native binding over
+the [`holo-projector`](../holo-projector) Rust engine, powered by
+[gitoxide](https://github.com/GitoxideLabs/gitoxide).
 
-This is the delivery vehicle for the hybrid CLI (`specs/behaviors/engine-selection.md`):
-`lib/RustEngine.js` loads this binding from the in-repo build and delegates
-pure composition to it, while the JS engine keeps ownership of side effects
-(fetching, lensing, commits, watch). If the addon isn't built, the CLI runs
-pure-JS exactly as before.
+- **No `git` binary.** Everything runs in-process through gix; nothing
+  shells out. Works anywhere Node runs, including environments with no git
+  installed.
+- **Composition, hash-identical.** Reads `.holo/` configuration from a git
+  tree, resolves sources, and merges trees according to mappings — producing
+  the same output hashes as the [hologit](https://github.com/JarvusInnovations/hologit)
+  CLI's projection pipeline (`specs/behaviors/composition.md`).
+- **Warm sessions.** One-shot functions for simple calls, or a
+  `ProjectionSession` holding a persistent repository handle + tree cache
+  for hosts that project repeatedly — watch cycles, servers, embedders.
+- **Built for embedding.** Stable machine-matchable error codes, panic
+  containment at the FFI boundary (a Rust bug can never abort your process),
+  and no reliance on thread-implicit state.
 
-## API
+This binding is the delivery vehicle for hologit's hybrid CLI
+(`specs/behaviors/engine-selection.md`): `lib/RustEngine.js` delegates pure
+composition to it while the JS engine keeps ownership of side effects
+(fetching, lensing, commits, watch). The CLI loads it from the in-repo build
+— if the addon isn't built, the CLI runs pure-JS exactly as before. As an
+npm package it is the same engine, standalone, for any Node host.
 
-Specced in [`specs/api/projector-napi.md`](../specs/api/projector-napi.md).
+## Install
+
+```sh
+npm install @hologit/holo-projector
+```
+
+Prebuilt release binaries ship as `optionalDependencies` for:
+linux-x64-gnu, linux-arm64-gnu, linux-x64-musl, darwin-arm64, darwin-x64,
+win32-x64-msvc (full matrix under [Publishing](#publishing)). No Rust
+toolchain needed on supported platforms.
+
+## Quick start
+
+The API contract is specced in
+[`specs/api/projector-napi.md`](../specs/api/projector-napi.md). All calls
+are synchronous; object ids cross the boundary as lowercase 40-char hex
+strings. `rootTree` accepts a tree hash, or a commit/tag hash which is
+peeled to its tree.
 
 ```js
 const { compositeBranch, projectBranch, projectPlan } = require('@hologit/holo-projector');
@@ -24,19 +54,19 @@ const preLens = compositeBranch('/repo/.git', rootTreeOrCommitHash, 'docs-site')
 // Full composition-only projection (final metadata strip included):
 const tree = projectBranch('/repo/.git', rootTreeOrCommitHash, 'docs-site');
 
-// Structured-config composition (the ProjectionPlan path):
+// Structured-config composition (no .holo/ config needed):
 const composed = projectPlan('/repo/.git',
     [{ name: 'base', ref: 'refs/heads/main' }],
     [{ source: 'base' }]);
 ```
 
 The top-level functions are one-shot (open repo, project, drop). Hosts making
-repeat projections — watch cycles, servers, embedders — hold a
-**`ProjectionSession`**: a warm context (persistent repository handle +
-tree cache) that only ever caches content-addressed state, re-resolving refs
-on every call. It also exposes `commitProjection` — create a projection
-commit and advance a ref per `specs/behaviors/projection-commits.md`, with a
-compare-and-swap advance that surfaces concurrent writers as `REF_CONFLICT`:
+repeat projections hold a **`ProjectionSession`** — a warm context
+(persistent repository handle + tree cache) that only ever caches
+content-addressed state, re-resolving refs on every call. It also exposes
+`commitProjection` — create a projection commit and advance a ref per
+`specs/behaviors/projection-commits.md`, with a compare-and-swap advance
+that surfaces concurrent writers as `REF_CONFLICT`:
 
 ```js
 const { ProjectionSession } = require('@hologit/holo-projector');
@@ -52,30 +82,165 @@ const commit = session.commitProjection({
 });
 ```
 
-Errors carry a stable `code` property (`SOURCE_RESOLUTION`,
-`LENSED_SUBPROJECTION`, `CONFIG`, …, plus the holo-tree codes and `PANIC`);
-match on codes, never message prose. Panics are contained at the FFI boundary
-and never abort the host process.
+### Session staleness contract
+
+The session caches **only content-addressed state** (parsed trees keyed by
+tree id) — immutable by construction, reusable forever. Everything mutable
+is read fresh on every call: refs are never cached (a ref advanced behind
+the session is observed by the next call), and objects written behind the
+session are visible without reopening it. `cachedTrees()` exposes cache
+warmth for observability; `clearCache()` is a memory valve for long-lived
+hosts, never required for correctness.
+
+## Errors: match on `code`, never on message
+
+Every failure is a catchable `Error` carrying a **stable `code` property** —
+codes, not message prose, are the API (messages may change freely; codes are
+append-only). The contract is
+[`specs/api/projector-napi.md`](../specs/api/projector-napi.md) § Error
+contract, extending [`specs/api/errors.md`](../specs/api/errors.md).
+
+Projector-level codes:
+
+| Code | Raised when |
+| --- | --- |
+| `CONFIG` | A `.holo/` TOML file is malformed or semantically invalid. |
+| `SOURCE_RESOLUTION` | A holosource resolved to no commit (gitlink → spec-ref → local ref). Often means the source simply isn't fetched. |
+| `SOURCE_FETCH` | A remote source fetch failed (network, auth, unknown remote ref) — distinct from `SOURCE_RESOLUTION`. |
+| `CIRCULAR_DEPENDENCY` | Mapping `before`/`after` constraints form a cycle. |
+| `LENSED_SUBPROJECTION` | A recursive sub-projection would lens; the composition-only path refuses rather than silently skipping the lens. |
+| `LENS_CONFIG` | A lens spec (`.holo/lenses/*.toml`) is malformed or semantically invalid. |
+| `LENS_IDENTITY` | The lens container identity could not be resolved. |
+| `LENS_PROTOCOL` | The lens image cannot run on this engine (e.g. a v1-protocol image). |
+| `LENS_FAILED` | The lens job ran and failed — carries the inner transform's real exit code, failing phase, and captured log. |
+| `LENS_TRANSPORT` | The lens job's result never arrived (container/exec plumbing), distinct from the lens tool failing. |
+| `LENS_TIMEOUT` | The lens job exceeded its deadline and was cancelled. |
+| `PROJECTION` | Residual projection failure not classified above. |
+
+Underlying git failures forward the
+[holo-tree codes](../specs/api/errors.md) unchanged — `GIT`,
+`OBJECT_NOT_FOUND`, `NOT_A_TREE`, `REF_CONFLICT` (a `commitProjection`
+compare-and-swap lost to a concurrent writer), … — plus `INVALID_ARGUMENT`
+(bad hex id) at the marshalling layer and `INTERNAL` / `PANIC` (always an
+engine bug — report it; the process stays healthy).
+
+## Performance — release builds only
+
+> **⚠️ Never benchmark or ship a debug build.** The published npm prebuilds
+> are release builds — `npm install` users are fine. But if you build from
+> source, `napi build` *without* `--release` produces a debug binary that is
+> drastically slower than the JS engine it replaces, silently inverting the
+> entire performance story. Always build with `npm run build`
+> (`napi build --platform --release`).
+
+Reference workload (the codeforphilly.org `emergence-site` holobranch:
+~3,000 tree writes, 9 recursive sub-projections): a one-shot composition
+runs in ~110–130ms; a warm `ProjectionSession` brings repeat projections to
+~27ms, versus multiple seconds for the JS engine on the same input.
+
+## Surface
+
+| Export | Returns | Notes |
+| --- | --- | --- |
+| `compositeBranch(gitDir, rootTree, holobranch)` | tree hash | pre-lens composed tree (`.holo/config.toml` + `.holo/lenses` retained) |
+| `projectBranch(gitDir, rootTree, holobranch)` | tree hash | full composition-only projection, metadata stripped |
+| `projectPlan(gitDir, sources, mappings)` | tree hash | structured-config composition; no `.holo/` needed |
+| `new ProjectionSession(gitDir)` | session | warm context; same three methods without `gitDir` |
+| `session.commitProjection(options)` | commit hash | projection commit + compare-and-swap ref advance |
+| `session.cachedTrees()` / `session.clearCache()` | — | cache observability / memory valve |
+| `stats()` / `resetStats()` | counters | process-global metrics (trees read/written, cache hits, …) |
+
+The binding is a deliberately thin marshalling shell: rough edges are fixed
+upstream in the `holo-projector` crate, never papered over here
+(`specs/principles.md`). New capability requests belong against the crate.
 
 ## Building
 
+Requires a Rust toolchain and `@napi-rs/cli` (a devDependency):
+
 ```sh
 npm install
-npm run build         # release; emits holo-projector.<platform>.node
-npm run build:debug   # faster compile for development
-npm test              # node --test suite (requires a built addon)
+npm run build         # release — use this for anything you'll measure or ship
+npm run build:debug   # faster compile for development, runs SLOW (see Performance)
+npm test              # node --test against scratch git repos (requires a built addon)
 ```
 
-From the repo root, `npm run build:projector-addon` does the install + release
-build in one step (this is what `test-cli` CI uses).
+`napi build` emits `holo-projector.<triple>.node`. The generated `index.js`
+loader and `index.d.ts` types **are committed**; only the `.node` binaries
+are git-ignored (built per-platform in CI).
 
-## Publication (deferred)
+From the hologit repo root, `npm run build:projector-addon` does the
+install + release build in one step — this is how the CLI's in-repo copy is
+built (and what `test-cli` CI uses).
 
-This package is **not published yet** — the CLI loads it via a relative
-require with graceful degradation, so `npm install hologit` consumers see no
-change. The packaging (napi config, committed `index.js`/`index.d.ts`,
-platform triples) mirrors [`holo-tree-napi`](../holo-tree-napi) so that
-publication is a follow-up workflow away. When that happens, the release tag
-track must be prefix-namespaced (e.g. `holo-projector-v*`) — **never a bare
-`v*` tag**, which collides with the `hologit` JS release namespace and the
-`publish-npm.yml` trigger.
+## Publishing
+
+Published as the scoped package **`@hologit/holo-projector`** with
+per-platform prebuilt binaries shipped as `optionalDependencies`:
+
+| Platform package | Triple | Built on | Smoke-tested |
+| --- | --- | --- | --- |
+| `@hologit/holo-projector-linux-x64-gnu` | `x86_64-unknown-linux-gnu` | ubuntu-latest | ✓ native |
+| `@hologit/holo-projector-linux-arm64-gnu` | `aarch64-unknown-linux-gnu` | ubuntu-24.04-arm | ✓ native |
+| `@hologit/holo-projector-linux-x64-musl` | `x86_64-unknown-linux-musl` | ubuntu-latest (musl cross) | build-only |
+| `@hologit/holo-projector-darwin-arm64` | `aarch64-apple-darwin` | macos-latest | ✓ native |
+| `@hologit/holo-projector-darwin-x64` | `x86_64-apple-darwin` | macos-latest (cross) | build-only |
+| `@hologit/holo-projector-win32-x64-msvc` | `x86_64-pc-windows-msvc` | windows-latest | ✓ native |
+
+Native targets build + smoke-test on a matching runner; cross targets (musl,
+darwin-x64) build only, since their `.node` can't run on the host arch/libc
+(the logic is covered by the native runs). The
+`.github/workflows/holo-projector-napi.yml` workflow builds all six on every
+PR touching the binding or either engine crate, and on a
+`holo-projector-v*` tag it builds then publishes.
+
+Auth is **npm trusted publishing (OIDC)** — no tokens, matching hologit's
+`publish-npm.yml`. Trusted publishing is configured *per package*, and a
+package can't get a trusted publisher until it exists — so the packages need
+a **one-time manual bootstrap** before automated releases work.
+
+### One-time bootstrap (manual first publish, then configure trusted publishing)
+
+The packages all start at an early version (currently `0.0.1`). They must
+exist on npm before trusted publishing can be turned on.
+
+1. **Get the prebuilt binaries.** Run the `holo-projector-napi` workflow
+   (push the branch / open a PR, or trigger `workflow_dispatch`) and download
+   its `bindings-*` artifacts — they hold the `.node` for each platform. A
+   single machine can't build all of them natively, so use the CI artifacts.
+
+2. **Publish all packages manually**, logged in as an `@hologit` org member
+   (`npm login`):
+
+   ```sh
+   cd holo-projector-napi
+   npm install
+   npx napi artifacts --dir <downloaded-artifacts-dir>   # → npm/<triple>/*.node
+   # platform packages first, then the main package:
+   for d in npm/*/ ; do ( cd "$d" && npm publish --access public ); done
+   npm publish --access public --ignore-scripts          # main; skip the napi
+                                                         # prepublish hook
+   ```
+
+3. **Turn on trusted publishing** on npmjs.com for **each** of the packages
+   → Settings → Trusted Publisher → GitHub Actions, repo
+   `JarvusInnovations/hologit`, workflow `holo-projector-napi.yml`.
+
+### Releases (after bootstrap — fully automated, tokenless)
+
+```sh
+git tag holo-projector-v0.1.1 && git push origin holo-projector-v0.1.1
+```
+
+The tag drives the published version; CI builds all platforms, then
+publishes via OIDC (provenance). No secret needed. The `holo-projector-v*`
+tag is the release marker — napi runs with `--skip-gh-release` so it does
+**not** create a bare `v<version>` GitHub release/tag. **Never tag this
+binding with a bare `v*`** — that namespace belongs to the `hologit` JS
+package (it matches `publish-npm.yml`'s trigger and the develop→master
+Release-PR flow).
+
+To add or drop a platform later, edit `napi.triples.additional` +
+`optionalDependencies` in `package.json`, run `napi create-npm-dir -t .`, add
+the matching matrix entry in the workflow, and (since it's a new package)
+bootstrap + trust that one package too.

--- a/holo-projector-napi/npm/darwin-arm64/README.md
+++ b/holo-projector-napi/npm/darwin-arm64/README.md
@@ -1,0 +1,3 @@
+# `@hologit/holo-projector-darwin-arm64`
+
+This is the **aarch64-apple-darwin** binary for `@hologit/holo-projector`

--- a/holo-projector-napi/npm/darwin-arm64/package.json
+++ b/holo-projector-napi/npm/darwin-arm64/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@hologit/holo-projector-darwin-arm64",
+  "version": "0.0.1",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "holo-projector.darwin-arm64.node",
+  "files": [
+    "holo-projector.darwin-arm64.node"
+  ],
+  "description": "Node.js native binding for holo-projector — the Rust holobranch composition engine",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JarvusInnovations/hologit.git",
+    "directory": "holo-projector-napi"
+  }
+}

--- a/holo-projector-napi/npm/darwin-x64/README.md
+++ b/holo-projector-napi/npm/darwin-x64/README.md
@@ -1,0 +1,3 @@
+# `@hologit/holo-projector-darwin-x64`
+
+This is the **x86_64-apple-darwin** binary for `@hologit/holo-projector`

--- a/holo-projector-napi/npm/darwin-x64/package.json
+++ b/holo-projector-napi/npm/darwin-x64/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@hologit/holo-projector-darwin-x64",
+  "version": "0.0.1",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "holo-projector.darwin-x64.node",
+  "files": [
+    "holo-projector.darwin-x64.node"
+  ],
+  "description": "Node.js native binding for holo-projector — the Rust holobranch composition engine",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JarvusInnovations/hologit.git",
+    "directory": "holo-projector-napi"
+  }
+}

--- a/holo-projector-napi/npm/linux-arm64-gnu/README.md
+++ b/holo-projector-napi/npm/linux-arm64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@hologit/holo-projector-linux-arm64-gnu`
+
+This is the **aarch64-unknown-linux-gnu** binary for `@hologit/holo-projector`

--- a/holo-projector-napi/npm/linux-arm64-gnu/package.json
+++ b/holo-projector-napi/npm/linux-arm64-gnu/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@hologit/holo-projector-linux-arm64-gnu",
+  "version": "0.0.1",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "holo-projector.linux-arm64-gnu.node",
+  "files": [
+    "holo-projector.linux-arm64-gnu.node"
+  ],
+  "description": "Node.js native binding for holo-projector — the Rust holobranch composition engine",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JarvusInnovations/hologit.git",
+    "directory": "holo-projector-napi"
+  },
+  "libc": [
+    "glibc"
+  ]
+}

--- a/holo-projector-napi/npm/linux-x64-gnu/README.md
+++ b/holo-projector-napi/npm/linux-x64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@hologit/holo-projector-linux-x64-gnu`
+
+This is the **x86_64-unknown-linux-gnu** binary for `@hologit/holo-projector`

--- a/holo-projector-napi/npm/linux-x64-gnu/package.json
+++ b/holo-projector-napi/npm/linux-x64-gnu/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@hologit/holo-projector-linux-x64-gnu",
+  "version": "0.0.1",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "holo-projector.linux-x64-gnu.node",
+  "files": [
+    "holo-projector.linux-x64-gnu.node"
+  ],
+  "description": "Node.js native binding for holo-projector — the Rust holobranch composition engine",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JarvusInnovations/hologit.git",
+    "directory": "holo-projector-napi"
+  },
+  "libc": [
+    "glibc"
+  ]
+}

--- a/holo-projector-napi/npm/linux-x64-musl/README.md
+++ b/holo-projector-napi/npm/linux-x64-musl/README.md
@@ -1,0 +1,3 @@
+# `@hologit/holo-projector-linux-x64-musl`
+
+This is the **x86_64-unknown-linux-musl** binary for `@hologit/holo-projector`

--- a/holo-projector-napi/npm/linux-x64-musl/package.json
+++ b/holo-projector-napi/npm/linux-x64-musl/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@hologit/holo-projector-linux-x64-musl",
+  "version": "0.0.1",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "holo-projector.linux-x64-musl.node",
+  "files": [
+    "holo-projector.linux-x64-musl.node"
+  ],
+  "description": "Node.js native binding for holo-projector — the Rust holobranch composition engine",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JarvusInnovations/hologit.git",
+    "directory": "holo-projector-napi"
+  },
+  "libc": [
+    "musl"
+  ]
+}

--- a/holo-projector-napi/npm/win32-x64-msvc/README.md
+++ b/holo-projector-napi/npm/win32-x64-msvc/README.md
@@ -1,0 +1,3 @@
+# `@hologit/holo-projector-win32-x64-msvc`
+
+This is the **x86_64-pc-windows-msvc** binary for `@hologit/holo-projector`

--- a/holo-projector-napi/npm/win32-x64-msvc/package.json
+++ b/holo-projector-napi/npm/win32-x64-msvc/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@hologit/holo-projector-win32-x64-msvc",
+  "version": "0.0.1",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "holo-projector.win32-x64-msvc.node",
+  "files": [
+    "holo-projector.win32-x64-msvc.node"
+  ],
+  "description": "Node.js native binding for holo-projector — the Rust holobranch composition engine",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JarvusInnovations/hologit.git",
+    "directory": "holo-projector-napi"
+  }
+}

--- a/holo-projector-napi/package-lock.json
+++ b/holo-projector-napi/package-lock.json
@@ -1,18 +1,26 @@
 {
   "name": "@hologit/holo-projector",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hologit/holo-projector",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"
       },
       "engines": {
         "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@hologit/holo-projector-darwin-arm64": "0.0.1",
+        "@hologit/holo-projector-darwin-x64": "0.0.1",
+        "@hologit/holo-projector-linux-arm64-gnu": "0.0.1",
+        "@hologit/holo-projector-linux-x64-gnu": "0.0.1",
+        "@hologit/holo-projector-linux-x64-musl": "0.0.1",
+        "@hologit/holo-projector-win32-x64-msvc": "0.0.1"
       }
     },
     "node_modules/@napi-rs/cli": {

--- a/holo-projector-napi/package.json
+++ b/holo-projector-napi/package.json
@@ -44,7 +44,7 @@
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
     "prepublishOnly": "napi prepublish -t npm --skip-gh-release",
-    "test": "node --test test/*.mjs",
+    "test": "node --test test/errors.mjs test/session.mjs test/smoke.mjs",
     "version": "napi version"
   },
   "devDependencies": {

--- a/holo-projector-napi/package.json
+++ b/holo-projector-napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hologit/holo-projector",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Node.js native binding for holo-projector — the Rust holobranch composition engine",
   "main": "index.js",
   "types": "index.d.ts",
@@ -31,10 +31,19 @@
     "index.js",
     "index.d.ts"
   ],
+  "optionalDependencies": {
+    "@hologit/holo-projector-linux-x64-gnu": "0.0.1",
+    "@hologit/holo-projector-linux-arm64-gnu": "0.0.1",
+    "@hologit/holo-projector-linux-x64-musl": "0.0.1",
+    "@hologit/holo-projector-darwin-arm64": "0.0.1",
+    "@hologit/holo-projector-darwin-x64": "0.0.1",
+    "@hologit/holo-projector-win32-x64-msvc": "0.0.1"
+  },
   "scripts": {
     "artifacts": "napi artifacts",
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
+    "prepublishOnly": "napi prepublish -t npm --skip-gh-release",
     "test": "node --test test/*.mjs",
     "version": "napi version"
   },

--- a/plans/holo-projector-publish.md
+++ b/plans/holo-projector-publish.md
@@ -1,10 +1,11 @@
 ---
-status: in-progress
+status: done
 depends: [projector-napi-cli]
 specs:
   - specs/architecture.md
   - specs/api/projector-napi.md
 issues: [493]
+pr: 503
 ---
 
 # Establish the @hologit/holo-projector publication track
@@ -86,20 +87,21 @@ scoped npm package **`@hologit/holo-projector`**, mirroring the proven
 
 ## Validation
 
-- [ ] `holo-projector-napi` workflow green on this PR: all six targets build,
+- [x] `holo-projector-napi` workflow green on this PR: all six targets build,
   native targets smoke-test (`npm test`) against the built addon
-- [ ] `npm run build:projector-addon` + `npm --prefix holo-projector-napi test`
-  pass locally — the CLI's in-repo load path is unchanged
-- [ ] Root `npm test` (jest) passes
-- [ ] `npm pack --dry-run` on the main package ships exactly
+  (run 29217354840; the publish job correctly skipped — no tag)
+- [x] `npm run build:projector-addon` + `npm --prefix holo-projector-napi test`
+  pass locally (18/18) — the CLI's in-repo load path is unchanged
+- [x] Root `npm test` (jest) passes (110/110; `test-cli` CI green too)
+- [x] `npm pack --dry-run` on the main package ships exactly
   `index.js`/`index.d.ts` (+ `package.json`/`README.md`); each
   `npm/<triple>/` manifest matches holo-tree's shape (os/cpu/libc, `main`
   and `files` naming the `.node`)
-- [ ] `specs/architecture.md` § Release tracks lists the
+- [x] `specs/architecture.md` § Release tracks lists the
   `holo-projector-v*` track; `specs/api/projector-napi.md` documents the
   full error-code table (incl. `SOURCE_FETCH`, `LENS_*`) with no
   "publication is deferred" residue
-- [ ] README covers install, quick start, error codes, the debug-vs-release
+- [x] README covers install, quick start, error codes, the debug-vs-release
   warning, the release track, and the one-time bootstrap procedure
 
 ## Risks / unknowns
@@ -119,8 +121,40 @@ scoped npm package **`@hologit/holo-projector`**, mirroring the proven
 
 ## Notes
 
-(Populated at closeout.)
+- **`node --test test/*.mjs` broke on the windows-latest runner** — pwsh
+  doesn't expand globs, so node got the literal pattern. Fixed by
+  enumerating the test files like holo-tree's script does (which also keeps
+  dodging node 22.22.x's broken `node --test <dir>` form, the reason #492
+  chose the glob). If a new test file is added, the script must list it.
+- **npm skips unresolvable optionalDependencies** (verified on npm 11:
+  `npm install` exits 0 and omits them from the lock), so the six
+  hand-pinned platform packages are safe to commit before they exist — the
+  same pre-bootstrap state holo-tree shipped in.
+- The six-target matrix follows holo-tree's *current* workflow, not the
+  older three-target description in CLAUDE.md/docs — the binding's
+  package.json already declared all six triples.
+- `workflow_dispatch` on a new workflow file is unusable until the file
+  reaches the default branch; the PR's own `pull_request` trigger served as
+  build verification instead.
+- The workflow's version stamping (`npm version` + `napi version`) leaves
+  the committed manifests at `0.0.1` forever; the `holo-projector-v*` tag is
+  the only version authority.
 
 ## Follow-ups
 
-(Populated at closeout.)
+- Tracked as: **first release awaits the one-time npm bootstrap** (issue
+  [#493](https://github.com/JarvusInnovations/hologit/issues/493) stays open
+  until the package publishes). Steps: (1) download the `bindings-*`
+  artifacts from a green `holo-projector-napi` run; (2) as an `@hologit` org
+  member: `cd holo-projector-napi && npm install && npx napi artifacts --dir
+  <artifacts-dir>`, then `for d in npm/*/ ; do ( cd "$d" && npm publish
+  --access public ); done`, then `npm publish --access public
+  --ignore-scripts`; (3) configure a trusted publisher (repo
+  `JarvusInnovations/hologit`, workflow `holo-projector-napi.yml`) for each
+  of the 7 packages on npmjs.com; (4) from master, `git tag
+  holo-projector-v0.1.0 && git push origin holo-projector-v0.1.0` — never a
+  bare `v*`.
+- Tracked as: wiring the CLI to prefer the published package when the
+  in-repo build is absent remains with issue
+  [#493](https://github.com/JarvusInnovations/hologit/issues/493) (its last
+  bullet) — deliberately out of this plan's scope.

--- a/plans/holo-projector-publish.md
+++ b/plans/holo-projector-publish.md
@@ -1,0 +1,126 @@
+---
+status: in-progress
+depends: [projector-napi-cli]
+specs:
+  - specs/architecture.md
+  - specs/api/projector-napi.md
+issues: [493]
+---
+
+# Establish the @hologit/holo-projector publication track
+
+## Scope
+
+Stand up the publication pipeline for the `holo-projector-napi` binding as the
+scoped npm package **`@hologit/holo-projector`**, mirroring the proven
+`holo-tree-napi` track end to end:
+
+- **Packaging** — publishing fields in `holo-projector-napi/package.json`
+  (optionalDependencies on the per-platform packages, `prepublishOnly` napi
+  hook, version aligned to the `0.0.1` pre-bootstrap convention) plus the
+  `npm/<triple>/` platform package manifests for the same six triples
+  holo-tree ships.
+- **Workflow** — `.github/workflows/holo-projector-napi.yml`: PR-triggered
+  build verification of all six prebuilds, and publish via npm trusted
+  publishing (OIDC, tokenless) on **`holo-projector-v*`** tags with the
+  version stamped from the tag. Never a bare `v*` tag — it collides with the
+  `hologit` JS release namespace and `publish-npm.yml`'s trigger.
+- **Docs** — rewrite `holo-projector-napi/README.md` as the consumer-facing
+  npm page (mirroring the holo-tree README structure), including the
+  one-time trusted-publishing bootstrap procedure.
+- **Spec amendments (same PR, spec-first)** — `specs/architecture.md`
+  § Release tracks gains the `holo-projector-v*` track (and the component
+  table/crate count catches up to the fourth crate);
+  `specs/api/projector-napi.md` drops its "publication is deferred" language
+  and absorbs the `LENS_*` error codes the crate already ships (drift from
+  the lens-execution merge, surfaced because the npm README must document
+  them).
+
+**Out of scope:**
+
+- **Pushing the first tag.** The packages must exist on npm before trusted
+  publishing can be configured, so the first release requires the manual
+  bootstrap documented in the README — recorded under Follow-ups with exact
+  commands. Issue #493 stays open until the package actually publishes.
+- **Wiring the CLI to prefer the published package** when the in-repo build
+  is absent (#493's last bullet) — the CLI keeps loading the in-repo build
+  via `npm run build:projector-addon` exactly as today.
+- **Any binding source changes** — the watch-mode and lens-execution work
+  just merged; this plan touches packaging, CI, and docs only.
+
+## Implements
+
+- `specs/architecture.md` § Release tracks — the third npm package track:
+  `@hologit/holo-projector` on `holo-projector-v*` tags.
+- `specs/api/projector-napi.md` § Notes (Packaging) — platform packages and
+  the prefix-namespaced release tag track; § Error contract — the complete
+  code table the published README documents.
+
+## Approach
+
+1. Amend the specs first (release-tracks row, packaging note, `LENS_*` code
+   rows sourced from `holo_projector::Error::code()`).
+2. `package.json`: version `0.0.1`, `optionalDependencies` pinning the six
+   platform packages at `0.0.1`, `prepublishOnly: napi prepublish -t npm
+   --skip-gh-release` — matching holo-tree field-for-field. npm skips
+   unresolvable optionalDependencies (verified empirically; also how
+   holo-tree's lock looked pre-bootstrap), so local `npm install` keeps
+   working before the platform packages exist.
+3. Generate `npm/<triple>/` manifests with `npx napi create-npm-dir -t .`
+   (the triples are already declared), then align the generated manifests
+   with holo-tree's committed ones.
+4. `holo-projector-napi.yml`: copy `holo-tree-napi.yml`, swap the package
+   name, tag prefix (`holo-projector-v*`), and paths filter (adding
+   `holo-projector/**` — the binding's crate dependency chain includes both
+   engine crates). Same six-target matrix (four native + musl-via-zig +
+   darwin-x64 cross), same tag-stamped `npm version --no-git-tag-version` +
+   `napi version` + optionalDependencies re-pin, same OIDC publish
+   (`npm publish --provenance --access public`).
+5. README rewrite mirroring holo-tree's: what it is, install, quick start
+   (one-shot functions + `ProjectionSession`), error-code table, the
+   release-build performance warning, engine-selection/embedding notes,
+   release track, and the one-time bootstrap.
+6. Prove the workflow by letting this PR's own `pull_request` trigger build
+   all six targets (workflow_dispatch is unavailable until the file reaches
+   the default branch). No tag is pushed.
+
+## Validation
+
+- [ ] `holo-projector-napi` workflow green on this PR: all six targets build,
+  native targets smoke-test (`npm test`) against the built addon
+- [ ] `npm run build:projector-addon` + `npm --prefix holo-projector-napi test`
+  pass locally — the CLI's in-repo load path is unchanged
+- [ ] Root `npm test` (jest) passes
+- [ ] `npm pack --dry-run` on the main package ships exactly
+  `index.js`/`index.d.ts` (+ `package.json`/`README.md`); each
+  `npm/<triple>/` manifest matches holo-tree's shape (os/cpu/libc, `main`
+  and `files` naming the `.node`)
+- [ ] `specs/architecture.md` § Release tracks lists the
+  `holo-projector-v*` track; `specs/api/projector-napi.md` documents the
+  full error-code table (incl. `SOURCE_FETCH`, `LENS_*`) with no
+  "publication is deferred" residue
+- [ ] README covers install, quick start, error codes, the debug-vs-release
+  warning, the release track, and the one-time bootstrap procedure
+
+## Risks / unknowns
+
+- **Unpublished optionalDependencies** — npm must tolerate the six platform
+  packages 404ing until bootstrap. Verified: npm v11 skips unresolvable
+  optional deps (exit 0, omitted from the lock), and holo-tree shipped in
+  exactly this state between its packaging commit and first publish.
+- **Workflow can't be dispatch-tested pre-merge** — `workflow_dispatch` only
+  works once the file is on the default branch; the `pull_request` trigger
+  on this PR is the build-verification evidence instead.
+- **Trusted publishing is per-package** — all seven packages (main + six
+  platform) need the one-time manual publish + trusted-publisher
+  configuration before the tag-driven flow works; a tag pushed before that
+  fails at `npm publish`. Mitigated by documenting the bootstrap in the
+  README and Follow-ups.
+
+## Notes
+
+(Populated at closeout.)
+
+## Follow-ups
+
+(Populated at closeout.)

--- a/specs/api/projector-napi.md
+++ b/specs/api/projector-napi.md
@@ -6,8 +6,10 @@ error contract they extend from `specs/api/errors.md`.
 
 ## Applies to
 
-- The `holo-projector-napi` crate (npm name `@hologit/holo-projector`;
-  publication is deferred — the CLI loads it from the in-repo build).
+- The `holo-projector-napi` crate, published to npm as
+  `@hologit/holo-projector` on the `holo-projector-v*` tag track
+  (`specs/architecture.md` § Release tracks). The CLI loads it from the
+  in-repo build, not the published package.
 - `lib/RustEngine.js`, the only in-repo consumer.
 
 ## Surface
@@ -84,6 +86,12 @@ Codes added by `holo_projector::Error` (surfaced via `Error::code()`):
 | `SOURCE_FETCH` | `Error::SourceFetch` | A remote source fetch failed (network, auth, unknown remote ref, non-zero git exit). Distinct from `SOURCE_RESOLUTION` per `specs/behaviors/source-resolution.md` § Errors. |
 | `CIRCULAR_DEPENDENCY` | `Error::CircularDependency` | Mapping `before`/`after` constraints form a cycle. |
 | `LENSED_SUBPROJECTION` | `Error::LensedSubprojection` | A recursive sub-projection would lens under the oracle's semantics (see `specs/behaviors/composition.md` § Sub-projection lensing). The composition-only engine refuses rather than silently skipping the lens. |
+| `LENS_CONFIG` | `Error::LensConfig` | A lens's `.holo/lenses/*.toml` spec is malformed or semantically invalid. |
+| `LENS_IDENTITY` | `Error::LensIdentity` | The lens container identity could not be resolved (`specs/behaviors/lensing.md` § Container identity resolution). |
+| `LENS_PROTOCOL` | `Error::LensProtocol` | The lens image cannot run on this engine — e.g. a v1-protocol image, or a `package`-only (Habitat) lens (`specs/behaviors/lensing.md`). The dispatcher-fallback signal. |
+| `LENS_FAILED` | `Error::LensFailed` | The lens job ran and failed; carries the inner transform's real exit code, the failing phase (`setup`/`transform`/`commit`), and the captured log per the error-commit contract (`specs/behaviors/lensing.md`). |
+| `LENS_TRANSPORT` | `Error::LensTransport` | The lens job's result never arrived — container/exec plumbing failure, distinct from the lens tool itself failing. |
+| `LENS_TIMEOUT` | `Error::LensTimeout` | The lens job exceeded its deadline and was cancelled. |
 | `PROJECTION` | `Error::Other` | Residual projection failure not classified above. |
 
 `Error::Tree` forwards the underlying `holo_tree::Error` code unchanged
@@ -93,10 +101,11 @@ matching the holo-tree binding.
 
 ## Notes
 
-- **Packaging**: mirrors `holo-tree-napi` conventions (napi-rs v2, committed
-  generated `index.js`/`index.d.ts`, platform triples declared) but ships no
-  platform packages yet — publication is a follow-up. When it happens, the
-  release tag track is prefix-namespaced (`holo-projector-v*`); a bare `v*`
+- **Packaging**: mirrors `holo-tree-napi` conventions — napi-rs v2, committed
+  generated `index.js`/`index.d.ts`, per-platform prebuilds shipped as
+  `optionalDependencies` (`npm/<triple>/` packages for the same six triples),
+  npm trusted publishing (OIDC) from `.github/workflows/holo-projector-napi.yml`.
+  The release tag track is prefix-namespaced (`holo-projector-v*`); a bare `v*`
   tag is never acceptable (it collides with the `hologit` release namespace).
 - The one-shot exports open the repository per call; callers batch work per
   projection, and tree caching lives inside the engine for the duration of a

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -12,15 +12,16 @@ The project is mid-migration from a Node.js engine to a Rust core. Both engines 
 | `holo-tree/` | Rust | Shared mutable git-tree primitives over gix: merge (overlay/replace/underlay), glob, blob/commit/ref ops, tree cache. Consumed by holo-projector and, as a Cargo git-tag dependency, by gitsheets-core. |
 | `holo-projector/` | Rust | The projection engine: `.holo/` config parsing, source resolution, mapping toposort, recursive sub-projection, composition. Pure — no network, containers, or ref writes. Benchmark CLI behind the `cli` feature. |
 | `holo-tree-napi/` | Rust (napi-rs) | Node binding over holo-tree only (tree/ref/blob CRUD), published to npm as `@hologit/holo-tree` — a supported standalone primitive for Node consumers (see Embedding consumers). Does **not** expose projection. |
+| `holo-projector-napi/` | Rust (napi-rs) | Node binding over holo-projector (composition entry points + `ProjectionSession`; see [api/projector-napi.md](api/projector-napi.md)), published to npm as `@hologit/holo-projector`. The hybrid CLI loads it from the in-repo build with graceful pure-JS degradation. |
 
-The three Rust crates form a Cargo workspace at the repo root.
+The four Rust crates form a Cargo workspace at the repo root.
 
 ## Migration strategy
 
 The migration proceeds capability-by-capability, pure core outward (see [principles.md — composition is pure](principles.md#composition-is-pure-side-effects-live-at-the-edges)):
 
 1. **Done:** tree primitives (holo-tree) and pure composition (holo-projector), validated hash-identical and ~130x faster warm on the reference projections.
-2. **Done:** wire the Rust projector into the Node CLI via the `holo-projector-napi` binding (#434). The interim CLI is a **hybrid**: JS handles side effects (fetching, lensing, commits, watch), delegating pure composition to Rust per `specs/behaviors/engine-selection.md`. The binding is not yet published — the CLI loads it from the in-repo build with graceful pure-JS degradation.
+2. **Done:** wire the Rust projector into the Node CLI via the `holo-projector-napi` binding (#434). The interim CLI is a **hybrid**: JS handles side effects (fetching, lensing, commits, watch), delegating pure composition to Rust per `specs/behaviors/engine-selection.md`. The binding publishes on its own `holo-projector-v*` track (see Release tracks), but the CLI loads it from the in-repo build with graceful pure-JS degradation.
 3. **Then:** port the side-effecting edges — projection commits (#438), remote fetching (#436), lens execution (#435), watch mode (#437) — each spec-first, since these are the areas where desired state may deliberately diverge from current JS behavior (notably the lens runtime).
 4. **End state:** the JS engine retires; the CLI becomes a thin shell over the Rust engine.
 
@@ -40,10 +41,13 @@ Both modes implement the same contract:
 
 ## Release tracks
 
-Two independent npm packages ship from this repo on prefix-namespaced git-tag tracks:
+Three independent npm packages ship from this repo on prefix-namespaced git-tag tracks:
 
 - **`hologit`** (Node CLI/library) — `v*` tags via the develop→master Release-PR flow.
-- **`@hologit/holo-tree`** (napi binding) — `holo-tree-v*` tags. One tag serves **both** consumption modes: it triggers the npm publish (platform prebuilds + trusted publishing) *and* is the Cargo git-dependency pin Rust consumers reference. Never tag the binding with a bare `v*`.
+- **`@hologit/holo-tree`** (napi binding) — `holo-tree-v*` tags. One tag serves **both** consumption modes: it triggers the npm publish (platform prebuilds + trusted publishing) *and* is the Cargo git-dependency pin Rust consumers reference.
+- **`@hologit/holo-projector`** (napi binding) — `holo-projector-v*` tags, same pipeline shape as holo-tree (platform prebuilds + trusted publishing) and the same version independence.
+
+Never tag a binding with a bare `v*` — it collides with the `hologit` JS release namespace (`publish-npm.yml`'s trigger).
 
 The `actions/projector/v1` ref publishes the GitHub Action consumers use to project holobranches in CI.
 


### PR DESCRIPTION
Refs #493 (the issue closes when the package actually publishes, which requires the one-time npm bootstrap below).

Stands up the publication pipeline for the `holo-projector-napi` binding as **`@hologit/holo-projector`**, mirroring the proven `holo-tree-napi` track. Plan: `plans/holo-projector-publish.md`.

## What mirrors holo-tree, field-for-field

- **Workflow** `.github/workflows/holo-projector-napi.yml` — same six-target matrix (4 native + smoke test: linux-x64-gnu, linux-arm64-gnu, darwin-arm64, win32-x64-msvc; 2 cross build-only: linux-x64-musl via zig, darwin-x64), same tag-stamped version (`npm version --no-git-tag-version` from the tag + `napi version` + optionalDependencies re-pin; the committed manifest stays `0.0.1` forever), same OIDC trusted publish (`npm publish --provenance --access public`, `napi prepublish --skip-gh-release`), same PR-triggered build-verification path.
- **Packaging** — `optionalDependencies` on the six platform packages, `prepublishOnly` hook, `npm/<triple>/` manifests generated with `npx napi create-npm-dir -t .` (byte-shape identical to holo-tree's committed ones).
- **README** — same structure as holo-tree's npm page, including the trusted-publishing **one-time bootstrap** (npm requires a package to exist before a trusted publisher can be configured): manual publish of all 7 packages from CI artifacts, then per-package trusted-publisher config.

## What differs, and why

- **Six prebuilds, not three.** The task/CLAUDE.md language predates holo-tree's matrix growing to six targets; mirroring the precedent end-to-end means matching the current workflow (and `holo-projector-napi/package.json` already declared all six triples).
- **Paths filter adds `holo-projector/**`** — the binding's crate dependency chain includes both engine crates, where holo-tree's workflow only watches `holo-tree/**`.
- **7 packages, not 4** in the bootstrap notes (main + six platform packages).
- **No `buildProfile()` mention in the README's debug-build warning** — this binding doesn't export it; the warning stays qualitative instead of borrowing holo-tree's measured numbers.
- **Spec-first amendments in this PR**: `specs/architecture.md` § Release tracks gains the third track (and the component table/crate count catch up to the fourth crate); `specs/api/projector-napi.md` drops "publication is deferred" and absorbs the six `LENS_*` error codes the crate already ships (drift from the lens-execution merge, surfaced because the npm README documents the full table).

## Build verification

- **The new workflow ran green on this PR** ([run 29217354840](https://github.com/JarvusInnovations/hologit/actions/runs/29217354840)): all six targets built, the four native targets smoke-tested, and the publish job correctly skipped (no tag). `workflow_dispatch` is unavailable until the file reaches the default branch, so the `pull_request` trigger is the verification path. No tag is pushed by this PR.
- One portability fix surfaced by the first run: `node --test test/*.mjs` fails on the windows-latest runner (pwsh doesn't expand globs) — the test script now enumerates the files explicitly, exactly as holo-tree-napi's does.
- Local: `npm run build:projector-addon` (release) → binding suite **18/18**, root `npm test` (jest) **110/110**, `npm pack --dry-run` ships exactly `index.js`/`index.d.ts`/`README.md`/`package.json`, and the CLI's in-repo loader still resolves the built addon.
- `npm install` with the six not-yet-published optionalDependencies verified to exit 0 (npm skips unresolvable optional deps — the same pre-bootstrap state holo-tree shipped in).

## Remaining to release (NOT in this PR)

1. **One-time npm bootstrap** — download this PR's `bindings-*` artifacts, then as an `@hologit` org member:

   ```sh
   cd holo-projector-napi && npm install
   npx napi artifacts --dir <downloaded-artifacts-dir>
   for d in npm/*/ ; do ( cd "$d" && npm publish --access public ); done
   npm publish --access public --ignore-scripts
   ```

2. **Configure trusted publishing** for each of the 7 packages on npmjs.com → Settings → Trusted Publisher → GitHub Actions, repo `JarvusInnovations/hologit`, workflow `holo-projector-napi.yml`.
3. **Tag the first automated release** (from master, per release convention): `git tag holo-projector-v0.1.0 && git push origin holo-projector-v0.1.0` — never a bare `v*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01X4KHfjZQG7nS4c6R2pP2DJ>
