### PR TITLE
ci(release): pin release-prepare to the v* tag track

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -18,3 +18,7 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         release-branch: master
+        # hologit shares one git tag space across three release tracks (v* for the
+        # JS package, holo-tree-v*, holo-projector-v*). Restrict the JS Release PR's
+        # version computation to the v* track so a binding tag can't poison the title.
+        release-tag-match: 'v[0-9]*'


### PR DESCRIPTION
Sets the new `release-tag-match: 'v[0-9]*'` input (infra-components release-prepare r9) so the develop→master JS Release PR computes its version from the `v*` track only, not whatever tag is topologically nearest.

Fixes the class of bug that mistitled #504 as `Release: holo-tree-v0.5.1` (it bumped the nearest tag, `holo-tree-v0.5.0`) instead of `v0.51.1`. Proven: `git describe --match 'v[0-9]*' origin/master` → v0.51.0 → v0.51.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4KHfjZQG7nS4c6R2pP2DJ