### PR TITLE
fix(lens): surface real lens failures on the v1 container transport

### DIFF
--- a/lib/Lens.js
+++ b/lib/Lens.js
@@ -691,18 +691,35 @@ class Lens extends Configurable {
                 throw new Error('Timeout waiting for git server to be ready');
             }
 
-            // push commit to git server
+            // push commit to git server, buffering the container's relayed
+            // output so a failure can carry its own diagnosis (#511)
             logger.info(`pushing and executing job: ${commitHash}`);
+            const containerOutput = [];
             await git.push(`http://localhost:9000/`, `${commitHash}:refs/heads/lens-input`, {
                 force: true,
                 $wait: true,
-                $onStderr: (line) => process.stderr.write(`\x1b[90m${line}\x1b[0m\n`)
+                $onStderr: (line) => {
+                    containerOutput.push(line);
+                    process.stderr.write(`\x1b[90m${line}\x1b[0m\n`);
+                }
             });
 
             // fetch and verify output commit
             const outputRef = `refs/lens-jobs/${specHash}`;
             logger.info('fetching result');
             await git.fetch('http://localhost:9000/', `+refs/heads/lens-input:${outputRef}`);
+
+            // a failed job never advances lens-input, so the fetch returns the
+            // unchanged (parentless) input commit — detect that before the ^
+            // check below turns it into an opaque rev-parse error (#511)
+            const outputCommit = await git.revParse(outputRef);
+            if (outputCommit === commitHash) {
+                const outputTail = containerOutput.slice(-15).join('\n');
+                throw new Error(
+                    `lens job failed: container ${containerRef} did not produce an output commit`
+                    + (outputTail ? `\nlast container output:\n${outputTail}` : '')
+                );
+            }
 
             // verify the output commit's parent matches our input commit
             const outputParent = await git.revParse(`${outputRef}^`);

--- a/plans/lens-v1-failure-reporting.md
+++ b/plans/lens-v1-failure-reporting.md
@@ -1,0 +1,65 @@
+---
+status: planned
+depends: []
+specs: []
+issues: [511]
+---
+
+# Plan: surface real lens failures on the v1 container transport
+
+## Scope
+
+Fix [#511](https://github.com/JarvusInnovations/hologit/issues/511): when a v1
+(port-9000 git server) container lens job fails, `executeSpecForContainerV1`
+currently throws the downstream `rev-parse <outputRef>^` git error (the
+unadvanced input commit is parentless), masking the real build failure that was
+relayed to stderr during the push. Detect the didn't-advance case directly and
+throw a lens-job-failed error carrying a tail of the container's own output.
+
+Out of scope: any change to the v2 (exec/stdio) path, which already reports
+failures directly; retiring the v1 fallback entirely (that's
+[#502](https://github.com/JarvusInnovations/hologit/issues/502)). No spec
+change — the v1 transport is a legacy-unspecced path; the specced successor is
+the v2 protocol (`specs/behaviors/lensing.md`), and this fix only improves v1's
+diagnostics on its way out.
+
+## Implements
+
+No specs — legacy-path bugfix (see Scope). Tracked by issue #511.
+
+## Approach
+
+1. In `executeSpecForContainerV1` (`lib/Lens.js`): buffer the container output
+   lines the push handler already receives (`$onStderr`) while continuing to
+   relay them to stderr.
+2. After the fetch, resolve `outputRef` itself and compare to the pushed input
+   `commitHash` **before** the existing `^` parent check. Equal ⇒ the job never
+   advanced `lens-input` ⇒ throw `lens job failed …` naming the container image
+   and embedding the last ~15 buffered output lines, so the underlying build
+   error is in the thrown error, not just somewhere above it in the log.
+3. Keep the existing parent-mismatch check unchanged as the corruption guard
+   for the advanced-but-wrong case.
+
+## Validation
+
+- [ ] A v1 lens whose build command exits non-zero surfaces `lens job failed`
+      with the container's output tail (manual repro per #511's environment —
+      requires docker + a v1 lens image)
+- [ ] A successful v1 lens run is byte-identical in behavior (guard compares
+      then falls through to the unchanged happy path)
+- [ ] Existing CI suites pass unchanged (test, test-cli, test-action, test-rust)
+
+## Risks / unknowns
+
+- **No automated coverage of the v1 container path** — CI has no docker-lens
+  fixture, so the failure branch is validated by manual repro + code review,
+  not a regression test. Acceptable for a diagnostics-only change on a path
+  being retired by #502.
+
+## Notes
+
+(populated at closeout)
+
+## Follow-ups
+
+(populated at closeout)


### PR DESCRIPTION
Fixes #511 — a failing v1 container lens surfaced an opaque `rev-parse <ref>^` git error instead of the lens's actual build failure.

Mechanism (verified against the code): on failure the container never advances `refs/heads/lens-input`, so the fetch brings back the unchanged input commit, which is parentless by construction (`commitTree(…, { p: [] })`) — the `^` validation is what threw.

The fix, per the issue's suggestion:
- Buffer the container output lines the push handler already relays (`$onStderr`), still streaming them to stderr as before.
- After the fetch, resolve `outputRef` itself and compare to the pushed input commit **before** the `^` check. Equal ⇒ the job never ran to success ⇒ throw `lens job failed: container <image> did not produce an output commit`, embedding the last 15 buffered lines — the real error (e.g. #511's Sencha `Unknown definition for dependency`) lands in the thrown message itself.
- The existing parent-mismatch check is unchanged as the corruption guard for the advanced-but-wrong case. The v2 path is untouched.

Validation: jest suite 107 passed locally; success-path behavior is byte-identical (the new guard compares and falls through). The failure branch has no automated CI coverage (no docker-lens fixture) — validated by code review against the issue's confirmed repro mechanism; the plan file records this honestly, and the durable fix for the v1 path remains its retirement (#502).

Plan: `plans/lens-v1-failure-reporting.md` (closeout after review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJCxogamrSUZ7etFGsnoD1